### PR TITLE
Adjust grid file path for FENSAP

### DIFF
--- a/glacium/engines/fluent2fensap.py
+++ b/glacium/engines/fluent2fensap.py
@@ -50,6 +50,7 @@ class Fluent2FensapJob(Job):
         shutil.move(str(produced), dest)
 
         rel = dest.relative_to(self.project.root)
-        cfg["FSP_FILES_GRID"] = str(rel)
+        rel_to_run = Path("..") / rel
+        cfg["FSP_FILES_GRID"] = str(rel_to_run)
         if "ICE_GRID_FILE" in cfg:
-            cfg["ICE_GRID_FILE"] = str(rel)
+            cfg["ICE_GRID_FILE"] = str(rel_to_run)

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -339,6 +339,7 @@ def test_fluent2fensap_job(monkeypatch, tmp_path):
     assert run_call["cmd"] == [str(exe), "mesh.cas", "mesh"]
     assert run_call["cwd"] == work
     rel = dest.relative_to(project.root)
-    assert cfg["FSP_FILES_GRID"] == str(rel)
-    assert cfg["ICE_GRID_FILE"] == str(rel)
+    expected = str(Path("..") / rel)
+    assert cfg["FSP_FILES_GRID"] == expected
+    assert cfg["ICE_GRID_FILE"] == expected
 

--- a/tests/test_fluent2fensap_default.py
+++ b/tests/test_fluent2fensap_default.py
@@ -45,4 +45,5 @@ def test_fluent2fensap_default(monkeypatch, tmp_path):
     assert called["cmd"] == [str(exe), "GCI.cas", "GCI"]
     assert called["cwd"] == work
     rel = dest.relative_to(project.root)
-    assert cfg["FSP_FILES_GRID"] == str(rel)
+    expected = str(Path("..") / rel)
+    assert cfg["FSP_FILES_GRID"] == expected


### PR DESCRIPTION
## Summary
- compute `FSP_FILES_GRID` and `ICE_GRID_FILE` relative to solver
- update expected paths in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862c98794a88327a9d5935a6bcda8c8