### PR TITLE
Extend project listing with recipe info

### DIFF
--- a/glacium/cli/projects.py
+++ b/glacium/cli/projects.py
@@ -14,16 +14,27 @@ console = Console()
 @log_call
 def cli_projects():
     """Listet alle Projekte mit Job-Fortschritt."""
+    root = Path("runs")
+    items = list_projects(root)
+
+    # Sammle alle Keys aus case.yaml
+    param_keys: set[str] = set()
+    for info in items:
+        param_keys.update(info.case_params.keys())
+
     table = Table(title="Glacium – Projekte", box=box.SIMPLE_HEAVY)
-    table.add_column("#",  justify="right")
+    table.add_column("#", justify="right")
     table.add_column("UID", overflow="fold")
     table.add_column("Name")
     table.add_column("Jobs")
+    table.add_column("Recipe")
+    for key in sorted(param_keys):
+        table.add_column(key)
 
-    root = Path("runs")
-    for idx, info in enumerate(list_projects(root), start=1):
+    for idx, info in enumerate(items, start=1):
         jobs = f"{info.jobs_done}/{info.jobs_total}" if info.jobs_total else "-"
-        table.add_row(str(idx), info.uid, info.name, jobs)
+        values = [str(info.case_params.get(k, "")) for k in sorted(param_keys)]
+        table.add_row(str(idx), info.uid, info.name, jobs, info.recipe, *values)
 
     console.print(table)
 

--- a/glacium/utils/ProjectIndex.py
+++ b/glacium/utils/ProjectIndex.py
@@ -2,6 +2,8 @@
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any, Dict
+
 import yaml
 
 @dataclass
@@ -12,6 +14,8 @@ class ProjectInfo:
     name: str  # optional
     jobs_done: int
     jobs_total: int
+    recipe: str
+    case_params: Dict[str, Any]
     path: Path
 
 def list_projects(root: Path) -> list[ProjectInfo]:
@@ -25,18 +29,25 @@ def list_projects(root: Path) -> list[ProjectInfo]:
         if not cfg_file.exists():
             cfg_file = p / "_cfg" / "global_config.yaml"
         jobs_file = p / "_cfg" / "jobs.yaml"
+        case_file = p / "case.yaml"
         name = "(unnamed)"
+        recipe = "-"
         done, total = 0, 0
+        case_params: Dict[str, Any] = {}
 
         if cfg_file.exists():
             cfg = yaml.safe_load(cfg_file.read_text()) or {}
             name = cfg.get("PROJECT_NAME", name)
+            recipe = cfg.get("RECIPE", recipe)
 
         if jobs_file.exists():
             data = yaml.safe_load(jobs_file.read_text()) or {}
             total = len(data)
             done = sum(1 for s in data.values() if s == "DONE")
 
-        items.append(ProjectInfo(p.name, name, done, total, p))
+        if case_file.exists():
+            case_params = yaml.safe_load(case_file.read_text()) or {}
+
+        items.append(ProjectInfo(p.name, name, done, total, recipe, case_params, p))
     return sorted(items, key=lambda x: x.uid, reverse=True)
 

--- a/tests/test_cli_projects.py
+++ b/tests/test_cli_projects.py
@@ -1,0 +1,33 @@
+import yaml
+from pathlib import Path
+from click.testing import CliRunner
+
+from glacium.cli import cli
+
+
+def test_cli_projects_columns(tmp_path):
+    runner = CliRunner()
+    env = {"HOME": str(tmp_path), "COLUMNS": "200"}
+
+    res = runner.invoke(cli, ["new", "demo", "-y"], env=env)
+    assert res.exit_code == 0
+    uid = res.output.strip().splitlines()[-1]
+
+    case_file = Path("runs") / uid / "case.yaml"
+    assert case_file.exists()
+    case = yaml.safe_load(case_file.read_text()) or {}
+
+    result = runner.invoke(cli, ["projects"], env=env)
+    assert result.exit_code == 0
+
+    import re
+    ansi = re.compile(r"\x1b\[[0-9;]*[mK]")
+    clean = ansi.sub("", result.output)
+
+    assert ("Recipe" in clean) or ("Re\u2026" in clean)
+    found = False
+    for key in case.keys():
+        if key in clean or (key[:2] + "\u2026") in clean:
+            found = True
+            break
+    assert found


### PR DESCRIPTION
## Summary
- add recipe and case parameters to `ProjectInfo`
- populate these fields when scanning projects
- display recipe and case parameter columns in `glacium projects`
- test that `glacium projects` prints recipe and at least one case parameter column

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d0a91ba4083278a5d07c8305262b8