### PR TITLE
Add Reynolds configurator job

### DIFF
--- a/glacium/engines/__init__.py
+++ b/glacium/engines/__init__.py
@@ -4,6 +4,7 @@ from .base_engine import BaseEngine, XfoilEngine, DummyEngine
 from .pointwise import PointwiseEngine, PointwiseScriptJob
 from .fensap import FensapEngine, FensapRunJob, Drop3dRunJob, Ice3dRunJob
 from .fluent2fensap import Fluent2FensapJob
+from .configurator import ReynoldsConfigJob
 
 __all__ = [
     "BaseEngine",
@@ -16,5 +17,6 @@ __all__ = [
     "Drop3dRunJob",
     "Ice3dRunJob",
     "Fluent2FensapJob",
+    "ReynoldsConfigJob",
 ]
 

--- a/glacium/engines/configurator.py
+++ b/glacium/engines/configurator.py
@@ -1,0 +1,36 @@
+"""Jobs manipulating project configuration."""
+
+from __future__ import annotations
+
+from glacium.models.job import Job
+from glacium.managers.ConfigManager import ConfigManager
+from lambda_explorer.tools.aero_formulas import ReynoldsNumber
+
+__all__ = ["ReynoldsConfigJob"]
+
+
+class ReynoldsConfigJob(Job):
+    """Compute and propagate the Reynolds number."""
+
+    name = "CONFIG_REYNOLDS"
+    deps: tuple[str, ...] = ()
+
+    def execute(self) -> None:  # noqa: D401
+        cfg_mgr = ConfigManager(self.project.paths)
+        cfg = cfg_mgr.load_global()
+
+        re = cfg.get("REYNOLDS_NUMBER")
+        if re is None:
+            rho = cfg.get("AIR_DENSITY", 1.225)
+            velocity = cfg.get("FSP_FREESTREAM_VELOCITY", cfg.get("ICE_REF_VELOCITY", 0))
+            chord = cfg.get("PWS_CHORD_LENGTH", 1.0)
+            mu = cfg.get("AIR_VISCOSITY", 1.789e-5)
+            re = ReynoldsNumber().solve(rho=rho, V=velocity, c=chord, mu=mu)
+            cfg["REYNOLDS_NUMBER"] = re
+
+        cfg["PWS_POL_REYNOLDS"] = re
+        cfg["PWS_PSI_REYNOLDS"] = re
+        cfg["FSP_REYNOLDS_NUMBER"] = re
+        cfg["ICE_REYNOLDS_NUMBER"] = re
+
+        cfg_mgr.dump_global()

--- a/glacium/utils/JobIndex.py
+++ b/glacium/utils/JobIndex.py
@@ -12,7 +12,7 @@ from glacium.models.job import Job
 _PACKAGES: Iterable[str] = ["glacium.engines", "glacium.recipes"]
 
 # names of jobs not shown in public listings
-_EXCLUDE: set[str] = {"FENSAP_RUN"}
+_EXCLUDE: set[str] = {"FENSAP_RUN", "CONFIG_REYNOLDS"}
 
 
 def _discover() -> None:


### PR DESCRIPTION
## Summary
- add `ReynoldsConfigJob` for handling Reynolds calculations
- export the new job through `glacium.engines`
- hide it from default job listings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68616ccbb6608327937857bff6bb44d1