### PR TITLE
Fix docs after module cleanup

### DIFF
--- a/docs/glacium.engines.rst
+++ b/docs/glacium.engines.rst
@@ -5,23 +5,11 @@ Submodules
 ----------
 
 glacium.engines.pointwise_jobs module
-------------------------------------
-
-.. automodule:: glacium.engines.pointwise_jobs
-   :members:
-   :show-inheritance:
-   :undoc-members:
-
-glacium.engines.xfoil_base module
---------------------------------
-
-.. automodule:: glacium.engines.xfoil_base
-   :members:
-   :show-inheritance:
-   :undoc-members:
+-------------------------------------
 
 glacium.engines.xfoil_jobs module
---------------------------------
+---------------------------------
+
 
 .. automodule:: glacium.engines.xfoil_jobs
    :members:
@@ -52,21 +40,6 @@ glacium.engines.pointwise module
    :show-inheritance:
    :undoc-members:
 
-glacium.engines.veusz module
-----------------------------
-
-.. automodule:: glacium.engines.veusz
-   :members:
-   :show-inheritance:
-   :undoc-members:
-
-glacium.engines.xfoil\_engine module
-------------------------------------
-
-.. automodule:: glacium.engines.xfoil_engine
-   :members:
-   :show-inheritance:
-   :undoc-members:
 
 Module contents
 ---------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,3 +7,4 @@ glacium documentation
 
    config_manager
    glacium
+   modules


### PR DESCRIPTION
## Summary
- remove obsolete engine references from Sphinx docs
- add `modules` to the docs toctree
- adjust underline lengths in `glacium.engines.rst`

## Testing
- `make html`

------
https://chatgpt.com/codex/tasks/task_e_686151cb9aac832783efe192c84c42a2