### PR TITLE
Fix relative airfoil path in global config

### DIFF
--- a/glacium/managers/project_manager.py
+++ b/glacium/managers/project_manager.py
@@ -76,7 +76,9 @@ class ProjectManager:
 
         cfg = GlobalConfig(**defaults, project_uid=uid, base_dir=root)
         cfg["PROJECT_NAME"] = name
-        cfg["PWS_AIRFOIL_FILE"] = f"_data/{airfoil.name}"
+        # Use path relative to solver directories so Pointwise and XFOIL can
+        # locate the airfoil file correctly.
+        cfg["PWS_AIRFOIL_FILE"] = f"../_data/{airfoil.name}"
         cfg.recipe = recipe_name
         cfg.dump(paths.global_cfg_file())
 

--- a/tests/test_project_config_generation.py
+++ b/tests/test_project_config_generation.py
@@ -26,3 +26,4 @@ def test_project_config_generation(tmp_path):
 
     expected = generate_global_defaults(case_file, global_default_config())
     assert cfg["FSP_MACH_NUMBER"] == pytest.approx(expected["FSP_MACH_NUMBER"])
+    assert cfg["PWS_AIRFOIL_FILE"] == expected["PWS_AIRFOIL_FILE"]


### PR DESCRIPTION
## Summary
- fix path for `PWS_AIRFOIL_FILE` so Pointwise and XFOIL can find the input
- verify global config uses the correct path on project creation

## Testing
- `pytest tests/test_project_config_generation.py::test_project_config_generation -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e898f37308327889e2f57feca344c