### PR TITLE
Fix recipe persistence when creating projects

### DIFF
--- a/glacium/managers/project_manager.py
+++ b/glacium/managers/project_manager.py
@@ -69,7 +69,7 @@ class ProjectManager:
         cfg = GlobalConfig(**defaults, project_uid=uid, base_dir=root)
         cfg["PROJECT_NAME"] = name
         cfg["PWS_AIRFOIL_FILE"] = f"_data/{airfoil.name}"
-        cfg["RECIPE"] = recipe_name
+        cfg.recipe = recipe_name
         cfg.dump(paths.global_cfg_file())
 
         # Airfoil kopieren

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from click.testing import CliRunner
 from glacium.cli import cli
+import yaml
 
 
 def test_cli_help():
@@ -43,3 +44,20 @@ def test_cli_init_creates_project(tmp_path):
         uid = result.output.strip()
         cfg = Path(env["GLACIUM_RUNS_ROOT"]) / uid / "_cfg" / "global_config.yaml"
         assert cfg.exists()
+
+
+def test_cli_init_writes_recipe(tmp_path):
+    runner = CliRunner()
+    env = {"HOME": str(tmp_path)}
+    from glacium.managers.path_manager import _SharedState
+    _SharedState._SharedState__shared_state.clear()
+
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        env["GLACIUM_RUNS_ROOT"] = str(Path(td) / "runs")
+        result = runner.invoke(cli, ["init", "--recipe", "fensap"], env=env)
+        assert result.exit_code == 0
+        uid = result.output.strip()
+        cfg_file = Path(env["GLACIUM_RUNS_ROOT"]) / uid / "_cfg" / "global_config.yaml"
+        data = yaml.safe_load(cfg_file.read_text())
+        assert data["RECIPE"] == "fensap"
+


### PR DESCRIPTION
## Summary
- ensure project creation stores the recipe name in `global_config.yaml`
- test that `--recipe` flag persists the value during `glacium init`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d0f8124d0832792485fc3f48f7525