### PR TITLE
Centralize logging setup

### DIFF
--- a/glacium/__init__.py
+++ b/glacium/__init__.py
@@ -9,11 +9,6 @@ Description
 
 from __future__ import annotations
 
-import typing as tp
-
-import coloredlogs
-import verboselogs
-
 # -----------------------------------------------------------------------------
 # COPYRIGHT
 # -----------------------------------------------------------------------------
@@ -31,9 +26,7 @@ __version__ = _version("glacium")
 # LOGGER
 # -----------------------------------------------------------------------------
 
-verboselogs.install()
-logger = verboselogs.VerboseLogger("module_logger")
-coloredlogs.install(level="CRITICAL", logger=logger)
+# The main logger is configured in :mod:`glacium.utils.logging`.
 
 # -----------------------------------------------------------------------------
 # CLASSES

--- a/glacium/utils/logging.py
+++ b/glacium/utils/logging.py
@@ -18,5 +18,18 @@ logging.basicConfig(
     handlers=[handler],
 )
 
+# Additional log level matching :func:`verboselogs.VerboseLogger.success`.
+_SUCCESS_LEVEL = 25
+logging.addLevelName(_SUCCESS_LEVEL, "SUCCESS")
+
+
+def _success(self: logging.Logger, message: str, *args, **kwargs) -> None:
+    """Log *message* with level ``SUCCESS``."""
+
+    self.log(_SUCCESS_LEVEL, message, *args, **kwargs)
+
+
+logging.Logger.success = _success  # type: ignore[attr-defined]
+
 log = logging.getLogger("glacium")
 log.setLevel(_LEVEL)


### PR DESCRIPTION
## Summary
- remove package logger initialization
- support a SUCCESS log level in `glacium.utils.logging`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68614fb6786c8327940ade39d8f61586