### PR TITLE
Clean up logger setup

### DIFF
--- a/glacium/__init__.py
+++ b/glacium/__init__.py
@@ -11,8 +11,7 @@ from __future__ import annotations
 
 import typing as tp
 
-import coloredlogs
-import verboselogs
+from glacium.utils.logging import log
 
 # -----------------------------------------------------------------------------
 # COPYRIGHT
@@ -31,9 +30,7 @@ __version__ = _version("glacium")
 # LOGGER
 # -----------------------------------------------------------------------------
 
-verboselogs.install()
-logger = verboselogs.VerboseLogger("module_logger")
-coloredlogs.install(level="CRITICAL", logger=logger)
+# ``log`` is shared across all modules
 
 # -----------------------------------------------------------------------------
 # CLASSES

--- a/glacium/recipes/fensap.py
+++ b/glacium/recipes/fensap.py
@@ -2,6 +2,7 @@
 
 from glacium.managers.RecipeManager import RecipeManager, BaseRecipe
 from glacium.engines.fensap import FensapEngine
+from glacium.utils.logging import log
 
 @RecipeManager.register
 class FensapRecipe(BaseRecipe):
@@ -14,8 +15,6 @@ class FensapRecipe(BaseRecipe):
             FensapEngine(project),
         ]
 
-import coloredlogs
-import verboselogs
 
 # -----------------------------------------------------------------------------
 # COPYRIGHT
@@ -34,9 +33,7 @@ __version__ = _version("glacium")
 # LOGGER
 # -----------------------------------------------------------------------------
 
-verboselogs.install()
-logger = verboselogs.VerboseLogger("module_logger")
-coloredlogs.install(level="CRITICAL", logger=logger)
+# ``log`` is shared across all modules
 
 # -----------------------------------------------------------------------------
 # CLASSES

--- a/glacium/utils/logging.py
+++ b/glacium/utils/logging.py
@@ -6,6 +6,18 @@ import logging
 from rich.console import Console
 from rich.logging import RichHandler
 
+# Add ``SUCCESS`` level similar to :mod:`verboselogs`
+SUCCESS = 35
+logging.addLevelName(SUCCESS, "SUCCESS")
+
+
+def _success(self, message: str, *args, **kwargs) -> None:  # type: ignore[override]
+    if self.isEnabledFor(SUCCESS):
+        self._log(SUCCESS, message, args, **kwargs)
+
+
+logging.Logger.success = _success  # type: ignore[attr-defined]
+
 # Basiskonfiguration – ändert nichts am globalen ``root``‑Logger
 _LEVEL = "INFO"
 


### PR DESCRIPTION
## Summary
- remove `coloredlogs`/`verboselogs` setup from package init and `fensap` recipe
- pull the shared logger from `glacium.utils.logging`
- emulate `SUCCESS` log level in `glacium.utils.logging`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863a1eb2fe883279f4818ffc0d249fe