### PR TITLE
Fix template paths and Pointwise cwd

### DIFF
--- a/glacium/engines/pointwise.py
+++ b/glacium/engines/pointwise.py
@@ -64,7 +64,7 @@ class PointwiseScriptJob(Job):
         exe = cfg.get("POINTWISE_BIN", "pointwise")
         engine = PointwiseEngine()
         # Run from project root so relative paths resolve correctly
-        engine.run_script(exe, dest_script, work)
+        engine.run_script(exe, dest_script, self.project.root)
 
         if self.cfg_key_out:
             out_name = cfg.get(self.cfg_key_out)

--- a/glacium/managers/template_manager.py
+++ b/glacium/managers/template_manager.py
@@ -75,8 +75,10 @@ class TemplateManager(_SharedState):
 
         self._ensure_loader()
         key = Path(rel_path)
+        # convert to posix path for jinja2 compatibility on Windows
+        posix_key = key.as_posix()
         if key not in self._cache:
-            self._cache[key] = self._env.get_template(str(key))  # type: ignore[index]
+            self._cache[key] = self._env.get_template(posix_key)  # type: ignore[index]
         return self._cache[key]
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- ensure TemplateManager uses POSIX paths when looking up templates
- run Pointwise jobs from the project root instead of the solver directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68664f141c2c8327a80334d56673d500