### PR TITLE
Improve run --all resilience

### DIFF
--- a/glacium/cli/run.py
+++ b/glacium/cli/run.py
@@ -1,7 +1,7 @@
 """Execute jobs for the current or all projects."""
 
 import click
-from glacium.utils.logging import log_call
+from glacium.utils.logging import log_call, log
 from pathlib import Path
 from glacium.utils.current import load as load_current
 from glacium.managers.project_manager import ProjectManager
@@ -27,6 +27,8 @@ def cli_run(jobs: tuple[str], run_all: bool):
                 pm.load(uid).job_manager.run(jobs or None)
             except FileNotFoundError:
                 click.echo(f"[red]Projekt '{uid}' nicht gefunden.[/red]")
+            except Exception as err:  # noqa: BLE001
+                log.error(f"{uid}: {err}")
         return
 
     uid = load_current()

--- a/tests/test_run_all.py
+++ b/tests/test_run_all.py
@@ -8,6 +8,7 @@ from click.testing import CliRunner
 
 from glacium.cli import cli
 from glacium.managers.project_manager import ProjectManager
+from glacium.managers.job_manager import JobManager
 
 
 def test_run_all_executes_jobs(tmp_path):
@@ -35,3 +36,31 @@ def test_run_all_executes_jobs(tmp_path):
 
         assert jobs1.get("HelloJob") == "DONE"
         assert jobs2.get("HelloJob") == "DONE"
+
+
+def test_run_all_continues_on_error(tmp_path, monkeypatch):
+    runner = CliRunner()
+    env = {"HOME": str(tmp_path)}
+
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pm = ProjectManager(Path("runs"))
+        airfoil = (
+            Path(__file__).resolve().parents[1] / "glacium" / "data" / "AH63K127.dat"
+        )
+
+        p1 = pm.create("proj1", "hello", airfoil)
+        p2 = pm.create("proj2", "hello", airfoil)
+
+        called = {}
+
+        def patched_run(self, jobs=None):
+            if self.project.uid == p1.uid:
+                raise RuntimeError("boom")
+            if self.project.uid == p2.uid:
+                called["ok"] = True
+
+        monkeypatch.setattr(JobManager, "run", patched_run)
+
+        result = runner.invoke(cli, ["run", "--all"], env=env)
+        assert result.exit_code == 0
+        assert called.get("ok")


### PR DESCRIPTION
## Summary
- handle unexpected errors while running all projects
- test that run --all continues despite errors

## Testing
- `ruff check glacium/cli/run.py tests/test_run_all.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686bbc8ae5508327bc102920acce4961