### PR TITLE
Fix job add to pull dependencies

### DIFF
--- a/glacium/utils/JobIndex.py
+++ b/glacium/utils/JobIndex.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import importlib
 import pkgutil
-from typing import Iterable
+from typing import Iterable, Dict, Optional
 
 from glacium.models.job import Job
 
@@ -42,3 +42,33 @@ def list_jobs() -> list[str]:
 
     _collect(Job)
     return sorted(found)
+
+
+def _collect_map() -> Dict[str, type[Job]]:
+    mapping: Dict[str, type[Job]] = {}
+
+    def _collect(cls: type[Job]) -> None:
+        for sub in cls.__subclasses__():
+            name = getattr(sub, "name", "BaseJob")
+            if name != "BaseJob":
+                mapping[name] = sub
+            _collect(sub)
+
+    _collect(Job)
+    return mapping
+
+
+def get_job_class(name: str) -> Optional[type[Job]]:
+    """Return the Job subclass with ``name`` if available."""
+
+    _discover()
+    return _collect_map().get(name)
+
+
+def create_job(name: str, project) -> Job:
+    """Instantiate the Job with ``name`` for ``project``."""
+
+    cls = get_job_class(name)
+    if cls is None:
+        raise KeyError(f"Job '{name}' nicht bekannt.")
+    return cls(project)

--- a/tests/test_job_add.py
+++ b/tests/test_job_add.py
@@ -1,0 +1,28 @@
+import yaml
+from pathlib import Path
+from click.testing import CliRunner
+from glacium.cli import cli
+from glacium.managers.PathManager import _SharedState
+
+
+def test_job_add_with_deps(tmp_path):
+    runner = CliRunner()
+    env = {"HOME": str(tmp_path)}
+    _SharedState._SharedState__shared_state.clear()
+
+    result = runner.invoke(cli, ["new", "proj", "-y"], env=env)
+    assert result.exit_code == 0
+    uid = result.output.strip().splitlines()[-1]
+
+    result = runner.invoke(cli, ["select", uid], env=env)
+    assert result.exit_code == 0
+
+    result = runner.invoke(cli, ["job", "add", "POINTWISE_MESH2"], env=env)
+    assert result.exit_code == 0
+    assert "POINTWISE_GCI hinzugefügt." in result.output
+    assert "POINTWISE_MESH2 hinzugefügt." in result.output
+
+    jobs_yaml = Path("runs") / uid / "_cfg" / "jobs.yaml"
+    data = yaml.safe_load(jobs_yaml.read_text())
+    assert "POINTWISE_GCI" in data
+    assert "POINTWISE_MESH2" in data


### PR DESCRIPTION
## Summary
- let `job add` fetch jobs from any recipe and include dependencies
- expose helpers to load job classes by name
- test adding a Pointwise job with dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686024da76c08327ae728f1d6e0cdf04