### PR TITLE
Insert Reynolds configuration step into recipes

### DIFF
--- a/glacium/recipes/default_aero.py
+++ b/glacium/recipes/default_aero.py
@@ -1,6 +1,7 @@
 """Recipes providing standard XFOIL workflows."""
 
 from glacium.managers.RecipeManager import RecipeManager, BaseRecipe
+from glacium.engines.configurator import ReynoldsConfigJob
 from glacium.engines.xfoil_jobs import (
     XfoilRefineJob,
     XfoilThickenTEJob,
@@ -22,6 +23,7 @@ class DefaultAero(BaseRecipe):
 
     def build(self, project):
         return [
+            ReynoldsConfigJob(project),
             XfoilRefineJob(project),
             XfoilThickenTEJob(project),
             XfoilConvertJob(project),
@@ -39,6 +41,7 @@ class MinimalXfoil(BaseRecipe):
 
     def build(self, project):
         return [
+            ReynoldsConfigJob(project),
             XfoilRefineJob(project),
             XfoilThickenTEJob(project),
             XfoilConvertJob(project),

--- a/glacium/recipes/fensap.py
+++ b/glacium/recipes/fensap.py
@@ -1,6 +1,7 @@
 """Recipe containing jobs to run the FENSAP solver."""
 
 from glacium.managers.RecipeManager import RecipeManager, BaseRecipe
+from glacium.engines.configurator import ReynoldsConfigJob
 from glacium.engines.fensap import FensapRunJob
 
 @RecipeManager.register
@@ -11,6 +12,7 @@ class FensapRecipe(BaseRecipe):
     description = "Run fensap scripts"
     def build(self, project):
         return [
+            ReynoldsConfigJob(project),
             FensapRunJob(project),
         ]
 

--- a/glacium/recipes/pointwise.py
+++ b/glacium/recipes/pointwise.py
@@ -1,6 +1,7 @@
 """Recipe integrating Pointwise mesh generation jobs."""
 
 from glacium.managers.RecipeManager import RecipeManager, BaseRecipe
+from glacium.engines.configurator import ReynoldsConfigJob
 from glacium.engines.pointwise_jobs import PointwiseGCIJob, PointwiseMesh2Job
 from glacium.engines.fluent2fensap import Fluent2FensapJob
 
@@ -13,6 +14,7 @@ class PointwiseRecipe(BaseRecipe):
 
     def build(self, project):
         return [
+            ReynoldsConfigJob(project),
             PointwiseGCIJob(project),
             PointwiseMesh2Job(project),
             Fluent2FensapJob(project),

--- a/tests/test_job_cli_numbers.py
+++ b/tests/test_job_cli_numbers.py
@@ -20,7 +20,7 @@ def test_list_numbering(tmp_path):
     runner, uid, env = _setup(tmp_path)
     res = runner.invoke(cli, ["list"], env=env)
     assert res.exit_code == 0
-    assert "1   XFOIL_REFINE" in res.output
+    assert "1   CONFIG_REYNOLDS" in res.output
 
 
 def test_job_select_and_remove_by_index(tmp_path):
@@ -55,13 +55,13 @@ def test_job_reset_by_index(tmp_path):
     jobs_yaml = Path("runs") / uid / "_cfg" / "jobs.yaml"
     # Mark job as DONE
     data = yaml.safe_load(jobs_yaml.read_text())
-    data["XFOIL_REFINE"] = "DONE"
+    data["CONFIG_REYNOLDS"] = "DONE"
     yaml.dump(data, jobs_yaml.open("w"))
 
     res = runner.invoke(cli, ["job", "reset", "1"], env=env)
     assert res.exit_code == 0
     data = yaml.safe_load(jobs_yaml.read_text())
-    assert data["XFOIL_REFINE"] == "PENDING"
+    assert data["CONFIG_REYNOLDS"] == "PENDING"
 
 
 def test_job_run_by_index(tmp_path, monkeypatch):
@@ -76,5 +76,5 @@ def test_job_run_by_index(tmp_path, monkeypatch):
 
     res = runner.invoke(cli, ["job", "run", "1"], env=env)
     assert res.exit_code == 0
-    assert called["jobs"] == ["XFOIL_REFINE"]
+    assert called["jobs"] == ["CONFIG_REYNOLDS"]
 

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -2,6 +2,7 @@ import pytest
 
 from glacium.recipes.fensap import FensapRecipe
 from glacium.engines.fensap import FensapRunJob
+from glacium.engines.configurator import ReynoldsConfigJob
 from glacium.models.config import GlobalConfig
 from glacium.managers.PathManager import PathBuilder
 from glacium.models.project import Project
@@ -15,5 +16,6 @@ def test_fensap_recipe_build(tmp_path):
     recipe = FensapRecipe()
     jobs = recipe.build(project)
 
-    assert len(jobs) == 1
-    assert isinstance(jobs[0], FensapRunJob)
+    assert len(jobs) == 2
+    assert isinstance(jobs[0], ReynoldsConfigJob)
+    assert isinstance(jobs[1], FensapRunJob)


### PR DESCRIPTION
## Summary
- run Reynolds number harmonization as first step for major recipes
- adjust Fensap recipe test
- update CLI job index tests for new first job

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68616ed99db48327b3615299544decfc