### PR TITLE
Add log_call decorators to main API

### DIFF
--- a/glacium/cli/init.py
+++ b/glacium/cli/init.py
@@ -1,6 +1,7 @@
 """Create a default project in the current directory."""
 from pathlib import Path
 import click
+from glacium.utils.logging import log_call
 
 from glacium.managers.project_manager import ProjectManager
 
@@ -17,6 +18,7 @@ DEFAULT_AIRFOIL = Path(__file__).resolve().parents[1] / "data" / "AH63K127.dat"
               type=click.Path(file_okay=False, dir_okay=True, path_type=Path,
                               writable=True),
               help="Root directory for projects")
+@log_call
 def cli_init(name: str, recipe: str, output: Path) -> None:
     """Create a new project below ``output`` using default settings."""
 

--- a/glacium/cli/job/__init__.py
+++ b/glacium/cli/job/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import click
+from glacium.utils.logging import log_call
 from rich.console import Console
 
 ROOT = Path("runs")
@@ -19,6 +20,7 @@ console = Console()
     help="Alle implementierten Jobs auflisten",
 )
 @click.pass_context
+@log_call
 def cli_job(ctx: click.Context, list_all: bool) -> None:
     """Job-Utilities für das aktuell gewählte Projekt."""
 

--- a/glacium/cli/job/add.py
+++ b/glacium/cli/job/add.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import click
+from glacium.utils.logging import log_call
 
 from glacium.utils.current import load
 from glacium.managers.project_manager import ProjectManager
@@ -12,6 +13,7 @@ from . import cli_job, ROOT
 
 @cli_job.command("add")
 @click.argument("job_name")
+@log_call
 def cli_job_add(job_name: str) -> None:
     """Fügt einen Job aus dem aktuellen Rezept hinzu."""
     uid = load()

--- a/glacium/cli/job/list.py
+++ b/glacium/cli/job/list.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import yaml
 import click
+from glacium.utils.logging import log_call
 from rich.table import Table
 from rich import box
 
@@ -15,6 +16,7 @@ from . import cli_job, ROOT, console
 
 @cli_job.command("list")
 @click.option("--available", is_flag=True, help="Nur die laut Rezept verfügbaren Jobs anzeigen")
+@log_call
 def cli_job_list(available: bool) -> None:
     """Zeigt alle Jobs + Status des aktuellen Projekts."""
     uid = load()

--- a/glacium/cli/job/remove.py
+++ b/glacium/cli/job/remove.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import click
+from glacium.utils.logging import log_call
 
 from glacium.utils.current import load
 from glacium.managers.project_manager import ProjectManager
@@ -12,6 +13,7 @@ from . import cli_job, ROOT
 
 @cli_job.command("remove")
 @click.argument("job_name")
+@log_call
 def cli_job_remove(job_name: str) -> None:
     """Entfernt einen Job aus dem aktuellen Projekt."""
     uid = load()

--- a/glacium/cli/job/reset.py
+++ b/glacium/cli/job/reset.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import click
+from glacium.utils.logging import log_call
 
 from glacium.utils.current import load
 from glacium.managers.project_manager import ProjectManager
@@ -13,6 +14,7 @@ from . import cli_job, ROOT
 
 @cli_job.command("reset")
 @click.argument("job_name")
+@log_call
 def cli_job_reset(job_name: str) -> None:
     """Setzt JOB auf PENDING (falls nicht RUNNING)."""
     uid = load()

--- a/glacium/cli/job/run.py
+++ b/glacium/cli/job/run.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import click
+from glacium.utils.logging import log_call
 
 from glacium.utils.current import load
 from glacium.managers.project_manager import ProjectManager
@@ -13,6 +14,7 @@ from . import cli_job, ROOT
 
 @cli_job.command("run")
 @click.argument("job_name")
+@log_call
 def cli_job_run(job_name: str) -> None:
     """Führe JOB aus dem aktuellen Projekt aus."""
     uid = load()

--- a/glacium/cli/job/select.py
+++ b/glacium/cli/job/select.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import click
+from glacium.utils.logging import log_call
 
 from glacium.utils.current import load
 from glacium.managers.project_manager import ProjectManager
@@ -12,6 +13,7 @@ from . import cli_job, ROOT
 
 @cli_job.command("select")
 @click.argument("job")
+@log_call
 def cli_job_select(job: str) -> None:
     """Wähle JOB innerhalb des aktuellen Projekts aus."""
     uid = load()

--- a/glacium/cli/list.py
+++ b/glacium/cli/list.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 import yaml
 import click
+from glacium.utils.logging import log_call
 from rich.console import Console
 from rich.table import Table
 from rich import box
@@ -14,6 +15,7 @@ console = Console()
 
 @click.command("list")
 @click.argument("uid", required=False)
+@log_call
 def cli_list(uid: str | None):
     """Zeigt alle Jobs + Status fuer ein Projekt.
 

--- a/glacium/cli/new.py
+++ b/glacium/cli/new.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 import click
 
-from glacium.utils.logging import log
+from glacium.utils.logging import log, log_call
 from glacium.utils.default_paths import global_default_config
 from glacium.models.config import GlobalConfig
 from glacium.managers.path_manager import PathBuilder
@@ -79,6 +79,7 @@ def _copy_default_cfg(dest: Path, uid: str) -> GlobalConfig:
               help="Root-Ordner für Projekte")
 @click.option("-y", "--yes", is_flag=True,
               help="Existierenden Ordner ohne Rückfrage überschreiben")
+@log_call
 def cli_new(name: str, airfoil: Path, recipe: str, output: Path, yes: bool):
     """Erstellt ein neues Glacium-Projekt."""
 

--- a/glacium/cli/projects.py
+++ b/glacium/cli/projects.py
@@ -1,6 +1,7 @@
 """List all projects with their job progress."""
 
 import click
+from glacium.utils.logging import log_call
 from rich.console import Console
 from rich.table import Table
 from rich import box
@@ -10,6 +11,7 @@ from glacium.utils.ProjectIndex import list_projects
 console = Console()
 
 @click.command("projects")
+@log_call
 def cli_projects():
     """Listet alle Projekte mit Job-Fortschritt."""
     table = Table(title="Glacium – Projekte", box=box.SIMPLE_HEAVY)

--- a/glacium/cli/remove.py
+++ b/glacium/cli/remove.py
@@ -4,6 +4,7 @@ import shutil
 from pathlib import Path
 
 import click
+from glacium.utils.logging import log_call
 from rich.console import Console
 
 from glacium.utils.ProjectIndex import list_projects
@@ -16,6 +17,7 @@ console = Console()
 @click.command("remove")
 @click.argument("project", required=False)
 @click.option("--all", "remove_all", is_flag=True, help="Alle Projekte löschen")
+@log_call
 def cli_remove(project: str | None, remove_all: bool):
     """Entfernt ein Projekt samt aller Daten.
 

--- a/glacium/cli/run.py
+++ b/glacium/cli/run.py
@@ -1,6 +1,7 @@
 """Execute jobs for the current or all projects."""
 
 import click
+from glacium.utils.logging import log_call
 from pathlib import Path
 from glacium.utils.current import load as load_current
 from glacium.managers.project_manager import ProjectManager
@@ -11,6 +12,7 @@ ROOT = Path("runs")
 @click.argument("jobs", nargs=-1)
 @click.option("--all", "run_all", is_flag=True,
               help="Alle Projekte nacheinander ausführen")
+@log_call
 def cli_run(jobs: tuple[str], run_all: bool):
     """Führt die Jobs des aktuellen Projekts aus.
     JOBS sind optionale Jobnamen, die ausgeführt werden sollen.

--- a/glacium/cli/select.py
+++ b/glacium/cli/select.py
@@ -1,6 +1,7 @@
 """Select a project UID and store it as the current project."""
 
 import click
+from glacium.utils.logging import log_call
 from pathlib import Path
 from rich.console import Console
 from glacium.utils.ProjectIndex import list_projects
@@ -10,6 +11,7 @@ console = Console()
 
 @click.command("select")
 @click.argument("project")          # Nummer **oder** UID
+@log_call
 def cli_select(project: str):
     """Projekt auswählen (Nr oder UID) und merken."""
     root   = Path("runs")

--- a/glacium/cli/sync.py
+++ b/glacium/cli/sync.py
@@ -1,6 +1,7 @@
 """Synchronise projects with the latest recipe definitions."""
 
 import click, yaml
+from glacium.utils.logging import log_call
 from pathlib import Path
 from glacium.managers.project_manager import ProjectManager
 from glacium.utils.current import load as load_current
@@ -12,6 +13,7 @@ ROOT = Path("runs")
 @click.argument("uid", required=False)
 @click.option("--all", "sync_all", is_flag=True,
               help="Alle Projekte mit dem aktuellen Rezept abgleichen")
+@log_call
 def cli_sync(uid: str | None, sync_all: bool):
     """
     Synchronisiert die Job-Liste eines Projekts mit dem neuesten Rezept.

--- a/glacium/engines/base_engine.py
+++ b/glacium/engines/base_engine.py
@@ -7,7 +7,7 @@ import time
 from pathlib import Path
 from typing import Sequence, IO, Optional
 
-from glacium.utils.logging import log
+from glacium.utils.logging import log, log_call
 from .engine_factory import EngineFactory
 
 
@@ -20,6 +20,7 @@ class BaseEngine:
 
         self.timeout = timeout
 
+    @log_call
     def run(
         self, cmd: Sequence[str], *, cwd: Path, stdin: Optional[IO[str]] = None
     ) -> None:

--- a/glacium/engines/fensap.py
+++ b/glacium/engines/fensap.py
@@ -8,7 +8,7 @@ import sys
 
 import yaml
 
-from glacium.utils.logging import log
+from glacium.utils.logging import log, log_call
 from glacium.models.job import Job
 from glacium.managers.template_manager import TemplateManager
 from .base_engine import BaseEngine
@@ -56,6 +56,7 @@ class FensapScriptJob(Job):
         cfg = self.project.config
         return {**defaults, **cfg.extras}
 
+    @log_call
     def execute(self) -> None:  # noqa: D401
         cfg = self.project.config
         paths = self.project.paths

--- a/glacium/engines/fluent2fensap.py
+++ b/glacium/engines/fluent2fensap.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from glacium.models.job import Job
 from glacium.engines.base_engine import BaseEngine
-from glacium.utils.logging import log
+from glacium.utils.logging import log, log_call
 from .engine_factory import EngineFactory
 __all__ = ["Fluent2FensapJob"]
 
@@ -22,6 +22,7 @@ class Fluent2FensapJob(Job):
         r"C:/Program Files/ANSYS Inc/v251/fensapice/bin/fluent2fensap.exe"
     )
 
+    @log_call
     def execute(self) -> None:  # noqa: D401
         cfg = self.project.config
         paths = self.project.paths

--- a/glacium/engines/pointwise.py
+++ b/glacium/engines/pointwise.py
@@ -7,7 +7,7 @@ from typing import Iterable
 
 from glacium.models.job import Job, JobStatus
 from glacium.managers.template_manager import TemplateManager
-from glacium.utils.logging import log
+from glacium.utils.logging import log, log_call
 from .base_engine import BaseEngine
 from .engine_factory import EngineFactory
 
@@ -54,6 +54,7 @@ class PointwiseScriptJob(Job):
 
         return ctx
 
+    @log_call
     def execute(self) -> None:  # noqa: D401
         cfg = self.project.config
         paths = self.project.paths

--- a/glacium/engines/xfoil_base.py
+++ b/glacium/engines/xfoil_base.py
@@ -16,7 +16,7 @@ from typing import Iterable
 
 from glacium.models.job import Job, JobStatus
 from glacium.managers.template_manager import TemplateManager
-from glacium.utils.logging import log
+from glacium.utils.logging import log, log_call
 from .base_engine import XfoilEngine
 from .engine_factory import EngineFactory
 
@@ -63,6 +63,7 @@ class XfoilScriptJob(Job):
         return ctx
 
     # ------------------------------------------------------------------
+    @log_call
     def execute(self):  # noqa: D401
         cfg   = self.project.config
         paths = self.project.paths

--- a/glacium/engines/xfoil_convert_job.py
+++ b/glacium/engines/xfoil_convert_job.py
@@ -3,12 +3,14 @@ from pathlib import Path
 from glacium.engines.py_engine import PyEngine
 from glacium.utils.convert_airfoil import xfoil_to_pointwise
 from glacium.models.job import Job
+from glacium.utils.logging import log_call
 
 class XfoilConvertJob(Job):
     name       = "XFOIL_PW_CONVERT"
     deps       = ("XFOIL_THICKEN_TE",)         # oder letzter Profil-Job
     cfg_key_out = "XFOIL_CONVERT_OUT"          # -> global_config
 
+    @log_call
     def execute(self):
         cfg   = self.project.config
         paths = self.project.paths

--- a/glacium/recipes/hello_world.py
+++ b/glacium/recipes/hello_world.py
@@ -3,6 +3,7 @@
 from glacium.managers.recipe_manager import BaseRecipe, RecipeManager
 from glacium.models.job import Job
 from glacium.utils.JobIndex import JobFactory
+from glacium.utils.logging import log_call
 
 
 class HelloJob(Job):
@@ -11,6 +12,7 @@ class HelloJob(Job):
     name = "HelloJob"
     deps = ()
 
+    @log_call
     def execute(self):
         from glacium.utils.logging import log
 


### PR DESCRIPTION
## Summary
- use `log_call` on major CLI entrypoints
- decorate execution methods for jobs and engines with `log_call`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867af3378b48327906bcd6af9cf0f97