### PR TITLE
Add configurable runs root

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ directory and consist of a global configuration, a set of jobs and
 rendered templates.  The focus lies on easily defining new recipes and
 executing jobs in dependency order.
 
+Projects are stored below `runs/` relative to the current working
+directory.  You can override this location by setting the
+`GLACIUM_RUNS_ROOT` environment variable.
+
 ## Installation
 
 Install the package with `pip` (Python 3.12 or newer is required):

--- a/glacium/cli/job/__init__.py
+++ b/glacium/cli/job/__init__.py
@@ -4,11 +4,17 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from glacium.utils.paths import get_runs_root
+
 import click
 from rich.console import Console
 
-ROOT = Path("runs")
 console = Console()
+
+
+def runs_root() -> Path:
+    """Return the project root directory."""
+    return get_runs_root()
 
 
 @click.group("job", invoke_without_command=True)

--- a/glacium/cli/job/add.py
+++ b/glacium/cli/job/add.py
@@ -7,7 +7,7 @@ import click
 from glacium.utils.current import load
 from glacium.managers.project_manager import ProjectManager
 
-from . import cli_job, ROOT
+from . import cli_job, runs_root
 
 
 @cli_job.command("add")
@@ -18,7 +18,7 @@ def cli_job_add(job_name: str) -> None:
     if uid is None:
         raise click.ClickException("Kein Projekt gewählt. Erst 'glacium select' nutzen.")
 
-    pm = ProjectManager(ROOT)
+    pm = ProjectManager(runs_root())
     try:
         proj = pm.load(uid)
     except FileNotFoundError:

--- a/glacium/cli/job/list.py
+++ b/glacium/cli/job/list.py
@@ -10,7 +10,7 @@ from rich import box
 from glacium.utils.current import load
 from glacium.managers.project_manager import ProjectManager
 
-from . import cli_job, ROOT, console
+from . import cli_job, runs_root, console
 
 
 @cli_job.command("list")
@@ -21,7 +21,7 @@ def cli_job_list(available: bool) -> None:
     if uid is None:
         raise click.ClickException("Kein Projekt gewählt. Erst 'glacium select' nutzen.")
 
-    pm = ProjectManager(ROOT)
+    pm = ProjectManager(runs_root())
     try:
         proj = pm.load(uid)
     except FileNotFoundError:

--- a/glacium/cli/job/remove.py
+++ b/glacium/cli/job/remove.py
@@ -7,7 +7,7 @@ import click
 from glacium.utils.current import load
 from glacium.managers.project_manager import ProjectManager
 
-from . import cli_job, ROOT
+from . import cli_job, runs_root
 
 
 @cli_job.command("remove")
@@ -18,7 +18,7 @@ def cli_job_remove(job_name: str) -> None:
     if uid is None:
         raise click.ClickException("Kein Projekt gewählt. Erst 'glacium select' nutzen.")
 
-    pm = ProjectManager(ROOT)
+    pm = ProjectManager(runs_root())
     try:
         proj = pm.load(uid)
     except FileNotFoundError:

--- a/glacium/cli/job/reset.py
+++ b/glacium/cli/job/reset.py
@@ -8,7 +8,7 @@ from glacium.utils.current import load
 from glacium.managers.project_manager import ProjectManager
 from glacium.models.job import JobStatus
 
-from . import cli_job, ROOT
+from . import cli_job, runs_root
 
 
 @cli_job.command("reset")
@@ -19,7 +19,7 @@ def cli_job_reset(job_name: str) -> None:
     if uid is None:
         raise click.ClickException("Kein Projekt gewählt. Erst 'glacium select' nutzen.")
 
-    pm = ProjectManager(ROOT)
+    pm = ProjectManager(runs_root())
     try:
         proj = pm.load(uid)
     except FileNotFoundError:

--- a/glacium/cli/job/run.py
+++ b/glacium/cli/job/run.py
@@ -8,7 +8,7 @@ from glacium.utils.current import load
 from glacium.managers.project_manager import ProjectManager
 from glacium.models.job import JobStatus
 
-from . import cli_job, ROOT
+from . import cli_job, runs_root
 
 
 @cli_job.command("run")
@@ -19,7 +19,7 @@ def cli_job_run(job_name: str) -> None:
     if uid is None:
         raise click.ClickException("Kein Projekt gewählt. Erst 'glacium select' nutzen.")
 
-    pm = ProjectManager(ROOT)
+    pm = ProjectManager(runs_root())
     try:
         proj = pm.load(uid)
     except FileNotFoundError:

--- a/glacium/cli/job/select.py
+++ b/glacium/cli/job/select.py
@@ -7,7 +7,7 @@ import click
 from glacium.utils.current import load
 from glacium.managers.project_manager import ProjectManager
 
-from . import cli_job, ROOT
+from . import cli_job, runs_root
 
 
 @cli_job.command("select")
@@ -18,7 +18,7 @@ def cli_job_select(job: str) -> None:
     if uid is None:
         raise click.ClickException("Kein Projekt gewählt. Erst 'glacium select' nutzen.")
 
-    pm = ProjectManager(ROOT)
+    pm = ProjectManager(runs_root())
     try:
         proj = pm.load(uid)
     except FileNotFoundError:

--- a/glacium/cli/list.py
+++ b/glacium/cli/list.py
@@ -1,6 +1,7 @@
 """Display jobs of a project in a table."""
 
 from pathlib import Path
+from glacium.utils.paths import get_runs_root
 import yaml
 import click
 from rich.console import Console
@@ -19,7 +20,7 @@ def cli_list(uid: str | None):
 
     Ohne UID wird das aktuell ausgewaehlte Projekt verwendet.
     """
-    pm = ProjectManager(Path("runs"))
+    pm = ProjectManager(get_runs_root())
 
     if uid is None:
         uid = load_current()

--- a/glacium/cli/new.py
+++ b/glacium/cli/new.py
@@ -17,6 +17,8 @@ import shutil
 from datetime import datetime, UTC
 from pathlib import Path
 
+from glacium.utils.paths import get_runs_root
+
 import click
 
 from glacium.utils.logging import log
@@ -33,7 +35,6 @@ PKG_ROOT      = Path(__file__).resolve().parents[2]       # repo‑Root
 PKG_PKG       = Path(__file__).resolve().parents[1]       # .../glacium
 TEMPLATE_ROOT = PKG_ROOT / "templates"
 DEFAULT_CFG   = global_default_config()
-RUNS_ROOT     = PKG_ROOT / "runs"
 
 DEFAULT_RECIPE  = "prep"
 DEFAULT_AIRFOIL = PKG_PKG / "data" / "AH63K127.dat"
@@ -74,13 +75,21 @@ def _copy_default_cfg(dest: Path, uid: str) -> GlobalConfig:
               default=DEFAULT_RECIPE,
               show_default=True,
               help="Name des Rezepts (Jobs)")
-@click.option("-o", "--output", default=str(RUNS_ROOT), show_default=True,
-              type=click.Path(file_okay=False, dir_okay=True, writable=True, path_type=Path),
-              help="Root-Ordner für Projekte")
+@click.option(
+    "-o",
+    "--output",
+    default=None,
+    show_default=True,
+    type=click.Path(file_okay=False, dir_okay=True, writable=True, path_type=Path),
+    help="Root-Ordner für Projekte",
+)
 @click.option("-y", "--yes", is_flag=True,
               help="Existierenden Ordner ohne Rückfrage überschreiben")
-def cli_new(name: str, airfoil: Path, recipe: str, output: Path, yes: bool):
+def cli_new(name: str, airfoil: Path, recipe: str, output: Path | None, yes: bool):
     """Erstellt ein neues Glacium-Projekt."""
+
+    if output is None:
+        output = get_runs_root()
 
     uid       = _uid(name)
     proj_root = output / uid

--- a/glacium/cli/projects.py
+++ b/glacium/cli/projects.py
@@ -5,6 +5,7 @@ from rich.console import Console
 from rich.table import Table
 from rich import box
 from pathlib import Path
+from glacium.utils.paths import get_runs_root
 from glacium.utils.ProjectIndex import list_projects
 
 console = Console()
@@ -18,7 +19,7 @@ def cli_projects():
     table.add_column("Name")
     table.add_column("Jobs")
 
-    root = Path("runs")
+    root = get_runs_root()
     for idx, info in enumerate(list_projects(root), start=1):
         jobs = f"{info.jobs_done}/{info.jobs_total}" if info.jobs_total else "-"
         table.add_row(str(idx), info.uid, info.name, jobs)

--- a/glacium/cli/remove.py
+++ b/glacium/cli/remove.py
@@ -8,8 +8,8 @@ from rich.console import Console
 
 from glacium.utils.ProjectIndex import list_projects
 from glacium.utils.current import load as load_current
+from glacium.utils.paths import get_runs_root
 
-ROOT = Path("runs")
 console = Console()
 
 
@@ -24,8 +24,9 @@ def cli_remove(project: str | None, remove_all: bool):
     Die Nummer entspricht der Ausgabe von ``glacium projects``.
     """
 
+    root = get_runs_root()
     if remove_all:
-        uids = [p.name for p in ROOT.iterdir() if p.is_dir()]
+        uids = [p.name for p in root.iterdir() if p.is_dir()]
     else:
         if project is None:
             uid = load_current()
@@ -36,7 +37,7 @@ def cli_remove(project: str | None, remove_all: bool):
                 )
         else:
             if project.isdigit():
-                items = list_projects(ROOT)
+                items = list_projects(root)
                 idx = int(project) - 1
                 if idx < 0 or idx >= len(items):
                     raise click.ClickException("Ungültige Nummer.")
@@ -46,7 +47,7 @@ def cli_remove(project: str | None, remove_all: bool):
         uids = [uid]
 
     for uid in uids:
-        path = ROOT / uid
+        path = root / uid
         if path.exists():
             shutil.rmtree(path)
             console.print(f"[green]{uid} entfernt.[/]")

--- a/glacium/cli/run.py
+++ b/glacium/cli/run.py
@@ -2,10 +2,9 @@
 
 import click
 from pathlib import Path
+from glacium.utils.paths import get_runs_root
 from glacium.utils.current import load as load_current
 from glacium.managers.project_manager import ProjectManager
-
-ROOT = Path("runs")
 
 @click.command("run")
 @click.argument("jobs", nargs=-1)
@@ -16,7 +15,8 @@ def cli_run(jobs: tuple[str], run_all: bool):
     JOBS sind optionale Jobnamen, die ausgeführt werden sollen.
     Mit ``--all`` werden alle Projekte verarbeitet."""
 
-    pm = ProjectManager(ROOT)
+    root = get_runs_root()
+    pm = ProjectManager(root)
 
     if run_all:
         for uid in pm.list_uids():

--- a/glacium/cli/select.py
+++ b/glacium/cli/select.py
@@ -2,6 +2,7 @@
 
 import click
 from pathlib import Path
+from glacium.utils.paths import get_runs_root
 from rich.console import Console
 from glacium.utils.ProjectIndex import list_projects
 from glacium.utils.current import save
@@ -12,7 +13,7 @@ console = Console()
 @click.argument("project")          # Nummer **oder** UID
 def cli_select(project: str):
     """Projekt auswählen (Nr oder UID) und merken."""
-    root   = Path("runs")
+    root   = get_runs_root()
     items  = list_projects(root)
 
     # Nummer → UID umwandeln

--- a/glacium/cli/sync.py
+++ b/glacium/cli/sync.py
@@ -2,11 +2,11 @@
 
 import click, yaml
 from pathlib import Path
+from glacium.utils.paths import get_runs_root
 from glacium.managers.project_manager import ProjectManager
 from glacium.utils.current import load as load_current
 from glacium.utils.ProjectIndex import list_projects
 
-ROOT = Path("runs")
 
 @click.command("sync")
 @click.argument("uid", required=False)
@@ -19,7 +19,8 @@ def cli_sync(uid: str | None, sync_all: bool):
     • Mit UID       → nur dieses Projekt
     • --all         → alle Projekte unter ./runs
     """
-    pm = ProjectManager(ROOT)
+    root = get_runs_root()
+    pm = ProjectManager(root)
 
     # -------------- Welche Projekte?
     if sync_all:

--- a/glacium/utils/__init__.py
+++ b/glacium/utils/__init__.py
@@ -3,3 +3,5 @@
 from .JobIndex import list_jobs
 from .current_job import save as save_current_job, load as load_current_job
 from .default_paths import global_default_config
+
+from .paths import get_runs_root

--- a/glacium/utils/paths.py
+++ b/glacium/utils/paths.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def get_runs_root() -> Path:
+    """Return the directory used to store projects."""
+    root = os.getenv("GLACIUM_RUNS_ROOT")
+    if root:
+        return Path(root)
+    return Path("runs")
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,8 +37,9 @@ def test_cli_init_creates_project(tmp_path):
     _SharedState._SharedState__shared_state.clear()
 
     with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        env["GLACIUM_RUNS_ROOT"] = str(Path(td) / "runs")
         result = runner.invoke(cli, ["init"], env=env)
         assert result.exit_code == 0
         uid = result.output.strip()
-        cfg = Path(td) / "runs" / uid / "_cfg" / "global_config.yaml"
+        cfg = Path(env["GLACIUM_RUNS_ROOT"]) / uid / "_cfg" / "global_config.yaml"
         assert cfg.exists()

--- a/tests/test_job_add.py
+++ b/tests/test_job_add.py
@@ -7,7 +7,7 @@ from glacium.managers.path_manager import _SharedState
 
 def test_job_add_with_deps(tmp_path):
     runner = CliRunner()
-    env = {"HOME": str(tmp_path)}
+    env = {"HOME": str(tmp_path), "GLACIUM_RUNS_ROOT": str(tmp_path / "runs")}
     _SharedState._SharedState__shared_state.clear()
 
     result = runner.invoke(cli, ["new", "proj", "-y"], env=env)
@@ -21,7 +21,7 @@ def test_job_add_with_deps(tmp_path):
     assert result.exit_code == 0
     assert "POINTWISE_MESH2 hinzugefügt." in result.output
 
-    jobs_yaml = Path("runs") / uid / "_cfg" / "jobs.yaml"
+    jobs_yaml = Path(env["GLACIUM_RUNS_ROOT"]) / uid / "_cfg" / "jobs.yaml"
     data = yaml.safe_load(jobs_yaml.read_text())
     assert "POINTWISE_GCI" in data
     assert "POINTWISE_MESH2" in data

--- a/tests/test_job_cli_numbers.py
+++ b/tests/test_job_cli_numbers.py
@@ -7,7 +7,7 @@ from glacium.managers.job_manager import JobManager
 
 
 def _setup(tmp_path):
-    env = {"HOME": str(tmp_path)}
+    env = {"HOME": str(tmp_path), "GLACIUM_RUNS_ROOT": str(tmp_path / "runs")}
     _SharedState._SharedState__shared_state.clear()
     runner = CliRunner()
     res = runner.invoke(cli, ["new", "proj", "-y"], env=env)
@@ -33,7 +33,7 @@ def test_job_select_and_remove_by_index(tmp_path):
 
     res = runner.invoke(cli, ["job", "remove", "1"], env=env)
     assert res.exit_code == 0
-    jobs_yaml = Path("runs") / uid / "_cfg" / "jobs.yaml"
+    jobs_yaml = Path(env["GLACIUM_RUNS_ROOT"]) / uid / "_cfg" / "jobs.yaml"
     data = yaml.safe_load(jobs_yaml.read_text())
     assert first not in data
 
@@ -42,7 +42,7 @@ def test_job_add_by_index(tmp_path):
     runner, uid, env = _setup(tmp_path)
     res = runner.invoke(cli, ["job", "add", "1"], env=env)
     assert res.exit_code == 0
-    jobs_yaml = Path("runs") / uid / "_cfg" / "jobs.yaml"
+    jobs_yaml = Path(env["GLACIUM_RUNS_ROOT"]) / uid / "_cfg" / "jobs.yaml"
     data = yaml.safe_load(jobs_yaml.read_text())
     from glacium.utils.JobIndex import list_jobs
 
@@ -52,7 +52,7 @@ def test_job_add_by_index(tmp_path):
 
 def test_job_reset_by_index(tmp_path):
     runner, uid, env = _setup(tmp_path)
-    jobs_yaml = Path("runs") / uid / "_cfg" / "jobs.yaml"
+    jobs_yaml = Path(env["GLACIUM_RUNS_ROOT"]) / uid / "_cfg" / "jobs.yaml"
     # Mark job as DONE
     data = yaml.safe_load(jobs_yaml.read_text())
     data["XFOIL_REFINE"] = "DONE"
@@ -89,7 +89,7 @@ def test_removed_job_no_longer_listed(tmp_path):
     assert res.exit_code == 0
     assert "XFOIL_REFINE" not in res.output
 
-    jobs_yaml = Path("runs") / uid / "_cfg" / "jobs.yaml"
+    jobs_yaml = Path(env["GLACIUM_RUNS_ROOT"]) / uid / "_cfg" / "jobs.yaml"
     data = yaml.safe_load(jobs_yaml.read_text())
     assert "XFOIL_REFINE" not in data
 


### PR DESCRIPTION
## Summary
- add `get_runs_root` helper in `glacium.utils.paths`
- use the helper throughout CLI modules
- adjust job subcommands to resolve runs root at runtime
- update tests to set `GLACIUM_RUNS_ROOT`
- document the new environment variable in the README

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b67a03108832786f3f72594e31040