### PR TITLE
Add PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,23 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install build tool
+        run: python -m pip install --upgrade build
+      - name: Build package
+        run: python -m build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
## Summary
- build package on tag and publish to PyPI

## Testing
- `pytest -q` *(fails: AssertionError in tests/test_job_cli_numbers.py::test_job_add_by_index)*

------
https://chatgpt.com/codex/tasks/task_e_6860ecfdcffc83278dc74a1dc75dad14