### PR TITLE
Add info command to display project details

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ glacium sync
 glacium update
 ```
 
+### Display project info
+
+```bash
+glacium info
+```
+Print the ``case.yaml`` parameters and a few values from
+``global_config.yaml`` for the current project.
+
 ### Remove projects
 
 ```bash

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -134,6 +134,16 @@ current project:
 
    glacium update
 
+Display project info
+--------------------
+
+Show parameters of ``case.yaml`` and selected values from the project
+configuration:
+
+.. code-block:: bash
+
+   glacium info
+
 Logging
 -------
 

--- a/glacium/cli/__init__.py
+++ b/glacium/cli/__init__.py
@@ -15,6 +15,7 @@ from .remove import cli_remove
 from .generate import cli_generate
 from .update import cli_update
 from .sweep import cli_sweep
+from .info import cli_info
 
 @click.group()
 def cli():
@@ -34,6 +35,7 @@ cli.add_command(cli_remove)
 cli.add_command(cli_generate)
 cli.add_command(cli_update)
 cli.add_command(cli_sweep)
+cli.add_command(cli_info)
 
 # entry-point für `python -m glacium.cli`
 if __name__ == "__main__":

--- a/glacium/cli/info.py
+++ b/glacium/cli/info.py
@@ -1,0 +1,61 @@
+"""Show configuration details for a project."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import yaml
+import click
+from glacium.utils.logging import log_call
+from rich.console import Console
+from rich.table import Table
+from rich import box
+
+from glacium.managers.project_manager import ProjectManager
+from glacium.utils.current import load as load_current
+
+ROOT = Path("runs")
+console = Console()
+
+
+@click.command("info")
+@click.argument("uid", required=False)
+@log_call
+def cli_info(uid: str | None) -> None:
+    """Print case parameters and selected global config values."""
+    pm = ProjectManager(ROOT)
+
+    if uid is None:
+        uid = load_current()
+        if uid is None:
+            raise click.ClickException(
+                "Kein Projekt ausgewaehlt. Erst 'glacium select <Nr>' nutzen."
+            )
+
+    try:
+        proj = pm.load(uid)
+    except FileNotFoundError:
+        raise click.ClickException(f"Projekt '{uid}' nicht gefunden.") from None
+
+    case_file = proj.root / "case.yaml"
+    case = yaml.safe_load(case_file.read_text()) if case_file.exists() else {}
+
+    console.print(f"[bold]case.yaml[/bold] ({case_file})")
+    console.print(yaml.safe_dump(case, sort_keys=False))
+
+    keys = [
+        "PROJECT_NAME",
+        "PWS_REFINEMENT",
+        "FSP_MACH_NUMBER",
+        "ICE_REF_VELOCITY",
+    ]
+    cfg = proj.config
+    table = Table(title="global_config", box=box.SIMPLE_HEAVY)
+    table.add_column("Key")
+    table.add_column("Value")
+    for k in keys:
+        if k in cfg:
+            table.add_row(k, str(cfg.get(k)))
+    console.print(table)
+
+
+__all__ = ["cli_info"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,7 +16,7 @@ def test_cli_help():
 import pytest
 
 
-@pytest.mark.parametrize('command', ['new', 'init', 'run', 'list', 'projects', 'select', 'job', 'sync', 'remove', 'generate', 'sweep'])
+@pytest.mark.parametrize('command', ['new', 'init', 'run', 'list', 'projects', 'select', 'job', 'sync', 'remove', 'generate', 'sweep', 'info'])
 def test_cli_subcommand_help(command):
     runner = CliRunner()
     result = runner.invoke(cli, [command, '--help'])
@@ -55,3 +55,18 @@ def test_cli_generate(tmp_path):
         assert result.exit_code == 0
         data = yaml.safe_load(out.read_text())
         assert data["CASE_AOA"] == 4
+
+
+def test_cli_info(tmp_path):
+    runner = CliRunner()
+    env = {"HOME": str(tmp_path)}
+
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        res = runner.invoke(cli, ["init"], env=env)
+        assert res.exit_code == 0
+        uid = res.output.strip()
+
+        result = runner.invoke(cli, ["info", uid], env=env)
+        assert result.exit_code == 0
+        assert "CASE_AOA" in result.output
+        assert "PWS_REFINEMENT" in result.output


### PR DESCRIPTION
## Summary
- implement `glacium info` command
- register command with CLI
- document usage in README and quick start
- cover new command in tests

## Testing
- `pip install click pyyaml rich jinja2 coloredlogs verboselogs`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ce07d20d08327be6eed1be396bc9e