### PR TITLE
Fix recipe persistence

### DIFF
--- a/glacium/managers/project_manager.py
+++ b/glacium/managers/project_manager.py
@@ -78,7 +78,7 @@ class ProjectManager:
         cfg = GlobalConfig(**defaults, project_uid=uid, base_dir=root)
         cfg["PROJECT_NAME"] = name
         cfg["PWS_AIRFOIL_FILE"] = f"_data/{airfoil.name}"
-        cfg["RECIPE"] = recipe_name
+        cfg.recipe = recipe_name
         cfg.dump(paths.global_cfg_file())
 
         # Airfoil kopieren

--- a/tests/test_recipe_saved.py
+++ b/tests/test_recipe_saved.py
@@ -1,0 +1,14 @@
+import yaml
+from pathlib import Path
+
+from glacium.managers.project_manager import ProjectManager
+
+
+def test_recipe_written(tmp_path):
+    pm = ProjectManager(tmp_path)
+    airfoil = Path(__file__).resolve().parents[1] / "glacium" / "data" / "AH63K127.dat"
+
+    project = pm.create("proj", "hello", airfoil)
+    cfg_file = tmp_path / project.uid / "_cfg" / "global_config.yaml"
+    data = yaml.safe_load(cfg_file.read_text())
+    assert data["RECIPE"] == "hello"


### PR DESCRIPTION
## Summary
- set `cfg.recipe` instead of the `RECIPE` dict item before dumping config
- test that project creation stores the recipe name in `global_config.yaml`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d11d828688327a730557629bafc17