### PR TITLE
Improve ConfigManager docs

### DIFF
--- a/docs/config_manager.rst
+++ b/docs/config_manager.rst
@@ -1,0 +1,38 @@
+ConfigManager Guide
+===================
+
+This guide explains how to use :class:`glacium.managers.ConfigManager` to
+read and write project configuration files.  The manager abstracts file
+handling and caches loaded data so repeated operations are fast.
+
+Basic usage
+-----------
+
+.. code-block:: python
+
+   from pathlib import Path
+   from glacium.managers.PathManager import PathBuilder
+   from glacium.managers.ConfigManager import ConfigManager
+
+   paths = PathBuilder(Path("runs/my_project")).build()
+   cfg_mgr = ConfigManager(paths)
+   cfg = cfg_mgr.load_global()
+   cfg_mgr.set("PROJECT_NAME", "demo")
+   cfg_mgr.dump_global()
+
+After calling :meth:`~glacium.managers.ConfigManager.dump_global`, any
+callbacks registered via :meth:`~glacium.managers.ConfigManager.add_observer`
+are triggered.  The manager can also merge subset files into the global
+configuration with :meth:`~glacium.managers.ConfigManager.merge_subsets` and
+split the global state back into subsets with
+:meth:`~glacium.managers.ConfigManager.split_all`.
+
+Tips
+----
+
+* Keep the manager instance alive for the lifetime of your project.  It
+  caches data internally and performs lazy loading on first access.
+* Use :meth:`~glacium.managers.ConfigManager.get` and
+  :meth:`~glacium.managers.ConfigManager.set` as convenience helpers for simple
+  key/value modifications.
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,4 +5,5 @@ glacium documentation
    :maxdepth: 2
    :caption: content:
 
+   config_manager
    glacium

--- a/glacium/managers/ConfigManager.py
+++ b/glacium/managers/ConfigManager.py
@@ -1,12 +1,13 @@
 """Central access point for project configuration.
 
-The :class:`ConfigManager` hides raw YAML handling behind a simple API.  The
-manager keeps the global configuration cached and allows loading and merging of
-partial configuration files.  Several design patterns are employed:
+The :class:`ConfigManager` hides raw YAML or JSON handling behind a small
+Python API.  It keeps the global configuration cached in memory and provides
+helpers to load, merge and split configuration subsets.
 
+Design patterns used
+--------------------
 * **Facade** – all configuration reads and writes go through this manager.
-* **Strategy** – the underlying serializer (``yaml`` or ``json``) can be
-  selected.
+* **Strategy** – the serializer (``yaml`` or ``json``) can be selected.
 * **Flyweight** – the :class:`~glacium.models.config.GlobalConfig` instance and
   subset data are cached.
 * **Observer** – registered callbacks are triggered whenever data is saved.
@@ -16,10 +17,10 @@ Example
 >>> from pathlib import Path
 >>> from glacium.managers.PathManager import PathBuilder
 >>> paths = PathBuilder(Path('runs/my_proj')).build()
->>> cfg_mgr = ConfigManager(paths)
->>> cfg = cfg_mgr.load_global()
->>> cfg_mgr.set('PROJECT_NAME', 'Demo')
->>> cfg_mgr.dump_global()
+>>> mgr = ConfigManager(paths)
+>>> cfg = mgr.load_global()
+>>> mgr.set('PROJECT_NAME', 'Demo')
+>>> mgr.dump_global()
 """
 from __future__ import annotations
 
@@ -39,29 +40,42 @@ __all__ = ["ConfigManager"]
 #  Serializer‑Strategien
 # ────────────────────────────────────────────────────────────────────────────────
 class _YamlSerializer:
+    """Helper strategy to read and write YAML files."""
+
     ext = ".yaml"
 
     @staticmethod
     def load(path: Path) -> Dict[str, Any]:
+        """Load ``path`` as YAML and return a dictionary."""
+
         return yaml.safe_load(path.read_text()) or {}
 
     @staticmethod
     def dump(data: Dict[str, Any], path: Path) -> None:
+        """Serialize ``data`` as YAML into ``path``."""
+
         path.write_text(yaml.dump(data, sort_keys=False), encoding="utf-8")
 
 
 class _JsonSerializer:
+    """Helper strategy to read and write JSON files."""
+
     ext = ".json"
 
     @staticmethod
     def load(path: Path) -> Dict[str, Any]:
+        """Return the parsed JSON content of ``path``."""
+
         return json.loads(path.read_text())
 
     @staticmethod
     def dump(data: Dict[str, Any], path: Path) -> None:
+        """Serialize ``data`` as JSON into ``path``."""
+
         path.write_text(json.dumps(data, indent=2), encoding="utf-8")
 
 
+# Map of available serializer strategies.
 _SERIALIZERS: Dict[str, Any] = {
     "yaml": _YamlSerializer,
     "json": _JsonSerializer,
@@ -72,17 +86,22 @@ _SERIALIZERS: Dict[str, Any] = {
 #  Main Facade
 # ────────────────────────────────────────────────────────────────────────────────
 class ConfigManager:
-    """Load and write configuration data with caching and merging helpers."""
+    """Facade for reading and writing project configuration files.
+
+    The manager lazily loads the global configuration and keeps it cached in
+    memory.  Additional subset files can be merged into the global state or
+    written back to disk.
+    """
 
     def __init__(self, paths: PathManager, *, fmt: Literal["yaml", "json"] = "yaml"):
         """Initialise the manager.
 
         Parameters
         ----------
-        paths:
-            :class:`PathManager` pointing to the project directories.
-        fmt:
-            Serializer format, either ``"yaml"`` or ``"json"``.
+        paths : PathManager
+            Object describing all project directories.
+        fmt : Literal["yaml", "json"], optional
+            Serializer format to use, defaults to ``"yaml"``.
         """
 
         self.paths = paths
@@ -95,12 +114,19 @@ class ConfigManager:
     # Observer‑Support
     # ------------------------------------------------------------------
     def add_observer(self, fn: Callable[[str], None]) -> None:
-        """Register ``fn`` to be notified when data is saved."""
+        """Register ``fn`` to be notified when data is saved.
+
+        The callback receives a string describing the event, e.g.
+        ``"global_saved"`` or ``"subset_saved:<name>"``.
+        """
 
         self._observers.append(fn)
 
     def _emit(self, event: str) -> None:
         """Call all registered observers with ``event``."""
+
+        # This helper isolates the observer pattern so other methods simply
+        # call ``_emit`` after persisting data.
 
         for fn in self._observers:
             fn(event)
@@ -111,8 +137,9 @@ class ConfigManager:
     def load_global(self) -> GlobalConfig:
         """Return the cached global configuration.
 
-        The configuration is read from ``global_config.yaml`` on first access
-        and then kept in memory.
+        On the first call the configuration is loaded from the
+        ``global_config.yaml`` file located in the project configuration
+        directory.  Subsequent calls return the cached object.
         """
 
         if self._global is None:
@@ -122,6 +149,7 @@ class ConfigManager:
     def dump_global(self) -> None:
         """Persist the global configuration to disk and notify observers."""
 
+        # Only writes when a configuration has been loaded or modified.
         if self._global is not None:
             self._global.dump(self.paths.global_cfg_file())  # type: ignore[attr-defined]
             self._emit("global_saved")
@@ -131,7 +159,7 @@ class ConfigManager:
 
         Parameters
         ----------
-        name:
+        name : str
             Name of the subset without file extension.
 
         Returns
@@ -148,6 +176,8 @@ class ConfigManager:
     def dump_subset(self, name: str) -> None:
         """Write a previously loaded subset back to disk."""
 
+        # Only subsets returned by :meth:`load_subset` are cached and can be
+        # written safely.
         if name in self._subset_cache:
             file = self.paths.cfg_dir() / f"{name}{self.serializer.ext}"
             self.serializer.dump(self._subset_cache[name], file)
@@ -161,7 +191,7 @@ class ConfigManager:
 
         Parameters
         ----------
-        names:
+        names : Iterable[str]
             Iterable of subset names to merge.
 
         Returns
@@ -179,6 +209,9 @@ class ConfigManager:
 
     def update_subset_from_global(self, name: str) -> None:
         """Update ``name`` subset with values from the global configuration."""
+
+        # Only keys present in the subset are overwritten to preserve
+        # additional user defined values.
         global_cfg = self.load_global().__dict__
         subset = self.load_subset(name)
         subset.update({k: global_cfg[k] for k in subset.keys() if k in global_cfg})
@@ -186,6 +219,9 @@ class ConfigManager:
 
     def split_all(self) -> None:
         """Refresh all known subsets from the global configuration."""
+
+        # Each ``*.yaml`` or ``*.json`` file under the configuration directory
+        # is treated as a subset and updated in place.
         for file in self.paths.cfg_dir().glob(f"*{self.serializer.ext}"):
             self.update_subset_from_global(file.stem)
 
@@ -195,11 +231,13 @@ class ConfigManager:
     def get(self, key: str) -> Any:
         """Return attribute ``key`` from the global configuration."""
 
+        # ``load_global`` ensures the configuration is loaded only once.
         return getattr(self.load_global(), key)
 
     def set(self, key: str, value: Any) -> None:
         """Set ``key`` in the global configuration and persist changes."""
 
+        # Persist the modification immediately so other components see it.
         setattr(self.load_global(), key, value)
         self.dump_global()
 


### PR DESCRIPTION
## Summary
- expand ConfigManager module docstring with patterns and example
- document serializer helper classes
- add detailed docstrings for ConfigManager methods
- add a small how-to on using ConfigManager
- reference the new guide from the docs index

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860fdf3180c8327a48009e25f8e5f38