### PR TITLE
Add logging configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,16 @@ Paths to third party programs can be configured in
 `POINTWISE_BIN`, `FENSAP_BIN` and the newly added
 `FLUENT2FENSAP_EXE` pointing to ``fluent2fensap.exe`` on Windows.
 
+### Logging
+
+Use `--log-level` to change the verbosity or `--log-file` to write the output
+to a file.  The environment variable `GLACIUM_LOG_LEVEL` can also be used to
+override the default level, e.g.:
+
+```bash
+GLACIUM_LOG_LEVEL=DEBUG glacium list
+```
+
 ## Development
 
 All tests can be run with:

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -80,3 +80,10 @@ Synchronising and removing projects
 
 Use ``--all`` with ``glacium remove`` to delete every project under
 ``./runs``.
+
+Logging
+-------
+
+Set the log level with ``--log-level`` or write output to a file with
+``--log-file``.  The environment variable ``GLACIUM_LOG_LEVEL`` can also be
+used to override the default level.

--- a/glacium/cli/__init__.py
+++ b/glacium/cli/__init__.py
@@ -1,6 +1,8 @@
 """Command line interface entry point for Glacium."""
 
 import click
+from pathlib import Path
+from glacium.utils.logging import configure
 
 # Einzel-Commands importieren
 from .new import cli_new
@@ -13,10 +15,14 @@ from .sync import cli_sync
 from .remove import cli_remove
 
 @click.group(context_settings={"ignore_unknown_options": True, "allow_extra_args": True})
+@click.option("--log-level", default=None, help="Set log level")
+@click.option("--log-file", type=click.Path(path_type=Path), help="Write logs to file")
 @click.option("--multirun", is_flag=True, help="Execute parameter sweep via Hydra")
 @click.pass_context
-def cli(ctx: click.Context, multirun: bool):
+def cli(ctx: click.Context, log_level: str | None, log_file: Path | None, multirun: bool):
     """Glacium – project & job control."""
+    configure(level=log_level or "INFO", file=log_file)
+
     if multirun:
         from glacium.main import main as hydra_main
         overrides = list(ctx.args) + ["--multirun", "hydra.run.dir=runs/${now:%Y-%m-%d_%H-%M-%S}"]

--- a/glacium/utils/logging.py
+++ b/glacium/utils/logging.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import logging
+import os
 from functools import wraps
+from pathlib import Path
 from rich.console import Console
 from rich.logging import RichHandler
 
@@ -45,6 +47,27 @@ log = logging.getLogger("glacium")
 log.setLevel(_LEVEL)
 
 
+def configure(level: str = "INFO", file: Path | None = None) -> None:
+    """Configure logging level and optional log file.
+
+    The level can be overridden via the ``GLACIUM_LOG_LEVEL`` environment
+    variable.
+    """
+
+    final_level = os.getenv("GLACIUM_LOG_LEVEL", level).upper()
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(final_level)
+    log.setLevel(final_level)
+    handler.setLevel(final_level)
+
+    if file is not None:
+        fh = logging.FileHandler(file)
+        fh.setFormatter(logging.Formatter("%(message)s"))
+        fh.setLevel(final_level)
+        root_logger.addHandler(fh)
+
+
 def trace_calls(func):
     """Log entering and exiting of ``func`` at ``TRACE`` level."""
 
@@ -59,4 +82,4 @@ def trace_calls(func):
     return wrapper
 
 
-__all__ = ["log", "SUCCESS", "TRACE", "trace_calls"]
+__all__ = ["log", "SUCCESS", "TRACE", "trace_calls", "configure"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,7 @@ def test_cli_help():
     runner = CliRunner()
     result = runner.invoke(cli, ['--help'])
     assert result.exit_code == 0
+    assert '--log-level' in result.output
 
 
 import pytest
@@ -28,3 +29,17 @@ def test_job_global_list():
     assert result.exit_code == 0
     assert '1)' in result.output
     assert 'XFOIL_REFINE' in result.output
+
+
+def test_cli_logging_options(tmp_path):
+    runner = CliRunner()
+    log_file = tmp_path / 'test.log'
+    result = runner.invoke(cli, ['--log-level', 'DEBUG', '--log-file', str(log_file), 'list', '--help'])
+    assert result.exit_code == 0
+    assert log_file.exists()
+
+
+def test_cli_log_env():
+    runner = CliRunner()
+    result = runner.invoke(cli, ['--help'], env={'GLACIUM_LOG_LEVEL': 'DEBUG'})
+    assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- add `configure()` to logging helpers
- support `--log-level` and `--log-file` in the CLI
- mention `GLACIUM_LOG_LEVEL` usage in README and quickstart
- test CLI logging options

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863a456585c8327b69d179454ebee54