### PR TITLE
Support numeric arguments for `glacium job reset`

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The table now includes an index column so you can refer to jobs by number.
 ```bash
 # reset a job to PENDING
 glacium job reset XFOIL_POLAR
+glacium job reset 1  # via index
 ```
 You can list all available job types with numbers:
 

--- a/glacium/cli/job.py
+++ b/glacium/cli/job.py
@@ -46,7 +46,16 @@ def cli_job_reset(job_name: str):
         proj = pm.load(uid)
     except FileNotFoundError:
         raise click.ClickException(f"Projekt '{uid}' nicht gefunden.") from None
-    job  = proj.job_manager._jobs.get(job_name.upper())
+
+    if job_name.isdigit():
+        idx = int(job_name) - 1
+        if idx < 0 or idx >= len(proj.jobs):
+            raise click.ClickException("Ungültige Nummer.")
+        jname = proj.jobs[idx].name
+    else:
+        jname = job_name.upper()
+
+    job = proj.job_manager._jobs.get(jname)
 
     if job is None:
         raise click.ClickException(f"Job '{job_name}' existiert nicht.")
@@ -55,7 +64,7 @@ def cli_job_reset(job_name: str):
 
     job.status = JobStatus.PENDING
     proj.job_manager._save_status()
-    click.echo(f"{job_name} → PENDING")
+    click.echo(f"{jname} → PENDING")
 
 
 @cli_job.command("list")

--- a/tests/test_job_cli_numbers.py
+++ b/tests/test_job_cli_numbers.py
@@ -44,3 +44,18 @@ def test_job_add_by_index(tmp_path):
     jobs_yaml = Path("runs") / uid / "_cfg" / "jobs.yaml"
     data = yaml.safe_load(jobs_yaml.read_text())
     assert "HelloJob" in data
+
+
+def test_job_reset_by_index(tmp_path):
+    runner, uid, env = _setup(tmp_path)
+    jobs_yaml = Path("runs") / uid / "_cfg" / "jobs.yaml"
+    # Mark job as DONE
+    data = yaml.safe_load(jobs_yaml.read_text())
+    data["XFOIL_REFINE"] = "DONE"
+    yaml.dump(data, jobs_yaml.open("w"))
+
+    res = runner.invoke(cli, ["job", "reset", "1"], env=env)
+    assert res.exit_code == 0
+    data = yaml.safe_load(jobs_yaml.read_text())
+    assert data["XFOIL_REFINE"] == "PENDING"
+


### PR DESCRIPTION
## Summary
- allow `glacium job reset` to take the job index
- document resetting by index in the README
- test resetting a job by index

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860f97902d08327a701e0daf4325b41