### PR TITLE
Add convergence stats to multishot recipe

### DIFF
--- a/glacium/recipes/multishot.py
+++ b/glacium/recipes/multishot.py
@@ -18,5 +18,6 @@ class DefaultAero(BaseRecipe):
             JobFactory.create("POINTWISE_GCI", project),
             JobFactory.create("FLUENT2FENSAP", project),
             JobFactory.create("MULTISHOT_RUN", project),
+            JobFactory.create("CONVERGENCE_STATS", project),
         ]
 


### PR DESCRIPTION
## Summary
- append `CONVERGENCE_STATS` job after `MULTISHOT_RUN` in multishot recipe

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e5b0aee248327bc805e190acde81f