### PR TITLE
Preserve recipe and name on update

### DIFF
--- a/glacium/cli/update.py
+++ b/glacium/cli/update.py
@@ -1,4 +1,8 @@
-"""Refresh ``global_config.yaml`` from ``case.yaml``."""
+"""Refresh ``global_config.yaml`` from ``case.yaml``.
+
+Existing values from an earlier configuration are preserved so custom
+modifications like ``RECIPE`` or ``PROJECT_NAME`` remain intact.
+"""
 
 from __future__ import annotations
 
@@ -49,7 +53,12 @@ def cli_update(uid: str | None, case_file: Path | None) -> None:
     cfg = generate_global_defaults(src, global_default_config())
 
     dest = proj.paths.global_cfg_file()
-    dest.write_text(yaml.safe_dump(cfg, sort_keys=False))
+    existing = yaml.safe_load(dest.read_text()) if dest.exists() else {}
+
+    merged = dict(existing)
+    merged.update(cfg)
+
+    dest.write_text(yaml.safe_dump(merged, sort_keys=False))
     click.echo(str(dest))
 
 

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -31,3 +31,5 @@ def test_cli_update(tmp_path):
         expected = generate_global_defaults(case_file, global_default_config())
         assert data["CASE_VELOCITY"] == 123.0
         assert data["FSP_MACH_NUMBER"] == pytest.approx(expected["FSP_MACH_NUMBER"])
+        assert data["RECIPE"] == "prep"
+        assert data["PROJECT_NAME"] == "project"


### PR DESCRIPTION
## Summary
- merge current global_config.yaml into newly generated defaults
- document preserved keys
- test that update keeps recipe and project name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d172dd3348327b3447b1faebd3885