### PR TITLE
Add architecture overview docs

### DIFF
--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -1,0 +1,46 @@
+Architecture Overview
+=====================
+
+This section summarises the overall design of **glacium** with a focus on the
+core packages and how data flows from the command line to job execution.
+
+Package layout
+--------------
+
+The project is organised into a set of top level packages:
+
+* ``glacium`` – root package exposing the public API
+* ``glacium/cli`` – ``click`` based command line interface
+* ``glacium/engines`` – wrappers around external programs
+* ``glacium/jobs`` – concrete job implementations
+* ``glacium/managers`` – high level helpers coordinating projects
+* ``glacium/recipes`` – collections of jobs bundled under a name
+* ``glacium/models`` – dataclasses used across the code base
+* ``glacium/utils`` – assorted utilities
+
+Data flow
+---------
+
+CLI commands create or load projects via :class:`glacium.managers.project_manager.ProjectManager`.
+A :class:`~glacium.managers.path_manager.PathManager` is built for each project to provide
+consistent directory access.  Configuration files are handled through
+:class:`~glacium.managers.config_manager.ConfigManager` which keeps the global
+state cached.  Recipes use :class:`glacium.utils.JobIndex.JobFactory` to create
+job objects from their registered names.  The resulting
+:class:`~glacium.managers.job_manager.JobManager` executes jobs in dependency
+order and persists their status.
+
+Managers
+--------
+
+``PathManager`` defines all project paths and creates directories on demand.
+``ConfigManager`` loads and saves ``global_config.yaml`` and optional subsets,
+triggering observer callbacks on writes. ``JobManager`` maintains ``jobs.yaml``,
+allows running selected jobs and notifies observers about execution events.
+
+Factories
+---------
+
+``EngineFactory`` and ``JobFactory`` implement simple registries.  Engines and
+jobs register themselves via class decorators.  Recipes or job classes can then
+instantiate them by name without direct imports.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,5 +6,6 @@ glacium documentation
    :caption: content:
 
    config_manager
+   architecture
    glacium
    modules


### PR DESCRIPTION
## Summary
- document high level architecture
- show package layout and data flow
- reference manager classes and factory utilities
- include new page in Sphinx toctree

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68679d8d0cc08327a7ac01650b1f84b4