### PR TITLE
Add Drop3d solver support

### DIFF
--- a/glacium/engines/__init__.py
+++ b/glacium/engines/__init__.py
@@ -2,7 +2,7 @@
 
 from .base_engine import BaseEngine, XfoilEngine, DummyEngine
 from .pointwise import PointwiseEngine, PointwiseScriptJob
-from .fensap import FensapEngine, FensapRunJob
+from .fensap import FensapEngine, FensapRunJob, Drop3dRunJob
 from .fluent2fensap import Fluent2FensapJob
 
 __all__ = [
@@ -13,6 +13,7 @@ __all__ = [
     "PointwiseScriptJob",
     "FensapEngine",
     "FensapRunJob",
+    "Drop3dRunJob",
     "Fluent2FensapJob",
 ]
 

--- a/tests/test_fluent2fensap_default.py
+++ b/tests/test_fluent2fensap_default.py
@@ -23,7 +23,7 @@ def test_fluent2fensap_default(monkeypatch, tmp_path):
     paths = PathBuilder(tmp_path).build()
     paths.ensure()
 
-    work = paths.solver_dir("pointwise")
+    work = paths.solver_dir("mesh")
     (work / "GCI.cas").write_text("case")
 
     project = Project("uid", tmp_path, cfg, paths, [])


### PR DESCRIPTION
## Summary
- support running DROP3D solver similar to FENSAP
- expose `Drop3dRunJob` via engine package
- test DROP3D integration
- fix fluent2fensap tests to use correct mesh directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686118caa1b083278ad0d2475c491ea1