### PR TITLE
Add default case file handling

### DIFF
--- a/glacium/cli/new.py
+++ b/glacium/cli/new.py
@@ -20,7 +20,7 @@ from pathlib import Path
 import click
 
 from glacium.utils.logging import log, log_call
-from glacium.utils.default_paths import global_default_config
+from glacium.utils.default_paths import global_default_config, default_case_file
 from glacium.models.config import GlobalConfig
 from glacium.managers.path_manager import PathBuilder
 from glacium.managers.template_manager import TemplateManager
@@ -33,6 +33,7 @@ PKG_ROOT      = Path(__file__).resolve().parents[2]       # repo‑Root
 PKG_PKG       = Path(__file__).resolve().parents[1]       # .../glacium
 TEMPLATE_ROOT = PKG_ROOT / "templates"
 DEFAULT_CFG   = global_default_config()
+DEFAULT_CASE  = default_case_file()
 RUNS_ROOT     = PKG_ROOT / "runs"
 
 DEFAULT_RECIPE  = "multishot"
@@ -94,6 +95,10 @@ def cli_new(name: str, airfoil: Path, recipe: str, output: Path, yes: bool):
     # 1) Pfade anlegen
     paths = PathBuilder(proj_root).build()
     paths.ensure()
+
+    # Kopiere Standard-"case.yaml" falls vorhanden
+    if DEFAULT_CASE.exists():
+        shutil.copy2(DEFAULT_CASE, proj_root / "case.yaml")
 
     # 2) Globale Config
     cfg_file = paths.global_cfg_file()

--- a/glacium/managers/project_manager.py
+++ b/glacium/managers/project_manager.py
@@ -13,6 +13,7 @@ Example
 from __future__ import annotations
 
 import hashlib
+import shutil
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
@@ -26,7 +27,7 @@ from glacium.managers.job_manager import JobManager, Job
 from glacium.models.config import GlobalConfig
 from glacium.models.project import Project
 from glacium.utils.logging import log
-from glacium.utils.default_paths import global_default_config
+from glacium.utils.default_paths import global_default_config, default_case_file
 
 __all__ = ["ProjectManager"]
 
@@ -62,6 +63,10 @@ class ProjectManager:
 
         # Pfade & Grundstruktur
         paths = PathBuilder(root).build(); paths.ensure()
+
+        case_src = default_case_file()
+        if case_src.exists():
+            shutil.copy2(case_src, root / "case.yaml")
 
         defaults_file = global_default_config()
         defaults = yaml.safe_load(defaults_file.read_text()) if defaults_file.exists() else {}

--- a/glacium/utils/__init__.py
+++ b/glacium/utils/__init__.py
@@ -2,5 +2,5 @@
 
 from .JobIndex import list_jobs
 from .current_job import save as save_current_job, load as load_current_job
-from .default_paths import global_default_config
+from .default_paths import global_default_config, default_case_file
 from .case_to_global import generate_global_defaults

--- a/glacium/utils/default_paths.py
+++ b/glacium/utils/default_paths.py
@@ -17,3 +17,18 @@ def global_default_config() -> Path:
     a = repo_root / "config" / "defaults" / "global_default.yaml"
     b = pkg_root / "config" / "defaults" / "global_default.yaml"
     return a if a.exists() else b
+
+
+def default_case_file() -> Path:
+    """Return the path to ``config/defaults/case.yaml``.
+
+    Just like :func:`global_default_config`, the repository root is preferred
+    over the installed package directory.
+    """
+
+    repo_root = Path(__file__).resolve().parents[2]
+    pkg_root = Path(__file__).resolve().parents[1]
+
+    a = repo_root / "config" / "defaults" / "case.yaml"
+    b = pkg_root / "config" / "defaults" / "case.yaml"
+    return a if a.exists() else b

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -43,6 +43,7 @@ def test_cli_init_creates_project(tmp_path):
         uid = result.output.strip()
         cfg = Path(td) / "runs" / uid / "_cfg" / "global_config.yaml"
         assert cfg.exists()
+        assert (Path(td) / "runs" / uid / "case.yaml").exists()
 
 
 def test_cli_generate(tmp_path):

--- a/tests/test_job_add.py
+++ b/tests/test_job_add.py
@@ -13,6 +13,7 @@ def test_job_add_with_deps(tmp_path):
     result = runner.invoke(cli, ["new", "proj", "-y"], env=env)
     assert result.exit_code == 0
     uid = result.output.strip().splitlines()[-1]
+    assert (Path("runs") / uid / "case.yaml").exists()
 
     result = runner.invoke(cli, ["select", uid], env=env)
     assert result.exit_code == 0

--- a/tests/test_job_cli_numbers.py
+++ b/tests/test_job_cli_numbers.py
@@ -12,6 +12,7 @@ def _setup(tmp_path):
     runner = CliRunner()
     res = runner.invoke(cli, ["new", "proj", "-y"], env=env)
     uid = res.output.strip().splitlines()[-1]
+    assert (Path("runs") / uid / "case.yaml").exists()
     runner.invoke(cli, ["select", uid], env=env)
     return runner, uid, env
 


### PR DESCRIPTION
## Summary
- add helper to find default `case.yaml`
- include `case.yaml` when creating new projects and via `ProjectManager`
- export new helper in utilities package
- update CLI `new` command for case file
- adjust unit tests to check `case.yaml`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a6d82f8248327b85765cf79a59676