### PR TITLE
Add recipe option to job add command

### DIFF
--- a/tests/test_job_add_recipe.py
+++ b/tests/test_job_add_recipe.py
@@ -1,0 +1,25 @@
+import yaml
+from pathlib import Path
+from click.testing import CliRunner
+from glacium.cli import cli
+from glacium.managers.PathManager import _SharedState
+
+
+def test_job_add_recipe(tmp_path):
+    runner = CliRunner()
+    env = {"HOME": str(tmp_path)}
+    _SharedState._SharedState__shared_state.clear()
+
+    result = runner.invoke(cli, ["new", "proj", "-y"], env=env)
+    assert result.exit_code == 0
+    uid = result.output.strip().splitlines()[-1]
+
+    result = runner.invoke(cli, ["select", uid], env=env)
+    assert result.exit_code == 0
+
+    result = runner.invoke(cli, ["job", "add", "--recipe", "pointwise"], env=env)
+    assert result.exit_code == 0
+    jobs_yaml = Path("runs") / uid / "_cfg" / "jobs.yaml"
+    data = yaml.safe_load(jobs_yaml.read_text())
+    assert "POINTWISE_MESH2" in data
+    assert "FLUENT2FENSAP" in data


### PR DESCRIPTION
## Summary
- allow `glacium job add` to add all jobs from a recipe via `--recipe`
- test adding recipe jobs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862b600d93c83279c25380659f1aac8