### PR TITLE
Update FENSAP solvercmd handling

### DIFF
--- a/glacium/conf/config.yaml
+++ b/glacium/conf/config.yaml
@@ -19,6 +19,9 @@ defaults:
   - templates/FENSAP.ICE3D.meshingSizes.scm
   - templates/FENSAP.ICE3D.par
   - templates/FENSAP.ICE3D.remeshing.jou
+  - templates/FENSAP.FENSAP.solvercmd
+  - templates/FENSAP.DROP3D.solvercmd
+  - templates/FENSAP.ICE3D.solvercmd
   - templates/FENSAP.solvercmd
   - templates/POINTWISE.GCI.glf
   - templates/POINTWISE.run_pointwise.sh

--- a/glacium/engines/fensap.py
+++ b/glacium/engines/fensap.py
@@ -44,7 +44,7 @@ class FensapRunJob(Job):
         tm = TemplateManager()
         tm.render_to_file("FENSAP.FENSAP.files.j2", ctx, work / "files")
         tm.render_to_file("FENSAP.FENSAP.par.j2", ctx, work / "fensap.par")
-        tm.render_to_file("FENSAP.solvercmd.j2", ctx, work / ".solvercmd")
+        tm.render_to_file("FENSAP.FENSAP.solvercmd.j2", ctx, work / ".solvercmd")
 
         exe = cfg.get("FENSAP_EXE", self._DEFAULT_EXE)
         engine = FensapEngine()
@@ -75,7 +75,7 @@ class Drop3dRunJob(Job):
         tm = TemplateManager()
         tm.render_to_file("FENSAP.DROP3D.files.j2", ctx, work / "files")
         tm.render_to_file("FENSAP.DROP3D.par.j2", ctx, work / "drop3d.par")
-        tm.render_to_file("FENSAP.solvercmd.j2", ctx, work / ".solvercmd")
+        tm.render_to_file("FENSAP.DROP3D.solvercmd.j2", ctx, work / ".solvercmd")
 
         exe = cfg.get("FENSAP_EXE", self._DEFAULT_EXE)
         engine = FensapEngine()
@@ -109,7 +109,7 @@ class Ice3dRunJob(Job):
         tm.render_to_file("FENSAP.ICE3D.meshingSizes.scm.j2", ctx, work / "meshingSizes.scm")
         tm.render_to_file("FENSAP.ICE3D.files.j2", ctx, work / "files")
         tm.render_to_file("FENSAP.ICE3D.par.j2", ctx, work / "ice3d.par")
-        tm.render_to_file("FENSAP.solvercmd.j2", ctx, work / ".solvercmd")
+        tm.render_to_file("FENSAP.ICE3D.solvercmd.j2", ctx, work / ".solvercmd")
 
         exe = cfg.get("FENSAP_EXE", self._DEFAULT_EXE)
         engine = FensapEngine()

--- a/glacium/index.yaml
+++ b/glacium/index.yaml
@@ -30,6 +30,9 @@ ROOT_TEMPLATES_FENSAP_ICE3D_FILES_J2: C:\Users\Noel\Documents\GitHub\Pipeline\03
 ROOT_TEMPLATES_FENSAP_ICE3D_MESHINGSIZES_SCM_J2: C:\Users\Noel\Documents\GitHub\Pipeline\03_runs\templates\FENSAP.ICE3D.meshingSizes.scm.j2
 ROOT_TEMPLATES_FENSAP_ICE3D_PAR_J2: C:\Users\Noel\Documents\GitHub\Pipeline\03_runs\templates\FENSAP.ICE3D.par.j2
 ROOT_TEMPLATES_FENSAP_ICE3D_REMESHING_JOU_J2: C:\Users\Noel\Documents\GitHub\Pipeline\03_runs\templates\FENSAP.ICE3D.remeshing.jou.j2
+ROOT_TEMPLATES_FENSAP_FENSAP_SOLVERCMD_J2: C:\Users\Noel\Documents\GitHub\Pipeline\03_runs\templates\FENSAP.FENSAP.solvercmd.j2
+ROOT_TEMPLATES_FENSAP_DROP3D_SOLVERCMD_J2: C:\Users\Noel\Documents\GitHub\Pipeline\03_runs\templates\FENSAP.DROP3D.solvercmd.j2
+ROOT_TEMPLATES_FENSAP_ICE3D_SOLVERCMD_J2: C:\Users\Noel\Documents\GitHub\Pipeline\03_runs\templates\FENSAP.ICE3D.solvercmd.j2
 ROOT_TEMPLATES_FENSAP_SOLVERCMD_J2: C:\Users\Noel\Documents\GitHub\Pipeline\03_runs\templates\FENSAP.solvercmd.j2
 ROOT_TEMPLATES_POINTWISE_GCI_GLF_J2: C:\Users\Noel\Documents\GitHub\Pipeline\03_runs\templates\POINTWISE.GCI.glf.j2
 ROOT_TEMPLATES_VSZ_PROFILES_VSZ_J2: C:\Users\Noel\Documents\GitHub\Pipeline\03_runs\templates\VSZ.profiles.vsz.j2

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -112,7 +112,7 @@ def test_fensap_run_job(tmp_path):
     template_root.mkdir()
     (template_root / "FENSAP.FENSAP.files.j2").write_text("files")
     (template_root / "FENSAP.FENSAP.par.j2").write_text("par")
-    (template_root / "FENSAP.solvercmd.j2").write_text("exit 0")
+    (template_root / "FENSAP.FENSAP.solvercmd.j2").write_text("exit 0")
 
     cfg = GlobalConfig(project_uid="uid", base_dir=tmp_path)
     cfg["FENSAP_EXE"] = "sh"
@@ -135,7 +135,7 @@ def test_fensap_run_job_calls_base_engine(monkeypatch, tmp_path):
     template_root.mkdir()
     (template_root / "FENSAP.FENSAP.files.j2").write_text("files")
     (template_root / "FENSAP.FENSAP.par.j2").write_text("par")
-    (template_root / "FENSAP.solvercmd.j2").write_text("exit 0")
+    (template_root / "FENSAP.FENSAP.solvercmd.j2").write_text("exit 0")
 
     exe = tmp_path / "bin" / "nti_sh.exe"
     exe.parent.mkdir()
@@ -176,7 +176,7 @@ def test_drop3d_run_job(tmp_path):
     template_root.mkdir()
     (template_root / "FENSAP.DROP3D.files.j2").write_text("files")
     (template_root / "FENSAP.DROP3D.par.j2").write_text("par")
-    (template_root / "FENSAP.solvercmd.j2").write_text("exit 0")
+    (template_root / "FENSAP.DROP3D.solvercmd.j2").write_text("exit 0")
 
     cfg = GlobalConfig(project_uid="uid", base_dir=tmp_path)
     cfg["FENSAP_EXE"] = "sh"
@@ -199,7 +199,7 @@ def test_drop3d_run_job_calls_base_engine(monkeypatch, tmp_path):
     template_root.mkdir()
     (template_root / "FENSAP.DROP3D.files.j2").write_text("files")
     (template_root / "FENSAP.DROP3D.par.j2").write_text("par")
-    (template_root / "FENSAP.solvercmd.j2").write_text("exit 0")
+    (template_root / "FENSAP.DROP3D.solvercmd.j2").write_text("exit 0")
 
     exe = tmp_path / "bin" / "nti_sh.exe"
     exe.parent.mkdir()
@@ -243,7 +243,7 @@ def test_ice3d_run_job(tmp_path):
     (template_root / "FENSAP.ICE3D.meshingSizes.scm.j2").write_text("scm")
     (template_root / "FENSAP.ICE3D.files.j2").write_text("files")
     (template_root / "FENSAP.ICE3D.par.j2").write_text("par")
-    (template_root / "FENSAP.solvercmd.j2").write_text("exit 0")
+    (template_root / "FENSAP.ICE3D.solvercmd.j2").write_text("exit 0")
 
     cfg = GlobalConfig(project_uid="uid", base_dir=tmp_path)
     cfg["FENSAP_EXE"] = "sh"
@@ -269,7 +269,7 @@ def test_ice3d_run_job_calls_base_engine(monkeypatch, tmp_path):
     (template_root / "FENSAP.ICE3D.meshingSizes.scm.j2").write_text("scm")
     (template_root / "FENSAP.ICE3D.files.j2").write_text("files")
     (template_root / "FENSAP.ICE3D.par.j2").write_text("par")
-    (template_root / "FENSAP.solvercmd.j2").write_text("exit 0")
+    (template_root / "FENSAP.ICE3D.solvercmd.j2").write_text("exit 0")
 
     exe = tmp_path / "bin" / "nti_sh.exe"
     exe.parent.mkdir()


### PR DESCRIPTION
## Summary
- generate engine specific `.solvercmd` scripts
- cover new templates in config and index
- adjust tests for solvercmd names

## Testing
- `pytest -q` *(fails: Package 'glacium' requires a different Python: 3.11.12 not in '>=3.12')*

------
https://chatgpt.com/codex/tasks/task_e_6862740864f4832787c2ab20c12c1dab