### PR TITLE
Refactor PathManager to per-instance state

### DIFF
--- a/glacium/cli/sweep.py
+++ b/glacium/cli/sweep.py
@@ -10,7 +10,6 @@ import io
 
 from glacium.utils.logging import log_call
 from glacium.managers.project_manager import ProjectManager
-from glacium.managers.path_manager import _SharedState
 from .update import cli_update
 
 ROOT = Path("runs")
@@ -31,7 +30,6 @@ def cli_sweep(start: float, steps: int, factor: float, do_run: bool) -> None:
     pm = ProjectManager(ROOT)
     value = start
     for _ in range(steps):
-        _SharedState._SharedState__shared_state.clear()
         proj = pm.create(f"sweep-{value}", "grid_dep", DEFAULT_AIRFOIL)
         uid = proj.uid
         with io.StringIO() as buf, redirect_stdout(buf):

--- a/glacium/managers/path_manager.py
+++ b/glacium/managers/path_manager.py
@@ -7,7 +7,6 @@ Several design patterns are used:
 1. **Builder** – customise directory names via :class:`PathBuilder`.
 2. **Facade** – call ``pm.mesh_dir()`` instead of ``root / 'mesh'``.
 3. **Null‑Object** – :class:`NullPath` avoids checks for missing paths.
-4. **Singleton (Borg)** – multiple instances share the same state.
 
 Example
 -------
@@ -118,21 +117,13 @@ class PathBuilder:
 
 
 # ────────────────────────────────────────────────────────────────────────────────
-#  Facade + Borg‑Singleton
+#  Facade
 # ────────────────────────────────────────────────────────────────────────────────
-class _SharedState:  # noqa: D401  # pylance: disable=too-few-public-methods
-    __shared_state: Dict[str, object] = {}
-
-    def __init__(self):
-        self.__dict__ = self.__shared_state
-
-
-class PathManager(_SharedState):
+class PathManager:
     """Provide well defined access points to all relevant paths.
 
     * **Facade** – external code calls ``pm.mesh_dir()`` rather than manually
       joining paths.
-    * **Borg‑Singleton** – multiple instances share the same internal state.
     """
 
     # default‑Ordnernamen (können via Builder überschrieben werden)
@@ -148,17 +139,14 @@ class PathManager(_SharedState):
             Custom names for the respective subdirectories.
         """
 
-        super().__init__()
-        if not getattr(self, "_initialized", False):  # nur beim ersten Mal setzen
-            self.root = root.resolve()
-            self._map = {
-                "cfg": cfg,
-                "tmpl": tmpl,
-                "data": data,
-                "mesh": mesh,
-                "runs": runs,
-            }
-            self._initialized = True
+        self.root = root.resolve()
+        self._map = {
+            "cfg": cfg,
+            "tmpl": tmpl,
+            "data": data,
+            "mesh": mesh,
+            "runs": runs,
+        }
 
     # Helper -------------------------------------------------------------------
     def _sub(self, key: str, *parts: Iterable[str | Path]) -> Path | NullPath:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,8 +34,6 @@ def test_job_global_list():
 def test_cli_init_creates_project(tmp_path):
     runner = CliRunner()
     env = {"HOME": str(tmp_path)}
-    from glacium.managers.path_manager import _SharedState
-    _SharedState._SharedState__shared_state.clear()
 
     with runner.isolated_filesystem(temp_dir=tmp_path) as td:
         result = runner.invoke(cli, ["init"], env=env)

--- a/tests/test_cli_sweep.py
+++ b/tests/test_cli_sweep.py
@@ -3,13 +3,11 @@ from pathlib import Path
 from click.testing import CliRunner
 
 from glacium.cli import cli
-from glacium.managers.path_manager import _SharedState
 
 
 def test_cli_sweep(tmp_path):
     runner = CliRunner()
     env = {"HOME": str(tmp_path)}
-    _SharedState._SharedState__shared_state.clear()
 
     with runner.isolated_filesystem(temp_dir=tmp_path):
         result = runner.invoke(cli, ["sweep", "8", "-n", "2", "-f", "2"] , env=env)

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -5,13 +5,11 @@ import pytest
 
 from glacium.cli import cli
 from glacium.utils import generate_global_defaults, global_default_config
-from glacium.managers.path_manager import _SharedState
 
 
 def test_cli_update(tmp_path):
     runner = CliRunner()
     env = {"HOME": str(tmp_path)}
-    _SharedState._SharedState__shared_state.clear()
 
     with runner.isolated_filesystem(temp_dir=tmp_path):
         res = runner.invoke(cli, ["init"], env=env)

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -22,7 +22,7 @@ from glacium.jobs.fensap_jobs import (
 import glacium.jobs.fensap_jobs as fensap_jobs
 from glacium.engines.fluent2fensap import Fluent2FensapJob
 from glacium.models.config import GlobalConfig
-from glacium.managers.path_manager import PathBuilder, _SharedState
+from glacium.managers.path_manager import PathBuilder
 from glacium.managers.template_manager import TemplateManager
 from glacium.models.project import Project
 
@@ -142,7 +142,6 @@ def test_pointwise_script_job_runs_in_project_root(monkeypatch, tmp_path):
 
 
 def test_fensap_engine_run_script(tmp_path):
-    _SharedState._SharedState__shared_state.clear()
     script = tmp_path / "run.sh"
     script.write_text("exit 0")
     engine = FensapEngine()
@@ -150,7 +149,6 @@ def test_fensap_engine_run_script(tmp_path):
 
 
 def test_fensap_run_job(tmp_path):
-    _SharedState._SharedState__shared_state.clear()
     template_root = tmp_path / "tmpl"
     template_root.mkdir()
     (template_root / "FENSAP.FENSAP.files.j2").write_text("files")
@@ -172,7 +170,6 @@ def test_fensap_run_job(tmp_path):
 
 def test_fensap_run_job_calls_base_engine(monkeypatch, tmp_path):
     """Ensure ``BaseEngine.run`` is executed with configured executable."""
-    _SharedState._SharedState__shared_state.clear()
 
     template_root = tmp_path / "tmpl"
     template_root.mkdir()
@@ -214,7 +211,6 @@ def test_fensap_run_job_calls_base_engine(monkeypatch, tmp_path):
 
 
 def test_multishot_run_job(monkeypatch, tmp_path):
-    _SharedState._SharedState__shared_state.clear()
     template_root = tmp_path / "templates"
     template_root.mkdir()
     monkeypatch.setattr(fensap_jobs, "__file__", str(tmp_path / "pkg" / "fensap_jobs.py"))
@@ -251,7 +247,6 @@ def test_multishot_run_job(monkeypatch, tmp_path):
 
 def test_multishot_run_job_calls_base_engine(monkeypatch, tmp_path):
     """Ensure ``BaseEngine.run`` is executed with configured executable."""
-    _SharedState._SharedState__shared_state.clear()
 
     template_root = tmp_path / "templates"
     template_root.mkdir()
@@ -302,7 +297,6 @@ def test_multishot_run_job_calls_base_engine(monkeypatch, tmp_path):
 
 
 def test_multishot_run_job_renders_batch(monkeypatch, tmp_path):
-    _SharedState._SharedState__shared_state.clear()
     template_root = tmp_path / "templates"
     (template_root / "MULTISHOT10").mkdir(parents=True)
     monkeypatch.setattr(fensap_jobs, "__file__", str(tmp_path / "pkg" / "fensap_jobs.py"))
@@ -341,7 +335,6 @@ def test_multishot_run_job_renders_batch(monkeypatch, tmp_path):
 
 
 def test_drop3d_run_job(tmp_path):
-    _SharedState._SharedState__shared_state.clear()
     template_root = tmp_path / "tmpl"
     template_root.mkdir()
     (template_root / "FENSAP.DROP3D.files.j2").write_text("files")
@@ -363,7 +356,6 @@ def test_drop3d_run_job(tmp_path):
 
 def test_drop3d_run_job_calls_base_engine(monkeypatch, tmp_path):
     """Ensure ``BaseEngine.run`` is executed with configured executable."""
-    _SharedState._SharedState__shared_state.clear()
 
     template_root = tmp_path / "tmpl"
     template_root.mkdir()
@@ -405,7 +397,6 @@ def test_drop3d_run_job_calls_base_engine(monkeypatch, tmp_path):
 
 
 def test_ice3d_run_job(tmp_path):
-    _SharedState._SharedState__shared_state.clear()
     template_root = tmp_path / "tmpl"
     template_root.mkdir()
     (template_root / "FENSAP.ICE3D.custom_remeshing.sh.j2").write_text("custom")
@@ -430,7 +421,6 @@ def test_ice3d_run_job(tmp_path):
 
 def test_ice3d_run_job_calls_base_engine(monkeypatch, tmp_path):
     """Ensure ``BaseEngine.run`` is executed with configured executable."""
-    _SharedState._SharedState__shared_state.clear()
 
     template_root = tmp_path / "tmpl"
     template_root.mkdir()
@@ -475,7 +465,6 @@ def test_ice3d_run_job_calls_base_engine(monkeypatch, tmp_path):
 
 
 def test_fluent2fensap_job(monkeypatch, tmp_path):
-    _SharedState._SharedState__shared_state.clear()
 
     cfg = GlobalConfig(project_uid="uid", base_dir=tmp_path)
     exe = tmp_path / "bin" / "fluent2fensap.exe"
@@ -514,7 +503,6 @@ def test_fluent2fensap_job(monkeypatch, tmp_path):
 
 
 def test_fluent2fensap_job_keeps_log_level(monkeypatch, tmp_path):
-    _SharedState._SharedState__shared_state.clear()
 
     from glacium.utils.logging import log
 
@@ -590,7 +578,6 @@ def test_xfoil_script_job_uses_engine_factory(monkeypatch, tmp_path):
 def test_fensap_script_job_uses_engine_factory(monkeypatch, tmp_path):
     """Verify ``EngineFactory.create`` is used by ``FensapScriptJob``."""
 
-    _SharedState._SharedState__shared_state.clear()
     template_root = tmp_path / "tmpl"
     template_root.mkdir()
     (template_root / "run.sh.j2").write_text("exit 0")

--- a/tests/test_fluent2fensap_default.py
+++ b/tests/test_fluent2fensap_default.py
@@ -5,12 +5,11 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from glacium.engines.fluent2fensap import Fluent2FensapJob
 from glacium.engines.base_engine import BaseEngine
 from glacium.models.config import GlobalConfig
-from glacium.managers.path_manager import PathBuilder, _SharedState
+from glacium.managers.path_manager import PathBuilder
 from glacium.models.project import Project
 
 
 def test_fluent2fensap_default(monkeypatch, tmp_path):
-    _SharedState._SharedState__shared_state.clear()
 
     exe = tmp_path / "bin" / "fluent2fensap.exe"
     exe.parent.mkdir()

--- a/tests/test_job_add.py
+++ b/tests/test_job_add.py
@@ -2,13 +2,11 @@ import yaml
 from pathlib import Path
 from click.testing import CliRunner
 from glacium.cli import cli
-from glacium.managers.path_manager import _SharedState
 
 
 def test_job_add_with_deps(tmp_path):
     runner = CliRunner()
     env = {"HOME": str(tmp_path)}
-    _SharedState._SharedState__shared_state.clear()
 
     result = runner.invoke(cli, ["new", "proj", "-y"], env=env)
     assert result.exit_code == 0

--- a/tests/test_job_cli_numbers.py
+++ b/tests/test_job_cli_numbers.py
@@ -2,13 +2,11 @@ import yaml
 from pathlib import Path
 from click.testing import CliRunner
 from glacium.cli import cli
-from glacium.managers.path_manager import _SharedState
 from glacium.managers.job_manager import JobManager
 
 
 def _setup(tmp_path):
     env = {"HOME": str(tmp_path)}
-    _SharedState._SharedState__shared_state.clear()
     runner = CliRunner()
     res = runner.invoke(cli, ["new", "proj", "-y"], env=env)
     uid = res.output.strip().splitlines()[-1]

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -3,13 +3,11 @@ from pathlib import Path
 from click.testing import CliRunner
 
 from glacium.cli import cli
-from glacium.managers.path_manager import _SharedState
 
 
 def test_sweep(tmp_path):
     runner = CliRunner()
     env = {"HOME": str(tmp_path)}
-    _SharedState._SharedState__shared_state.clear()
 
     with runner.isolated_filesystem(temp_dir=tmp_path):
         result = runner.invoke(cli, ["sweep", "8"], env=env)


### PR DESCRIPTION
## Summary
- remove Borg-like shared state from `PathManager`
- clean up CLI sweep command and tests
- adjust unit tests for new PathManager behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bb36bb97883279469e1853ec3cb77