### PR TITLE
Fix Pointwise defaults

### DIFF
--- a/glacium/config/defaults/global_default.yaml
+++ b/glacium/config/defaults/global_default.yaml
@@ -10,6 +10,9 @@ XFOIL_BOUNDARY_OUT: bnd.dat
 XFOIL_POLAR_OUT: polars.dat
 XFOIL_SUCTION_OUT: psi.dat
 
+# Default path to the Pointwise executable (WSL-friendly)
+POINTWISE_BIN: "/mnt/c/Program Files/Cadence/FidelityPointwise2023.2.3/win64/bin/tclsh.exe"
+
 PWS_INI_NUM_PANELS: 400
 PWS_INI_TE_YPLUS: 0.0005
 PWS_INI_TE_YMINUS: -0.0005

--- a/glacium/templates/POINTWISE.run_pointwise.sh.j2
+++ b/glacium/templates/POINTWISE.run_pointwise.sh.j2
@@ -6,7 +6,8 @@
 set -euo pipefail
 
 # Pointwise executable – WSL-kompatibler Pfad
-POINTWISE_EXEC="/mnt/c/Program Files/Cadence/FidelityPointwise2023.2.3/win64/bin/tclsh.exe"
+# Use configured Pointwise executable
+POINTWISE_EXEC="{{ POINTWISE_BIN }}"
 
 # Alle .glf-Dateien im aktuellen Verzeichnis verarbeiten
 for glf in *.glf; do


### PR DESCRIPTION
## Summary
- set `POINTWISE_BIN` in the default config so jobs know where Pointwise lives
- allow Pointwise batch script to use the configured executable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68603288bc7483278d5dfa0399133c57