### PR TITLE
Display case parameters in info output

### DIFF
--- a/glacium/cli/info.py
+++ b/glacium/cli/info.py
@@ -40,7 +40,13 @@ def cli_info(uid: str | None) -> None:
     case = yaml.safe_load(case_file.read_text()) if case_file.exists() else {}
 
     console.print(f"[bold]case.yaml[/bold] ({case_file})")
-    console.print(yaml.safe_dump(case, sort_keys=False))
+
+    case_table = Table(title="case.yaml", box=box.SIMPLE_HEAVY)
+    case_table.add_column("Key")
+    case_table.add_column("Value")
+    for key, value in case.items():
+        case_table.add_row(str(key), str(value))
+    console.print(case_table)
 
     keys = [
         "PROJECT_NAME",


### PR DESCRIPTION
## Summary
- show `case.yaml` parameters in a table when running `glacium info`

## Testing
- `pytest -k info -vv`

------
https://chatgpt.com/codex/tasks/task_e_686ce2798400832785e2b388e412b269