### PR TITLE
Add FENSAP convergence utilities

### DIFF
--- a/glacium/utils/__init__.py
+++ b/glacium/utils/__init__.py
@@ -5,3 +5,9 @@ from .current_job import save as save_current_job, load as load_current_job
 from .default_paths import global_default_config, default_case_file
 from .case_to_global import generate_global_defaults
 from .first_cellheight import from_case as first_cellheight
+from .convergence import (
+    read_history,
+    stats_last_n,
+    aggregate_report,
+    plot_stats,
+)

--- a/glacium/utils/convergence.py
+++ b/glacium/utils/convergence.py
@@ -1,0 +1,95 @@
+"""Helpers for analysing FENSAP convergence history files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+__all__ = [
+    "read_history",
+    "stats_last_n",
+    "aggregate_report",
+    "plot_stats",
+]
+
+
+def read_history(file: str | Path, nrows: int | None = None) -> "np.ndarray":
+    """Return the last ``nrows`` rows from ``file`` as ``numpy`` array.
+
+    Header lines starting with ``#`` are ignored.
+    """
+    import numpy as np
+
+    path = Path(file)
+    data = [
+        [float(val.replace("D", "E")) for val in line.split()]
+        for line in path.read_text().splitlines()
+        if not line.lstrip().startswith("#") and line.strip()
+    ]
+    arr = np.array(data, dtype=float)
+    if nrows is not None:
+        arr = arr[-nrows:]
+    return arr
+
+
+def stats_last_n(data: "np.ndarray", n: int = 15) -> tuple["np.ndarray", "np.ndarray"]:
+    """Return column-wise mean and std of the last ``n`` rows in ``data``."""
+
+    import numpy as np
+
+    tail = data[-n:] if n else data
+    return np.mean(tail, axis=0), np.std(tail, axis=0)
+
+
+def aggregate_report(
+    directory: str | Path, n: int = 15
+) -> tuple["np.ndarray", "np.ndarray", "np.ndarray"]:
+    """Aggregate stats for all ``converg.fensap.*`` files in ``directory``."""
+
+    import numpy as np
+
+    root = Path(directory)
+    means = []
+    stds = []
+    indices = []
+    for file in sorted(root.glob("converg.fensap.*")):
+        data = read_history(file, n)
+        mean, std = stats_last_n(data, n)
+        means.append(mean)
+        stds.append(std)
+        try:
+            indices.append(int(file.name.split(".")[-1]))
+        except ValueError:
+            indices.append(len(indices))
+
+    return (
+        np.array(indices, dtype=int),
+        np.vstack(means) if means else np.empty((0, 0)),
+        np.vstack(stds) if stds else np.empty((0, 0)),
+    )
+
+
+def plot_stats(
+    indices: "Iterable[int]",
+    means: "np.ndarray",
+    stds: "np.ndarray",
+    out_dir: str | Path,
+) -> None:
+    """Write ``matplotlib`` plots visualising ``means`` and ``stds``."""
+
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    ind = np.array(list(indices))
+    for col in range(means.shape[1]):
+        plt.figure()
+        plt.errorbar(ind, means[:, col], yerr=stds[:, col], fmt="o-", capsize=3)
+        plt.xlabel("multishot index")
+        plt.ylabel(f"column {col}")
+        plt.grid(True)
+        plt.tight_layout()
+        plt.savefig(out / f"column_{col:02d}.png")
+        plt.close()


### PR DESCRIPTION
## Summary
- add `glacium/utils/convergence.py` with helpers for reading convergence histories
- export convergence helpers from `glacium.utils`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e51ea9a2883278247050d29398812