### PR TITLE
Fix custom recipe job handling

### DIFF
--- a/glacium/cli/job/add.py
+++ b/glacium/cli/job/add.py
@@ -31,9 +31,13 @@ def cli_job_add(job_name: str) -> None:
 
     from glacium.managers.recipe_manager import RecipeManager
 
-    recipe_jobs = {
-        j.name: j for j in RecipeManager.create(proj.config.recipe).build(proj)
-    }
+    if proj.config.recipe == "CUSTOM":
+        recipe_jobs = {}
+    else:
+        recipe_jobs = {
+            j.name: j
+            for j in RecipeManager.create(proj.config.recipe).build(proj)
+        }
 
     if job_name.isdigit():
         from glacium.utils import list_jobs

--- a/glacium/cli/job/list.py
+++ b/glacium/cli/job/list.py
@@ -30,6 +30,13 @@ def cli_job_list(available: bool) -> None:
         raise click.ClickException(f"Projekt '{uid}' nicht gefunden.") from None
 
     if available:
+        if proj.config.recipe == "CUSTOM":
+            from glacium.utils.JobIndex import JobFactory
+
+            for name in JobFactory.list():
+                click.echo(name)
+            return
+
         from glacium.managers.recipe_manager import RecipeManager
 
         recipe = RecipeManager.create(proj.config.recipe)

--- a/tests/test_job_add.py
+++ b/tests/test_job_add.py
@@ -53,3 +53,50 @@ def test_job_add_renders_script(tmp_path):
 
     script = Path("runs") / uid / "pointwise" / "POINTWISE.mesh2.glf"
     assert script.exists()
+
+
+def test_job_add_multiple_custom(tmp_path):
+    TemplateManager(Path(__file__).resolve().parents[1] / "glacium" / "templates")
+    runner = CliRunner()
+    env = {"HOME": str(tmp_path)}
+
+    res = runner.invoke(cli, ["new", "proj", "-y"], env=env)
+    assert res.exit_code == 0
+    uid = res.output.strip().splitlines()[-1]
+
+    res = runner.invoke(cli, ["select", uid], env=env)
+    assert res.exit_code == 0
+
+    res = runner.invoke(cli, ["job", "add", "POINTWISE_MESH2"], env=env)
+    assert res.exit_code == 0
+
+    res = runner.invoke(cli, ["job", "add", "POINTWISE_GCI"], env=env)
+    assert res.exit_code == 0
+
+    jobs_yaml = Path("runs") / uid / "_cfg" / "jobs.yaml"
+    data = yaml.safe_load(jobs_yaml.read_text())
+    assert "POINTWISE_MESH2" in data
+    assert "POINTWISE_GCI" in data
+
+    cfg_file = Path("runs") / uid / "_cfg" / "global_config.yaml"
+    cfg = yaml.safe_load(cfg_file.read_text())
+    assert cfg["RECIPE"] == "CUSTOM"
+
+
+def test_job_list_available_custom(tmp_path):
+    TemplateManager(Path(__file__).resolve().parents[1] / "glacium" / "templates")
+    runner = CliRunner()
+    env = {"HOME": str(tmp_path)}
+
+    res = runner.invoke(cli, ["new", "proj", "-y"], env=env)
+    assert res.exit_code == 0
+    uid = res.output.strip().splitlines()[-1]
+
+    res = runner.invoke(cli, ["select", uid], env=env)
+    assert res.exit_code == 0
+
+    res = runner.invoke(cli, ["job", "add", "POINTWISE_MESH2"], env=env)
+    assert res.exit_code == 0
+
+    res = runner.invoke(cli, ["job", "list", "--available"], env=env)
+    assert res.exit_code == 0


### PR DESCRIPTION
## Summary
- handle custom recipes properly when adding or listing jobs
- allow listing available jobs for custom projects
- test adding multiple jobs after customisation
- regression test for listing available jobs in custom project

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e3f66ec008327a1b3f6e928aa01f4