### PR TITLE
Add log file handler option

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,14 @@ override the default level, e.g.:
 GLACIUM_LOG_LEVEL=DEBUG glacium list
 ```
 
+When using the library directly, you can pass a path to
+``glacium.utils.logging.configure`` to log to a file:
+
+```python
+from glacium.utils.logging import configure
+configure(file="glacium.log")
+```
+
 ## Development
 
 All tests can be run with:

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -87,3 +87,11 @@ Logging
 Set the log level with ``--log-level`` or write output to a file with
 ``--log-file``.  The environment variable ``GLACIUM_LOG_LEVEL`` can also be
 used to override the default level.
+
+When scripting with the API you can enable a log file via
+``glacium.utils.logging.configure``:
+
+.. code-block:: python
+
+   from glacium.utils.logging import configure
+   configure(file="glacium.log")

--- a/glacium/utils/logging.py
+++ b/glacium/utils/logging.py
@@ -47,11 +47,11 @@ log = logging.getLogger("glacium")
 log.setLevel(_LEVEL)
 
 
-def configure(level: str = "INFO", file: Path | None = None) -> None:
+def configure(level: str = "INFO", file: str | os.PathLike[str] | Path | None = None) -> None:
     """Configure logging level and optional log file.
 
-    The level can be overridden via the ``GLACIUM_LOG_LEVEL`` environment
-    variable.
+    ``file`` may be a :class:`~pathlib.Path` or string. The level can be
+    overridden via the ``GLACIUM_LOG_LEVEL`` environment variable.
     """
 
     final_level = os.getenv("GLACIUM_LOG_LEVEL", level).upper()
@@ -62,7 +62,8 @@ def configure(level: str = "INFO", file: Path | None = None) -> None:
     handler.setLevel(final_level)
 
     if file is not None:
-        fh = logging.FileHandler(file)
+        file_path = Path(file)
+        fh = logging.FileHandler(file_path)
         fh.setFormatter(logging.Formatter("%(message)s"))
         fh.setLevel(final_level)
         root_logger.addHandler(fh)

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+import logging
+
+from glacium.utils.logging import configure, log
+
+
+def test_configure_file(tmp_path):
+    log_path = tmp_path / "log.txt"
+    root = logging.getLogger()
+    old_handlers = list(root.handlers)
+    try:
+        configure(level="DEBUG", file=log_path)
+        log.debug("hello")
+        assert log_path.exists()
+        assert "hello" in log_path.read_text()
+    finally:
+        root.handlers = old_handlers
+


### PR DESCRIPTION
## Summary
- extend `logging.configure` with optional file path and create a FileHandler
- document log file usage in README and Quickstart
- test logging to file

## Testing
- `pytest -q`
- `pytest tests/test_logging_config.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6863a9c62c208327be8c821b6d3c827a