### PR TITLE
Add multirun CLI wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,11 @@ You can run specific jobs by name as well:
 glacium run XFOIL_REFINE XFOIL_POLAR
 ```
 
-For sweeps you can invoke the Hydra entry point:
+For sweeps you can use Hydra directly via ``glacium --multirun``. Results are
+stored under ``runs/${now}`` as configured via ``hydra.run.dir``:
 
 ```bash
-python -m glacium.main xfoil.XFOIL_POLAR_OUT=my.dat --multirun
+glacium --multirun xfoil.thickness=[0.01,0.02]
 ```
 
 ### Show job status

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -43,11 +43,12 @@ You can also run specific jobs:
 
    glacium run XFOIL_REFINE XFOIL_POLAR
 
-Hydra overrides are supported for parameter sweeps:
+Hydra overrides are supported for parameter sweeps. Results will appear under
+``runs/${now}`` according to ``hydra.run.dir``:
 
 .. code-block:: bash
 
-   python -m glacium.main xfoil.XFOIL_POLAR_OUT=my.dat --multirun
+   glacium --multirun xfoil.thickness=[0.01,0.02]
 
 Checking job status
 -------------------

--- a/glacium/cli/__init__.py
+++ b/glacium/cli/__init__.py
@@ -12,10 +12,16 @@ from .job      import cli_job
 from .sync import cli_sync
 from .remove import cli_remove
 
-@click.group()
-def cli():
+@click.group(context_settings={"ignore_unknown_options": True, "allow_extra_args": True})
+@click.option("--multirun", is_flag=True, help="Execute parameter sweep via Hydra")
+@click.pass_context
+def cli(ctx: click.Context, multirun: bool):
     """Glacium – project & job control."""
-    pass
+    if multirun:
+        from glacium.main import main as hydra_main
+        overrides = list(ctx.args) + ["--multirun", "hydra.run.dir=runs/${now:%Y-%m-%d_%H-%M-%S}"]
+        hydra_main(overrides)
+        ctx.exit()
 
 # Befehle registrieren
 cli.add_command(cli_new)


### PR DESCRIPTION
## Summary
- allow `glacium` to forward `--multirun` to Hydra
- document how to run parameter sweeps via the new option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68625b92b6b48327a2815693d142bb0a