### PR TITLE
Add docs for configurator job

### DIFF
--- a/docs/configurator_job.rst
+++ b/docs/configurator_job.rst
@@ -1,0 +1,18 @@
+Configurator job
+================
+
+The :class:`glacium.engines.configurator.ReynoldsConfigJob` updates
+Reynolds number fields in the active project.  It is available under the
+job name ``CONFIG_REYNOLDS``.
+
+When run, the job loads the global configuration and checks for a master
+key ``REYNOLDS_NUMBER``.  If the key is missing, the value is computed
+using :mod:`lambda_explorer.tools.aero_formulas.ReynoldsNumber` based on
+freestream parameters.  The result is propagated to multiple keys such
+as ``PWS_POL_REYNOLDS`` and ``FSP_REYNOLDS_NUMBER`` and written back to
+``global_config.yaml``.
+
+Execute the job manually with::
+
+   glacium run CONFIG_REYNOLDS
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,5 +6,6 @@ glacium documentation
    :caption: content:
 
    config_manager
+   configurator_job
    glacium
    modules


### PR DESCRIPTION
## Summary
- document `ReynoldsConfigJob` and how it uses lambda-explorer
- link the new doc page from the main index
- regenerate Sphinx docs

## Testing
- `make html`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861709b49448327808866e9f40d3804