### PR TITLE
Improve fluent2fensap error output

### DIFF
--- a/glacium/engines/base_engine.py
+++ b/glacium/engines/base_engine.py
@@ -22,15 +22,20 @@ class BaseEngine:
         self, cmd: Sequence[str], *, cwd: Path, stdin: Optional[IO[str]] = None
     ) -> None:
         """Execute *cmd* inside *cwd* with optional timeout."""
-        subprocess.run(
-            cmd,
-            stdin=stdin,
-            cwd=cwd,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            check=True,
-            timeout=self.timeout,
-        )
+        cmd_str = " ".join(cmd)
+        log.info(f"🚀  {cmd_str}")
+        try:
+            subprocess.run(
+                cmd,
+                stdin=stdin,
+                cwd=cwd,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=True,
+                timeout=self.timeout,
+            )
+        except FileNotFoundError as exc:
+            raise FileNotFoundError(f"Executable not found: {cmd[0]}") from exc
 
 
 class XfoilEngine(BaseEngine):

--- a/glacium/engines/fluent2fensap.py
+++ b/glacium/engines/fluent2fensap.py
@@ -31,6 +31,14 @@ class Fluent2FensapJob(Job):
         cas_stem = cas_path.stem
 
         exe = cfg.get("FLUENT2FENSAP_EXE", self._DEFAULT_EXE)
+
+        exe_path = Path(exe)
+        if not exe_path.exists():
+            raise FileNotFoundError(f"fluent2fensap executable not found: {exe_path}")
+        cas_file = work / cas_name
+        if not cas_file.exists():
+            raise FileNotFoundError(f"case file not found: {cas_file}")
+
         engine = BaseEngine()
         engine.run([exe, cas_name, cas_stem], cwd=work)
 


### PR DESCRIPTION
## Summary
- show executed commands in `BaseEngine.run`
- raise clearer errors if `fluent2fensap.exe` or the case file is missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68610e4a5a608327a2d2433fdd79240c