### PR TITLE
Add default path for Fluent2Fensap and load defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ glacium remove
 
 Use `--all` to remove every project under `./runs`.
 
+### External executables
+
+Paths to third party programs can be configured in
+`runs/<UID>/_cfg/global_config.yaml`.  Important keys include
+`POINTWISE_BIN`, `FENSAP_BIN` and the newly added
+`FLUENT2FENSAP_EXE` pointing to ``fluent2fensap.exe`` on Windows.
+
 ## Development
 
 All tests can be run with:

--- a/glacium/managers/ProjectManager.py
+++ b/glacium/managers/ProjectManager.py
@@ -61,7 +61,11 @@ class ProjectManager:
 
         # Pfade & Grundstruktur
         paths = PathBuilder(root).build(); paths.ensure()
-        cfg   = GlobalConfig(project_uid=uid, base_dir=root)
+
+        defaults_file = Path(__file__).resolve().parents[1] / "config" / "defaults" / "global_default.yaml"
+        defaults = yaml.safe_load(defaults_file.read_text()) if defaults_file.exists() else {}
+
+        cfg = GlobalConfig(**defaults, project_uid=uid, base_dir=root)
         cfg["PROJECT_NAME"] = name
         cfg["PWS_AIRFOIL_FILE"] = f"_data/{airfoil.name}"
         cfg["RECIPE"] = recipe_name


### PR DESCRIPTION
## Summary
- load global_default.yaml when creating projects
- document config keys in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686103833ae08327a662a852607e26d0