### PR TITLE
Fix NullPath for Python 3.13

### DIFF
--- a/glacium/managers/PathManager.py
+++ b/glacium/managers/PathManager.py
@@ -31,7 +31,9 @@ __all__ = ["PathBuilder", "PathManager"]
 class NullPath(Path):  # type: ignore[misc]
     """Ein *Path*-Platzhalter, der jede Operation überlebt."""
 
-    _flavour = type(Path())._flavour  # intern nötig
+    def __new__(cls) -> "NullPath":  # noqa: D401
+        """Erzeugt eine neutrale ``Path``-Instanz ohne System-Access."""
+        return super().__new__(cls, "")
 
     def __truediv__(self, key: str | Path) -> "NullPath":  # noqa: D401
         return self  # Chain bleibt Null


### PR DESCRIPTION
## Summary
- fix `NullPath` so that it doesn't rely on internal `_flavour`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68601dc6e870832784bbf2c8af4eeb62