### PR TITLE
Add log_call decorator

### DIFF
--- a/glacium/utils/logging.py
+++ b/glacium/utils/logging.py
@@ -41,3 +41,22 @@ logging.Logger.success = _success  # type: ignore[attr-defined]
 
 log = logging.getLogger("glacium")
 log.setLevel(_LEVEL)
+
+
+def log_call(fn):
+    """Return a wrapper logging calls to ``fn`` at ``log.verbose``."""
+
+    from functools import wraps
+    from inspect import signature
+
+    sig = signature(fn)
+
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        bound = sig.bind_partial(*args, **kwargs)
+        bound.apply_defaults()
+        arg_str = ", ".join(f"{n}={v!r}" for n, v in bound.arguments.items())
+        log.verbose(f"{fn.__qualname__}({arg_str})")
+        return fn(*args, **kwargs)
+
+    return wrapper

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,15 @@
+import logging
+from glacium.utils.logging import log, log_call
+
+
+def test_log_call_logs_verbose(caplog):
+    log.setLevel('VERBOSE')
+
+    @log_call
+    def add(a, b=0):
+        return a + b
+
+    with caplog.at_level(logging.VERBOSE, logger=log.name):
+        result = add(1, b=2)
+    assert result == 3
+    assert any('add(a=1, b=2)' in rec.getMessage() for rec in caplog.records)


### PR DESCRIPTION
## Summary
- add `log_call` decorator to log function calls using `log.verbose`
- test the decorator functionality

## Testing
- `flake8 tests/test_logging.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867ae094e288327a47fcff068f029e7