### PR TITLE
Ensure unique project UIDs

### DIFF
--- a/glacium/cli/new.py
+++ b/glacium/cli/new.py
@@ -44,7 +44,7 @@ DEFAULT_AIRFOIL = PKG_PKG / "data" / "AH63K127.dat"
 # ------------------------------------------------------------------------
 
 def _uid(name: str) -> str:
-    ts = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
+    ts = datetime.now(UTC).strftime("%Y%m%d-%H%M%S-%f")
     h  = hashlib.sha1(name.encode()).hexdigest()[:4].upper()
     return f"{ts}-{h}"
 

--- a/glacium/managers/project_manager.py
+++ b/glacium/managers/project_manager.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import hashlib
 import shutil
-from datetime import datetime
+from datetime import datetime, UTC
 from pathlib import Path
 from typing import Dict, List
 import yaml
@@ -179,7 +179,7 @@ class ProjectManager:
     def _uid(name: str) -> str:
         """Generate a deterministic UID from ``name`` and current time."""
 
-        ts = datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+        ts = datetime.now(UTC).strftime("%Y%m%d-%H%M%S-%f")
         h = hashlib.sha1(name.encode()).hexdigest()[:4]
         return f"{ts}-{h.upper()}"
 

--- a/tests/test_cli_case_sweep.py
+++ b/tests/test_cli_case_sweep.py
@@ -15,7 +15,7 @@ def test_cli_case_sweep(tmp_path, monkeypatch):
     def fake_uid(name: str) -> str:
         nonlocal counter
         counter += 1
-        return f"20000101-000000-{counter:04X}"
+        return f"20000101-000000-000000-{counter:04X}"
 
     monkeypatch.setattr(ProjectManager, "_uid", staticmethod(fake_uid))
 
@@ -36,7 +36,11 @@ def test_cli_case_sweep(tmp_path, monkeypatch):
         )
         assert result.exit_code == 0
         lines = [l.strip() for l in result.output.splitlines()]
-        uids = [l for l in lines if re.match(r"\d{8}-\d{6}-[0-9A-F]{4}", l)]
+        uids = [
+            l
+            for l in lines
+            if re.match(r"\d{8}-\d{6}-\d{6}-[0-9A-F]{4}", l)
+        ]
         assert len(uids) == 4
 
         combos = set()

--- a/tests/test_uid_unique.py
+++ b/tests/test_uid_unique.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from glacium.managers.project_manager import ProjectManager
+
+
+def test_uid_uniqueness(tmp_path):
+    pm = ProjectManager(tmp_path)
+    airfoil = Path(__file__).resolve().parents[1] / "glacium" / "data" / "AH63K127.dat"
+
+    uids = [pm.create("proj", "hello", airfoil).uid for _ in range(5)]
+    assert len(set(uids)) == len(uids)


### PR DESCRIPTION
## Summary
- prevent UID collisions by adding microsecond precision
- update CLI to output the new UID format
- adapt case sweep test to new format
- add a regression test checking UID uniqueness

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d07f1eb5c8327b08a07dd7f3a76d0