### PR TITLE
Document generate command

### DIFF
--- a/docs/glacium.cli.rst
+++ b/docs/glacium.cli.rst
@@ -60,6 +60,22 @@ glacium.cli.select module
    :show-inheritance:
    :undoc-members:
 
+glacium.cli.generate module
+---------------------------
+
+.. automodule:: glacium.cli.generate
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+glacium.cli.init module
+-----------------------
+
+.. automodule:: glacium.cli.init
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
 glacium.cli.sync module
 -----------------------
 

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -105,6 +105,19 @@ Paths to third party programs are configured in
 ``POINTWISE_BIN``, ``FENSAP_BIN`` and ``FLUENT2FENSAP_EXE`` which should
 point to the corresponding executables on your system.
 
+Generate a configuration
+-----------------------
+
+The ``generate`` command creates a ``global_config`` dictionary from a
+``case.yaml`` description.  Provide the input file and optionally an output
+path:
+
+.. code-block:: bash
+
+   glacium generate case.yaml -o global_default.yaml
+
+Omit ``-o`` to print the YAML to ``stdout`` instead of writing a file.
+
 Logging
 -------
 


### PR DESCRIPTION
## Summary
- document the `generate` CLI command in the quick start guide
- add autodocs for `glacium.cli.generate` and `glacium.cli.init`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a62258cb883278aa85cd278d4066b