### PR TITLE
Add per-job run command

### DIFF
--- a/glacium/cli/job.py
+++ b/glacium/cli/job.py
@@ -199,6 +199,39 @@ def cli_job_remove(job_name: str):
     click.echo(f"{jname} entfernt.")
 
 
+@cli_job.command("run")
+@click.argument("job_name")
+def cli_job_run(job_name: str):
+    """Führe JOB aus dem aktuellen Projekt aus."""
+    uid = load()
+    if uid is None:
+        raise click.ClickException("Kein Projekt gewählt. Erst 'glacium select' nutzen.")
+
+    pm = ProjectManager(ROOT)
+    try:
+        proj = pm.load(uid)
+    except FileNotFoundError:
+        raise click.ClickException(f"Projekt '{uid}' nicht gefunden.") from None
+
+    if job_name.isdigit():
+        idx = int(job_name) - 1
+        if idx < 0 or idx >= len(proj.jobs):
+            raise click.ClickException("Ungültige Nummer.")
+        jname = proj.jobs[idx].name
+    else:
+        jname = job_name.upper()
+        if jname not in proj.job_manager._jobs:
+            raise click.ClickException(f"Job '{job_name}' existiert nicht.")
+
+    job = proj.job_manager._jobs[jname]
+    if job.status is JobStatus.RUNNING:
+        raise click.ClickException("Job läuft bereits.")
+    job.status = JobStatus.PENDING
+    proj.job_manager._save_status()
+
+    proj.job_manager.run([jname])
+
+
 @cli_job.command("select")
 @click.argument("job")
 def cli_job_select(job: str):

--- a/glacium/managers/JobManager.py
+++ b/glacium/managers/JobManager.py
@@ -102,7 +102,14 @@ class JobManager:
         def ready(j: Job) -> bool:
             """Return ``True`` if all dependencies of ``j`` are done."""
 
-            return all(self._jobs[d].status is JobStatus.DONE for d in j.deps)
+            for d in j.deps:
+                dep = self._jobs.get(d)
+                if dep is None:
+                    log.warning(f"Dependency '{d}' for job '{j.name}' missing")
+                    return False
+                if dep.status is not JobStatus.DONE:
+                    return False
+            return True
 
         while True:
             runnable = [j for j in self._jobs.values()

--- a/tests/test_job_cli_numbers.py
+++ b/tests/test_job_cli_numbers.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from click.testing import CliRunner
 from glacium.cli import cli
 from glacium.managers.PathManager import _SharedState
+from glacium.managers.JobManager import JobManager
 
 
 def _setup(tmp_path):
@@ -61,4 +62,19 @@ def test_job_reset_by_index(tmp_path):
     assert res.exit_code == 0
     data = yaml.safe_load(jobs_yaml.read_text())
     assert data["XFOIL_REFINE"] == "PENDING"
+
+
+def test_job_run_by_index(tmp_path, monkeypatch):
+    runner, uid, env = _setup(tmp_path)
+
+    called = {}
+
+    def fake_run(self, jobs=None):
+        called["jobs"] = jobs
+
+    monkeypatch.setattr(JobManager, "run", fake_run)
+
+    res = runner.invoke(cli, ["job", "run", "1"], env=env)
+    assert res.exit_code == 0
+    assert called["jobs"] == ["XFOIL_REFINE"]
 


### PR DESCRIPTION
## Summary
- avoid crashing if job dependencies are missing
- allow running a single job via `glacium job run`
- test running a job by index

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861104655f4832792b48761fd5bc230