### PR TITLE
Implement JobFactory and refactor job creation

### DIFF
--- a/glacium/cli/job/add.py
+++ b/glacium/cli/job/add.py
@@ -46,11 +46,11 @@ def cli_job_add(job_name: str) -> None:
             return
         job = recipe_jobs.get(name)
         if job is None:
-            from glacium.utils.JobIndex import create_job, get_job_class
+            from glacium.utils.JobIndex import JobFactory
 
-            if get_job_class(name) is None:
+            if JobFactory.get(name) is None:
                 raise click.ClickException(f"Job '{name}' nicht bekannt.")
-            job = create_job(name, proj)
+            job = JobFactory.create(name, proj)
         for dep in getattr(job, "deps", ()):
             add_with_deps(dep)
         proj.jobs.append(job)

--- a/glacium/managers/project_manager.py
+++ b/glacium/managers/project_manager.py
@@ -127,13 +127,11 @@ class ProjectManager:
         status_file = paths.cfg_dir() / "jobs.yaml"
         if status_file.exists():
             data = yaml.safe_load(status_file.read_text()) or {}
-            from glacium.utils.JobIndex import create_job, get_job_class
+            from glacium.utils.JobIndex import JobFactory
             existing = {j.name for j in project.jobs}
             for name in data.keys():
-                if name not in existing:
-                    cls = get_job_class(name)
-                    if cls:
-                        project.jobs.append(create_job(name, project))
+                if name not in existing and JobFactory.get(name):
+                    project.jobs.append(JobFactory.create(name, project))
 
         project.job_manager = JobManager(project)  # type: ignore[attr-defined]
         self._cache[uid] = project

--- a/glacium/models/job.py
+++ b/glacium/models/job.py
@@ -23,6 +23,17 @@ class Job:
     # optionale Abhängigkeiten (Namen anderer Jobs)
     deps: Sequence[str] = ()
 
+    # Register subclasses automatically ---------------------------------
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        try:  # avoid circular import during bootstrap
+            from glacium.utils.JobIndex import JobFactory
+        except Exception:
+            return
+        name = getattr(cls, "name", "BaseJob")
+        if name != "BaseJob":
+            JobFactory.register(cls)
+
     def __init__(self, project: "Project"):   # noqa: F821  (Vorwärtsreferenz)
         self.project = project
         self.status  = JobStatus.PENDING

--- a/glacium/recipes/default_aero.py
+++ b/glacium/recipes/default_aero.py
@@ -1,16 +1,7 @@
 """Recipes providing standard XFOIL workflows."""
 
 from glacium.managers.recipe_manager import RecipeManager, BaseRecipe
-from glacium.jobs.xfoil_jobs import (
-    XfoilRefineJob,
-    XfoilThickenTEJob,
-    XfoilBoundaryLayerJob,
-    XfoilPolarsJob,
-    XfoilSuctionCurveJob,
-)
-from glacium.engines.xfoil_convert_job import XfoilConvertJob
-from glacium.jobs.pointwise_jobs import PointwiseGCIJob
-from glacium.engines.fluent2fensap import Fluent2FensapJob
+from glacium.utils.JobIndex import JobFactory
 
 
 @RecipeManager.register
@@ -22,10 +13,10 @@ class DefaultAero(BaseRecipe):
 
     def build(self, project):
         return [
-            XfoilRefineJob(project),
-            XfoilThickenTEJob(project),
-            XfoilConvertJob(project),
-            PointwiseGCIJob(project),
-            Fluent2FensapJob(project),
+            JobFactory.create("XFOIL_REFINE", project),
+            JobFactory.create("XFOIL_THICKEN_TE", project),
+            JobFactory.create("XFOIL_PW_CONVERT", project),
+            JobFactory.create("POINTWISE_GCI", project),
+            JobFactory.create("FLUENT2FENSAP", project),
         ]
 

--- a/glacium/recipes/fensap.py
+++ b/glacium/recipes/fensap.py
@@ -1,7 +1,7 @@
 """Recipe containing jobs to run the FENSAP solver."""
 
 from glacium.managers.recipe_manager import RecipeManager, BaseRecipe
-from glacium.jobs.fensap_jobs import FensapRunJob
+from glacium.utils.JobIndex import JobFactory
 
 @RecipeManager.register
 class FensapRecipe(BaseRecipe):
@@ -10,8 +10,6 @@ class FensapRecipe(BaseRecipe):
     name = "fensap"
     description = "Run fensap scripts"
     def build(self, project):
-        return [
-            FensapRunJob(project),
-        ]
+        return [JobFactory.create("FENSAP_RUN", project)]
 
 

--- a/glacium/recipes/hello_world.py
+++ b/glacium/recipes/hello_world.py
@@ -2,6 +2,7 @@
 
 from glacium.managers.recipe_manager import BaseRecipe, RecipeManager
 from glacium.models.job import Job
+from glacium.utils.JobIndex import JobFactory
 
 
 class HelloJob(Job):
@@ -24,4 +25,4 @@ class HelloWorldRecipe(BaseRecipe):
     description = "single dummy job"
 
     def build(self, project):
-        return [HelloJob(project)]
+        return [JobFactory.create("HelloJob", project)]

--- a/glacium/recipes/multishot.py
+++ b/glacium/recipes/multishot.py
@@ -1,15 +1,7 @@
 """Recipes providing standard XFOIL workflows."""
 
 from glacium.managers.recipe_manager import RecipeManager, BaseRecipe
-
-from glacium.engines.xfoil_convert_job import XfoilConvertJob
-from glacium.jobs.xfoil_jobs import (
-    XfoilRefineJob,
-    XfoilThickenTEJob,
-)
-from glacium.jobs.pointwise_jobs import PointwiseGCIJob
-from glacium.engines.fluent2fensap import Fluent2FensapJob
-from glacium.jobs.fensap_jobs import MultiShotRunJob
+from glacium.utils.JobIndex import JobFactory
 
 @RecipeManager.register
 class DefaultAero(BaseRecipe):
@@ -20,11 +12,11 @@ class DefaultAero(BaseRecipe):
 
     def build(self, project):
         return [
-            XfoilRefineJob(project),
-            XfoilThickenTEJob(project),
-            XfoilConvertJob(project),
-            PointwiseGCIJob(project),
-            Fluent2FensapJob(project),
-            MultiShotRunJob(project),
+            JobFactory.create("XFOIL_REFINE", project),
+            JobFactory.create("XFOIL_THICKEN_TE", project),
+            JobFactory.create("XFOIL_PW_CONVERT", project),
+            JobFactory.create("POINTWISE_GCI", project),
+            JobFactory.create("FLUENT2FENSAP", project),
+            JobFactory.create("MULTISHOT_RUN", project),
         ]
 

--- a/glacium/recipes/pointwise.py
+++ b/glacium/recipes/pointwise.py
@@ -1,8 +1,7 @@
 """Recipe integrating Pointwise mesh generation jobs."""
 
 from glacium.managers.recipe_manager import RecipeManager, BaseRecipe
-from glacium.jobs.pointwise_jobs import PointwiseGCIJob, PointwiseMesh2Job
-from glacium.engines.fluent2fensap import Fluent2FensapJob
+from glacium.utils.JobIndex import JobFactory
 
 @RecipeManager.register
 class PointwiseRecipe(BaseRecipe):
@@ -13,9 +12,9 @@ class PointwiseRecipe(BaseRecipe):
 
     def build(self, project):
         return [
-            PointwiseGCIJob(project),
-            PointwiseMesh2Job(project),
-            Fluent2FensapJob(project),
+            JobFactory.create("POINTWISE_GCI", project),
+            JobFactory.create("POINTWISE_MESH2", project),
+            JobFactory.create("FLUENT2FENSAP", project),
         ]
 
 

--- a/glacium/recipes/prep.py
+++ b/glacium/recipes/prep.py
@@ -1,10 +1,7 @@
 """Recipe preparing meshes and conversions before solver runs."""
 
 from glacium.managers.recipe_manager import RecipeManager, BaseRecipe
-from glacium.jobs.xfoil_jobs import XfoilRefineJob, XfoilThickenTEJob
-from glacium.engines.xfoil_convert_job import XfoilConvertJob
-from glacium.jobs.pointwise_jobs import PointwiseGCIJob
-from glacium.engines.fluent2fensap import Fluent2FensapJob
+from glacium.utils.JobIndex import JobFactory
 
 
 @RecipeManager.register
@@ -16,9 +13,9 @@ class PrepRecipe(BaseRecipe):
 
     def build(self, project):
         return [
-            XfoilRefineJob(project),
-            XfoilThickenTEJob(project),
-            XfoilConvertJob(project),
-            PointwiseGCIJob(project),
-            Fluent2FensapJob(project),
+            JobFactory.create("XFOIL_REFINE", project),
+            JobFactory.create("XFOIL_THICKEN_TE", project),
+            JobFactory.create("XFOIL_PW_CONVERT", project),
+            JobFactory.create("POINTWISE_GCI", project),
+            JobFactory.create("FLUENT2FENSAP", project),
         ]

--- a/glacium/recipes/solver.py
+++ b/glacium/recipes/solver.py
@@ -1,7 +1,7 @@
 """Recipe executing the FENSAP solver chain."""
 
 from glacium.managers.recipe_manager import RecipeManager, BaseRecipe
-from glacium.jobs.fensap_jobs import FensapRunJob, Drop3dRunJob, Ice3dRunJob
+from glacium.utils.JobIndex import JobFactory
 
 
 @RecipeManager.register
@@ -13,7 +13,7 @@ class SolverRecipe(BaseRecipe):
 
     def build(self, project):
         return [
-            FensapRunJob(project),
-            Drop3dRunJob(project),
-            Ice3dRunJob(project),
+            JobFactory.create("FENSAP_RUN", project),
+            JobFactory.create("DROP3D_RUN", project),
+            JobFactory.create("ICE3D_RUN", project),
         ]

--- a/glacium/utils/JobIndex.py
+++ b/glacium/utils/JobIndex.py
@@ -4,71 +4,95 @@ from __future__ import annotations
 
 import importlib
 import pkgutil
-from typing import Iterable, Dict, Optional
+from typing import Iterable, Dict, Optional, Type
 
 from glacium.models.job import Job
+from glacium.utils.logging import log
 
-# packages containing job implementations
-_PACKAGES: Iterable[str] = ["glacium.jobs", "glacium.engines", "glacium.recipes"]
+__all__ = ["JobFactory", "list_jobs", "get_job_class", "create_job"]
 
 
-def _discover() -> None:
-    """Import all modules from known packages to populate Job subclasses."""
-    for pkg_name in _PACKAGES:
-        try:
-            pkg = importlib.import_module(pkg_name)
-        except ModuleNotFoundError:
-            continue
-        for mod in pkgutil.walk_packages(pkg.__path__, pkg_name + "."):
+class JobFactory:
+    """Registry and factory for :class:`Job` classes."""
+
+    _jobs: Dict[str, Type[Job]] | None = None
+    _loaded: bool = False
+    _PACKAGES: Iterable[str] = ["glacium.jobs", "glacium.engines", "glacium.recipes"]
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def register(cls, job_cls: Type[Job]) -> Type[Job]:
+        """Register ``job_cls`` under its ``name`` attribute."""
+        if cls._jobs is None:
+            cls._jobs = {}
+        name = getattr(job_cls, "name", "BaseJob")
+        if name == "BaseJob":
+            return job_cls
+        if name in cls._jobs:  # type: ignore[arg-type]
+            log.warning(f"Job '{name}' wird überschrieben.")
+        cls._jobs[name] = job_cls  # type: ignore[index]
+        return job_cls
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def create(cls, name: str, project) -> Job:
+        """Instantiate the registered job ``name`` for ``project``."""
+
+        cls._load()
+        if name not in cls._jobs:  # type: ignore[arg-type]
+            raise KeyError(f"Job '{name}' nicht bekannt.")
+        return cls._jobs[name](project)  # type: ignore[index]
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def list(cls) -> list[str]:
+        """Return all registered job names."""
+
+        cls._load()
+        return sorted(cls._jobs)  # type: ignore[arg-type]
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def get(cls, name: str) -> Optional[Type[Job]]:
+        """Return the registered class for ``name`` if available."""
+
+        cls._load()
+        return cls._jobs.get(name)  # type: ignore[return-value]
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def _load(cls) -> None:
+        if cls._jobs is None:
+            cls._jobs = {}
+        if not cls._loaded:
+            cls._discover()
+            cls._loaded = True
+
+    @classmethod
+    def _discover(cls) -> None:
+        """Import all modules from known packages to populate registry."""
+
+        for pkg_name in cls._PACKAGES:
             try:
-                importlib.import_module(mod.name)
-            except Exception:
-                # ignore faulty modules during discovery
-                pass
+                pkg = importlib.import_module(pkg_name)
+            except ModuleNotFoundError:
+                continue
+            for mod in pkgutil.walk_packages(pkg.__path__, pkg_name + "."):
+                try:
+                    importlib.import_module(mod.name)
+                except Exception:
+                    # ignore faulty modules during discovery
+                    pass
 
 
+# Backwards compatible helper functions --------------------------------------
 def list_jobs() -> list[str]:
-    """Return a sorted list of all implemented job names."""
-    _discover()
-
-    found: set[str] = set()
-
-    def _collect(cls: type[Job]) -> None:
-        for sub in cls.__subclasses__():
-            name = getattr(sub, "name", "BaseJob")
-            if name != "BaseJob":
-                found.add(name)
-            _collect(sub)
-
-    _collect(Job)
-    return sorted(n for n in found)
+    return JobFactory.list()
 
 
-def _collect_map() -> Dict[str, type[Job]]:
-    mapping: Dict[str, type[Job]] = {}
-
-    def _collect(cls: type[Job]) -> None:
-        for sub in cls.__subclasses__():
-            name = getattr(sub, "name", "BaseJob")
-            if name != "BaseJob":
-                mapping[name] = sub
-            _collect(sub)
-
-    _collect(Job)
-    return mapping
-
-
-def get_job_class(name: str) -> Optional[type[Job]]:
-    """Return the Job subclass with ``name`` if available."""
-
-    _discover()
-    return _collect_map().get(name)
+def get_job_class(name: str) -> Optional[Type[Job]]:
+    return JobFactory.get(name)
 
 
 def create_job(name: str, project) -> Job:
-    """Instantiate the Job with ``name`` for ``project``."""
-
-    cls = get_job_class(name)
-    if cls is None:
-        raise KeyError(f"Job '{name}' nicht bekannt.")
-    return cls(project)
+    return JobFactory.create(name, project)


### PR DESCRIPTION
## Summary
- implement `JobFactory` with `register`, `create`, `get` and `list`
- automatically register jobs via `Job.__init_subclass__`
- refactor recipes and CLI to use the factory
- load persisted jobs through `JobFactory`
- update tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686782c89d8c832782b4ad823b45707f