### PR TITLE
Add default config helper

### DIFF
--- a/glacium/cli/new.py
+++ b/glacium/cli/new.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import click
 
 from glacium.utils.logging import log
+from glacium.utils.default_paths import global_default_config
 from glacium.models.config import GlobalConfig
 from glacium.managers.PathManager import PathBuilder
 from glacium.managers.TemplateManager import TemplateManager
@@ -31,13 +32,8 @@ from glacium.managers.JobManager import JobManager
 PKG_ROOT      = Path(__file__).resolve().parents[2]       # repo‑Root
 PKG_PKG       = Path(__file__).resolve().parents[1]       # .../glacium
 TEMPLATE_ROOT = PKG_ROOT / "templates"
-DEFAULT_CFG   = PKG_ROOT / "config" / "defaults" / "global_default.yaml"
+DEFAULT_CFG   = global_default_config()
 RUNS_ROOT     = PKG_ROOT / "runs"
-
-# Erst versuchen: repo/config/defaults/...
-_default_a = PKG_ROOT  / "config"  / "defaults" / "global_default.yaml"
-_default_b = PKG_PKG   / "config"  / "defaults" / "global_default.yaml"
-DEFAULT_CFG = _default_a if _default_a.exists() else _default_b
 
 DEFAULT_RECIPE  = "minimal_xfoil"
 DEFAULT_AIRFOIL = PKG_PKG / "data" / "AH63K127.dat"

--- a/glacium/managers/ProjectManager.py
+++ b/glacium/managers/ProjectManager.py
@@ -26,6 +26,7 @@ from glacium.managers.JobManager import JobManager, Job
 from glacium.models.config import GlobalConfig
 from glacium.models.project import Project
 from glacium.utils.logging import log
+from glacium.utils.default_paths import global_default_config
 
 __all__ = ["ProjectManager"]
 
@@ -62,7 +63,7 @@ class ProjectManager:
         # Pfade & Grundstruktur
         paths = PathBuilder(root).build(); paths.ensure()
 
-        defaults_file = Path(__file__).resolve().parents[1] / "config" / "defaults" / "global_default.yaml"
+        defaults_file = global_default_config()
         defaults = yaml.safe_load(defaults_file.read_text()) if defaults_file.exists() else {}
 
         cfg = GlobalConfig(**defaults, project_uid=uid, base_dir=root)

--- a/glacium/utils/__init__.py
+++ b/glacium/utils/__init__.py
@@ -2,3 +2,4 @@
 
 from .JobIndex import list_jobs
 from .current_job import save as save_current_job, load as load_current_job
+from .default_paths import global_default_config

--- a/glacium/utils/default_paths.py
+++ b/glacium/utils/default_paths.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def global_default_config() -> Path:
+    """Return the path to ``config/defaults/global_default.yaml``.
+
+    The function first looks for ``config/defaults`` at the repository root
+    and falls back to the package directory. This mirrors the behaviour
+    previously duplicated across multiple modules.
+    """
+
+    repo_root = Path(__file__).resolve().parents[2]
+    pkg_root = Path(__file__).resolve().parents[1]
+
+    a = repo_root / "config" / "defaults" / "global_default.yaml"
+    b = pkg_root / "config" / "defaults" / "global_default.yaml"
+    return a if a.exists() else b


### PR DESCRIPTION
## Summary
- provide `global_default_config` helper for the default config path
- use helper in `cli/new` and `ProjectManager`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68614d7f91ec83278f4d095b7b760926