### PR TITLE
Load projects respecting jobs list

### DIFF
--- a/glacium/managers/job_manager.py
+++ b/glacium/managers/job_manager.py
@@ -82,7 +82,8 @@ class JobManager:
 
         self._ensure_status_parent()
         data = {n: j.status.name for n, j in self._jobs.items()}
-        yaml.dump(data, self._status_file().open("w"), sort_keys=False)
+        with self._status_file().open("w") as fh:
+            yaml.dump(data, fh, sort_keys=False)
 
     # ------------------------------------------------------------------
     # Public API

--- a/glacium/managers/project_manager.py
+++ b/glacium/managers/project_manager.py
@@ -126,12 +126,21 @@ class ProjectManager:
 
         project = Project(uid, root, cfg, paths, jobs=[])
         recipe = RecipeManager.create(cfg.recipe)
-        project.jobs.extend(recipe.build(project))
 
-        # Persisted jobs that are not part of the recipe -----------------
         status_file = paths.cfg_dir() / "jobs.yaml"
         if status_file.exists():
             data = yaml.safe_load(status_file.read_text()) or {}
+            job_names = set(data.keys())
+        else:
+            data = {}
+            job_names = set()
+
+        for job in recipe.build(project):
+            if not status_file.exists() or job.name in job_names:
+                project.jobs.append(job)
+
+        # Persisted jobs that are not part of the recipe -----------------
+        if status_file.exists():
             from glacium.utils.JobIndex import JobFactory
             existing = {j.name for j in project.jobs}
             for name in data.keys():

--- a/tests/test_job_cli_numbers.py
+++ b/tests/test_job_cli_numbers.py
@@ -79,3 +79,17 @@ def test_job_run_by_index(tmp_path, monkeypatch):
     assert res.exit_code == 0
     assert called["jobs"] == ["XFOIL_REFINE"]
 
+
+def test_remove_updates_listing(tmp_path):
+    runner, uid, env = _setup(tmp_path)
+    res = runner.invoke(cli, ["job", "remove", "1"], env=env)
+    assert res.exit_code == 0
+
+    res = runner.invoke(cli, ["list"], env=env)
+    assert res.exit_code == 0
+    assert "XFOIL_REFINE" not in res.output
+
+    jobs_yaml = Path("runs") / uid / "_cfg" / "jobs.yaml"
+    data = yaml.safe_load(jobs_yaml.read_text())
+    assert "XFOIL_REFINE" not in data
+


### PR DESCRIPTION
## Summary
- rebuild only selected recipe jobs when `_cfg/jobs.yaml` exists
- fix context manager usage when saving job status
- test removing a job updates job listing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b6c410b748327a30dbfdcbbbb7812