### PR TITLE
Render batch templates in MultiShotRunJob

### DIFF
--- a/glacium/jobs/fensap_jobs.py
+++ b/glacium/jobs/fensap_jobs.py
@@ -151,6 +151,10 @@ class MultiShotRunJob(Job):
         ctx = {**defaults, **cfg.extras}
 
         tm = TemplateManager()
+        template_root = Path(__file__).resolve().parents[1] / "templates"
+        batch_root = template_root / "MULITSHOT10"
+        rel_paths = [p.relative_to(template_root) for p in batch_root.glob("*.j2")]
+        tm.render_batch(rel_paths, ctx, work)
         tm.render_to_file("MULTISHOT.meshingSizes.scm.j2", ctx, work / "meshingSizes.scm")
         tm.render_to_file("MULTISHOT.custom_remeshing.sh.j2", ctx, work / "custom_remeshing.sh")
         tm.render_to_file("MULTISHOT.solvercmd.j2", ctx, work / ".solvercmd")


### PR DESCRIPTION
## Summary
- render templates from `MULITSHOT10` using `TemplateManager.render_batch`
- patch tests to use temporary template root via `__file__` monkeypatching
- ensure MULTISHOT batch templates are generated

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686647effd8c83279af09684096d2a46