### PR TITLE
Add composite recipe support

### DIFF
--- a/docs/glacium.recipes.rst
+++ b/docs/glacium.recipes.rst
@@ -5,6 +5,10 @@ Recipes bundle jobs into reusable workflows.  They may be combined with
 the :mod:`glacium.cli.case_sweep` command to create multiple projects
 from parameter sweeps.
 
+Multiple recipes can be chained by joining their names with ``+`` when
+creating a project.  For example ``prep+solver`` first runs the
+``prep`` recipe and then ``solver``.
+
 Submodules
 ----------
 

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -26,6 +26,12 @@ project from the default recipe and prints its unique identifier (UID):
 
    glacium new MyWing
 
+To chain multiple recipes use ``+`` between their names, e.g.:
+
+.. code-block:: bash
+
+   glacium new MyWing -r prep+solver
+
 The project will be created under ``runs/<UID>``.
 
 Case sweep

--- a/glacium/cli/case_sweep.py
+++ b/glacium/cli/case_sweep.py
@@ -28,7 +28,7 @@ DEFAULT_AIRFOIL = Path(__file__).resolve().parents[1] / "data" / "AH63K127.dat"
     "--recipe",
     default=DEFAULT_RECIPE,
     show_default=True,
-    help="Recipe used for created projects",
+    help="Recipe name or names joined with '+'",
 )
 @click.option(
     "-o",

--- a/glacium/cli/new.py
+++ b/glacium/cli/new.py
@@ -39,10 +39,13 @@ DEFAULT_AIRFOIL = PKG_PKG / "data" / "AH63K127.dat"
               default=DEFAULT_AIRFOIL,
               show_default=True,
               help="Pfad zur Profil-Datei")
-@click.option("-r", "--recipe",
-              default=DEFAULT_RECIPE,
-              show_default=True,
-              help="Name des Rezepts (Jobs)")
+@click.option(
+    "-r",
+    "--recipe",
+    default=DEFAULT_RECIPE,
+    show_default=True,
+    help="Recipe name or multiple names joined with '+'",
+)
 @click.option("-o", "--output", default=str(RUNS_ROOT), show_default=True,
               type=click.Path(file_okay=False, dir_okay=True, writable=True, path_type=Path),
               help="Root-Ordner für Projekte")

--- a/glacium/managers/recipe_manager.py
+++ b/glacium/managers/recipe_manager.py
@@ -51,6 +51,13 @@ class RecipeManager:
         """
 
         cls._load()
+
+        if "+" in name:
+            from glacium.recipes.composite import CompositeRecipe
+
+            parts = [n for n in name.split("+") if n]
+            return CompositeRecipe(parts)
+
         if name not in cls._recipes:  # type: ignore
             raise KeyError(f"Recipe '{name}' nicht registriert.")
         return cls._recipes[name]()  # type: ignore[index]

--- a/glacium/recipes/composite.py
+++ b/glacium/recipes/composite.py
@@ -1,0 +1,22 @@
+"""Recipe concatenating multiple recipes."""
+
+from __future__ import annotations
+
+from glacium.managers.recipe_manager import RecipeManager, BaseRecipe
+
+
+class CompositeRecipe(BaseRecipe):
+    """Combine several recipes into one."""
+
+    name = "composite"
+    description = "Concatenate recipes"
+
+    def __init__(self, recipe_names: list[str]):
+        self.recipe_names = recipe_names
+        self._recipes = [RecipeManager.create(n) for n in recipe_names]
+
+    def build(self, project):
+        jobs = []
+        for recipe in self._recipes:
+            jobs.extend(recipe.build(project))
+        return jobs

--- a/tests/test_recipe_saved.py
+++ b/tests/test_recipe_saved.py
@@ -12,3 +12,13 @@ def test_recipe_written(tmp_path):
     cfg_file = tmp_path / project.uid / "_cfg" / "global_config.yaml"
     data = yaml.safe_load(cfg_file.read_text())
     assert data["RECIPE"] == "hello"
+
+
+def test_composite_recipe_saved(tmp_path):
+    pm = ProjectManager(tmp_path)
+    airfoil = Path(__file__).resolve().parents[1] / "glacium" / "data" / "AH63K127.dat"
+
+    project = pm.create("proj", "prep+solver", airfoil)
+    cfg_file = tmp_path / project.uid / "_cfg" / "global_config.yaml"
+    data = yaml.safe_load(cfg_file.read_text())
+    assert data["RECIPE"] == "prep+solver"

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -17,3 +17,16 @@ def test_fensap_recipe_build(tmp_path):
 
     assert len(jobs) == 1
     assert isinstance(jobs[0], FensapRunJob)
+
+
+def test_composite_recipe_build(tmp_path):
+    cfg = GlobalConfig(project_uid="uid", base_dir=tmp_path)
+    paths = PathBuilder(tmp_path).build()
+    project = Project("uid", tmp_path, cfg, paths, [])
+
+    from glacium.managers.recipe_manager import RecipeManager
+
+    recipe = RecipeManager.create("prep+solver")
+    jobs = recipe.build(project)
+
+    assert len(jobs) == 8


### PR DESCRIPTION
## Summary
- allow selecting multiple recipes with "name+name" syntax
- implement CompositeRecipe and update RecipeManager
- keep recipe string unchanged in config
- update CLI help for `new` and `case-sweep`
- document composite recipe usage
- add tests for composite recipes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d2886614c8327a34d951349555f4d