### PR TITLE
Add ICE3D solver support

### DIFF
--- a/glacium/engines/__init__.py
+++ b/glacium/engines/__init__.py
@@ -2,7 +2,7 @@
 
 from .base_engine import BaseEngine, XfoilEngine, DummyEngine
 from .pointwise import PointwiseEngine, PointwiseScriptJob
-from .fensap import FensapEngine, FensapRunJob, Drop3dRunJob
+from .fensap import FensapEngine, FensapRunJob, Drop3dRunJob, Ice3dRunJob
 from .fluent2fensap import Fluent2FensapJob
 
 __all__ = [
@@ -14,6 +14,7 @@ __all__ = [
     "FensapEngine",
     "FensapRunJob",
     "Drop3dRunJob",
+    "Ice3dRunJob",
     "Fluent2FensapJob",
 ]
 

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -12,6 +12,7 @@ from glacium.engines.base_engine import BaseEngine, XfoilEngine, DummyEngine
 from glacium.engines.XfoilBase import XfoilScriptJob
 from glacium.engines.pointwise import PointwiseEngine, PointwiseScriptJob
 from glacium.engines.fensap import FensapEngine, FensapRunJob, Drop3dRunJob
+from glacium.engines.fensap import Ice3dRunJob
 from glacium.engines.fluent2fensap import Fluent2FensapJob
 from glacium.models.config import GlobalConfig
 from glacium.managers.PathManager import PathBuilder, _SharedState
@@ -226,6 +227,76 @@ def test_drop3d_run_job_calls_base_engine(monkeypatch, tmp_path):
     job.execute()
 
     work = paths.solver_dir("run_DROP3D")
+    solvercmd = work / ".solvercmd"
+
+    assert solvercmd.exists()
+    assert called["cmd"] == [str(exe), str(solvercmd)]
+    assert called["cwd"] == work
+
+
+def test_ice3d_run_job(tmp_path):
+    _SharedState._SharedState__shared_state.clear()
+    template_root = tmp_path / "tmpl"
+    template_root.mkdir()
+    (template_root / "FENSAP.ICE3D.custom_remeshing.sh.j2").write_text("custom")
+    (template_root / "FENSAP.ICE3D.remeshing.jou.j2").write_text("jou")
+    (template_root / "FENSAP.ICE3D.meshingSizes.scm.j2").write_text("scm")
+    (template_root / "FENSAP.ICE3D.files.j2").write_text("files")
+    (template_root / "FENSAP.ICE3D.par.j2").write_text("par")
+    (template_root / "FENSAP.solvercmd.j2").write_text("exit 0")
+
+    cfg = GlobalConfig(project_uid="uid", base_dir=tmp_path)
+    cfg["FENSAP_EXE"] = "sh"
+
+    paths = PathBuilder(tmp_path).build()
+    paths.ensure()
+    TemplateManager(template_root)
+
+    project = Project("uid", tmp_path, cfg, paths, [])
+    job = Ice3dRunJob(project)
+    job.execute()
+    assert (paths.solver_dir("run_ICE3D") / ".solvercmd").exists()
+
+
+def test_ice3d_run_job_calls_base_engine(monkeypatch, tmp_path):
+    """Ensure ``BaseEngine.run`` is executed with configured executable."""
+    _SharedState._SharedState__shared_state.clear()
+
+    template_root = tmp_path / "tmpl"
+    template_root.mkdir()
+    (template_root / "FENSAP.ICE3D.custom_remeshing.sh.j2").write_text("custom")
+    (template_root / "FENSAP.ICE3D.remeshing.jou.j2").write_text("jou")
+    (template_root / "FENSAP.ICE3D.meshingSizes.scm.j2").write_text("scm")
+    (template_root / "FENSAP.ICE3D.files.j2").write_text("files")
+    (template_root / "FENSAP.ICE3D.par.j2").write_text("par")
+    (template_root / "FENSAP.solvercmd.j2").write_text("exit 0")
+
+    exe = tmp_path / "bin" / "nti_sh.exe"
+    exe.parent.mkdir()
+    exe.write_text("")
+
+    cfg = GlobalConfig(project_uid="uid", base_dir=tmp_path)
+    cfg["FENSAP_EXE"] = str(exe)
+
+    paths = PathBuilder(tmp_path).build()
+    paths.ensure()
+    TemplateManager(template_root)
+
+    project = Project("uid", tmp_path, cfg, paths, [])
+    job = Ice3dRunJob(project)
+
+    called = {}
+
+    def fake_run(self, cmd, *, cwd, stdin=None):
+        called["cmd"] = cmd
+        called["cwd"] = cwd
+        called["stdin"] = stdin
+
+    monkeypatch.setattr(BaseEngine, "run", fake_run)
+
+    job.execute()
+
+    work = paths.solver_dir("run_ICE3D")
     solvercmd = work / ".solvercmd"
 
     assert solvercmd.exists()


### PR DESCRIPTION
## Summary
- add `Ice3dRunJob` mirroring the existing DROP3D and FENSAP jobs
- expose new job in `glacium.engines`
- test ICE3D job execution

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686128ab58a48327b01bd79e215cbf2d