### PR TITLE
Add convergence stats job

### DIFF
--- a/glacium/jobs/__init__.py
+++ b/glacium/jobs/__init__.py
@@ -6,6 +6,7 @@ from .fensap_jobs import (
     Ice3dRunJob,
     MultiShotRunJob,
 )
+from .analysis_jobs import ConvergenceStatsJob
 from .pointwise_jobs import PointwiseGCIJob, PointwiseMesh2Job
 from .xfoil_jobs import (
     XfoilRefineJob,
@@ -20,6 +21,7 @@ __all__ = [
     "Drop3dRunJob",
     "Ice3dRunJob",
     "MultiShotRunJob",
+    "ConvergenceStatsJob",
     "PointwiseGCIJob",
     "PointwiseMesh2Job",
     "XfoilRefineJob",

--- a/glacium/jobs/analysis_jobs.py
+++ b/glacium/jobs/analysis_jobs.py
@@ -1,0 +1,24 @@
+"""Job classes performing post-processing analysis."""
+
+from glacium.models.job import Job
+from glacium.engines.py_engine import PyEngine
+from glacium.utils.convergence import analysis
+
+
+class ConvergenceStatsJob(Job):
+    """Aggregate convergence statistics of a MULTISHOT run."""
+
+    name = "CONVERGENCE_STATS"
+    deps = ("MULTISHOT_RUN",)
+
+    def execute(self) -> None:  # noqa: D401
+        project_root = self.project.root
+        report_dir = project_root / "report"
+        out_dir = project_root / "analysis"
+
+        engine = PyEngine(analysis)
+        engine.run([report_dir, out_dir], cwd=project_root)
+
+
+__all__ = ["ConvergenceStatsJob"]
+

--- a/glacium/utils/convergence.py
+++ b/glacium/utils/convergence.py
@@ -10,6 +10,7 @@ __all__ = [
     "stats_last_n",
     "aggregate_report",
     "plot_stats",
+    "analysis",
 ]
 
 
@@ -93,3 +94,26 @@ def plot_stats(
         plt.tight_layout()
         plt.savefig(out / f"column_{col:02d}.png")
         plt.close()
+
+
+def analysis(cwd: Path, args: "Sequence[str | Path]") -> None:
+    """Aggregate convergence data and create plots.
+
+    Parameters
+    ----------
+    cwd:
+        Working directory supplied by :class:`~glacium.engines.py_engine.PyEngine`.
+        Unused but kept for API compatibility.
+    args:
+        Sequence containing the input report directory and the output directory.
+    """
+
+    if len(args) < 2:
+        raise ValueError("analysis requires input and output directory")
+
+    report_dir = Path(args[0])
+    out_dir = Path(args[1])
+
+    idx, means, stds = aggregate_report(report_dir)
+    if means.size:
+        plot_stats(idx, means, stds, out_dir)


### PR DESCRIPTION
## Summary
- add `analysis` function to `utils.convergence`
- implement `ConvergenceStatsJob` to run convergence statistics
- expose the new job in `glacium.jobs`

## Testing
- `pip install click pyyaml rich jinja2 coloredlogs verboselogs`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e58a023c48327a0abb86ed01d1704