### PR TITLE
Add docs for extending engines

### DIFF
--- a/docs/adding_engines.rst
+++ b/docs/adding_engines.rst
@@ -1,0 +1,54 @@
+Adding new engines
+==================
+
+This guide explains how to extend Glacium with custom engine wrappers.
+Engines are responsible for invoking external programs and are created
+via :class:`~glacium.engines.engine_factory.EngineFactory`.
+
+Implement a subclass
+--------------------
+
+Create a new class derived from
+:class:`~glacium.engines.base_engine.BaseEngine` and add methods that
+run your solver or other tools.  Use :meth:`~glacium.engines.base_engine.BaseEngine.run`
+to execute commands.
+
+.. code-block:: python
+
+   from pathlib import Path
+   from glacium.engines.base_engine import BaseEngine
+
+   class MyEngine(BaseEngine):
+       def run_my_solver(self, exe: str, work: Path) -> None:
+           # call the executable inside ``work``
+           self.run([exe, "--foo"], cwd=work)
+
+Register the class
+------------------
+
+Decorate the engine with
+:meth:`~glacium.engines.engine_factory.EngineFactory.register`.  The
+registry maps class names to constructors so you can instantiate engines
+by name.
+
+.. code-block:: python
+
+   from glacium.engines.engine_factory import EngineFactory
+
+   @EngineFactory.register
+   class MyEngine(BaseEngine):
+       ...
+
+Later you can create an instance dynamically:
+
+.. code-block:: python
+
+   engine = EngineFactory.create("MyEngine")
+
+Example
+-------
+
+The project includes :class:`~glacium.engines.base_engine.DummyEngine`
+used in the test suite.  It simply sleeps for a few seconds and serves as
+an easy reference implementation for a registered engine.
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,3 +8,4 @@ glacium documentation
    config_manager
    glacium
    modules
+   adding_engines


### PR DESCRIPTION
## Summary
- document how to implement and register engines
- link the new page from the main docs index

## Testing
- `pytest -q`
- `make -C docs html`

------
https://chatgpt.com/codex/tasks/task_e_68679d9f2c3c8327972fe25d9dbcd0b5