### PR TITLE
Add command to list globally available jobs

### DIFF
--- a/glacium/cli/job.py
+++ b/glacium/cli/job.py
@@ -13,10 +13,25 @@ from rich import box
 ROOT = Path("runs")
 console = Console()
 
-@click.group("job")
-def cli_job():
+@click.group("job", invoke_without_command=True)
+@click.option(
+    "--list",
+    "list_all",
+    is_flag=True,
+    help="Alle implementierten Jobs auflisten",
+)
+@click.pass_context
+def cli_job(ctx: click.Context, list_all: bool):
     """Job-Utilities für das aktuell gewählte Projekt."""
-    pass
+
+    if ctx.invoked_subcommand is None:
+        if list_all:
+            from glacium.utils import list_jobs
+
+            for name in list_jobs():
+                click.echo(name)
+        else:
+            click.echo(ctx.get_help())
 
 @cli_job.command("reset")
 @click.argument("job_name")

--- a/glacium/utils/JobIndex.py
+++ b/glacium/utils/JobIndex.py
@@ -1,0 +1,44 @@
+"""Helper for discovering implemented Job classes."""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+from typing import Iterable
+
+from glacium.models.job import Job
+
+# packages containing job implementations
+_PACKAGES: Iterable[str] = ["glacium.engines", "glacium.recipes"]
+
+
+def _discover() -> None:
+    """Import all modules from known packages to populate Job subclasses."""
+    for pkg_name in _PACKAGES:
+        try:
+            pkg = importlib.import_module(pkg_name)
+        except ModuleNotFoundError:
+            continue
+        for mod in pkgutil.walk_packages(pkg.__path__, pkg_name + "."):
+            try:
+                importlib.import_module(mod.name)
+            except Exception:
+                # ignore faulty modules during discovery
+                pass
+
+
+def list_jobs() -> list[str]:
+    """Return a sorted list of all implemented job names."""
+    _discover()
+
+    found: set[str] = set()
+
+    def _collect(cls: type[Job]) -> None:
+        for sub in cls.__subclasses__():
+            name = getattr(sub, "name", "BaseJob")
+            if name != "BaseJob":
+                found.add(name)
+            _collect(sub)
+
+    _collect(Job)
+    return sorted(found)

--- a/glacium/utils/__init__.py
+++ b/glacium/utils/__init__.py
@@ -1,2 +1,3 @@
 """Utility helpers used across the Glacium code base."""
 
+from .JobIndex import list_jobs

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,3 +20,10 @@ def test_cli_subcommand_help(command):
     runner = CliRunner()
     result = runner.invoke(cli, [command, '--help'])
     assert result.exit_code == 0
+
+
+def test_job_global_list():
+    runner = CliRunner()
+    result = runner.invoke(cli, ['job', '--list'])
+    assert result.exit_code == 0
+    assert 'XFOIL_REFINE' in result.output


### PR DESCRIPTION
## Summary
- support `glacium job --list` to show all job implementations
- introspect job classes via new `JobIndex` helper
- expose `list_jobs` from `utils`
- test new CLI option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686022125f7483279f60bf6f3bd7a437