### PR TITLE
Add development guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# Glacium Development Guidelines
+
+These rules apply to all files in this repository.
+
+## Code Style
+
+- Use **black** (default settings) for formatting.  The CI uses the same configuration.
+- Write type hints for all new Python functions and methods.
+- Keep imports sorted with **isort**.
+
+## Testing
+
+- Set up the development environment once with:
+
+  ```bash
+  poetry install --with dev
+  poetry self add "poetry-dynamic-versioning[plugin]"
+  ```
+
+- Run the test suite with `pytest` before committing.
+
+## Documentation
+
+- Build the Sphinx documentation via `make -C docs html` to ensure that no warnings are introduced.
+
+## Commit Messages
+
+- Start commit messages with a short, uppercase tag such as `FEAT`, `FIX`, or `DOC`.
+- Follow the tag with a short summary in the same line.
+


### PR DESCRIPTION
## Summary
- add AGENTS guidelines for code style, testing, docs, and commit messages

## Testing
- `poetry install --with dev` *(fails: pyproject changed)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6864df23e4188327b836d7d9ee360d4f