### PR TITLE
Update case sweep tests for PWS refinement

### DIFF
--- a/tests/test_case_sweep.py
+++ b/tests/test_case_sweep.py
@@ -25,13 +25,14 @@ def test_case_sweep_creates_projects(tmp_path, monkeypatch):
             (
                 "CASE_AOA=0,4",
                 "CASE_VELOCITY=50,100",
+                "PWS_REFINEMENT=1,2",
             ),
             recipe="multishot",
             output=Path("runs"),
         )
 
         uids = [p.name for p in Path("runs").iterdir() if p.is_dir()]
-        assert len(uids) == 4
+        assert len(uids) == 8
 
         combos = set()
         for uid in uids:
@@ -41,10 +42,20 @@ def test_case_sweep_creates_projects(tmp_path, monkeypatch):
             assert cfg_file.exists()
             case = yaml.safe_load(case_file.read_text())
             cfg = yaml.safe_load(cfg_file.read_text())
-            combos.add((case["CASE_AOA"], case["CASE_VELOCITY"]))
+            combos.add((case["CASE_AOA"], case["CASE_VELOCITY"], case["PWS_REFINEMENT"]))
             assert cfg["CASE_AOA"] == case["CASE_AOA"]
             assert cfg["CASE_VELOCITY"] == case["CASE_VELOCITY"]
+            assert cfg["PWS_REFINEMENT"] == case["PWS_REFINEMENT"]
 
-        assert combos == {(0, 50), (0, 100), (4, 50), (4, 100)}
+        assert combos == {
+            (0, 50, 1),
+            (0, 50, 2),
+            (0, 100, 1),
+            (0, 100, 2),
+            (4, 50, 1),
+            (4, 50, 2),
+            (4, 100, 1),
+            (4, 100, 2),
+        }
 
 

--- a/tests/test_cli_case_sweep.py
+++ b/tests/test_cli_case_sweep.py
@@ -31,6 +31,8 @@ def test_cli_case_sweep(tmp_path, monkeypatch):
                 "CASE_AOA=0,4",
                 "--param",
                 "CASE_VELOCITY=50,100",
+                "--param",
+                "PWS_REFINEMENT=1,2",
             ],
             env=env,
         )
@@ -41,7 +43,7 @@ def test_cli_case_sweep(tmp_path, monkeypatch):
             for l in lines
             if re.match(r"\d{8}-\d{6}-\d{6}-[0-9A-F]{4}", l)
         ]
-        assert len(uids) == 4
+        assert len(uids) == 8
 
         combos = set()
         for uid in uids:
@@ -51,9 +53,19 @@ def test_cli_case_sweep(tmp_path, monkeypatch):
             assert cfg_file.exists()
             case = yaml.safe_load(case_file.read_text())
             cfg = yaml.safe_load(cfg_file.read_text())
-            combos.add((case["CASE_AOA"], case["CASE_VELOCITY"]))
+            combos.add((case["CASE_AOA"], case["CASE_VELOCITY"], case["PWS_REFINEMENT"]))
             assert cfg["CASE_AOA"] == case["CASE_AOA"]
             assert cfg["CASE_VELOCITY"] == case["CASE_VELOCITY"]
+            assert cfg["PWS_REFINEMENT"] == case["PWS_REFINEMENT"]
 
-        assert combos == {(0, 50), (0, 100), (4, 50), (4, 100)}
+        assert combos == {
+            (0, 50, 1),
+            (0, 50, 2),
+            (0, 100, 1),
+            (0, 100, 2),
+            (4, 50, 1),
+            (4, 50, 2),
+            (4, 100, 1),
+            (4, 100, 2),
+        }
 


### PR DESCRIPTION
## Summary
- extend the case sweep tests with `PWS_REFINEMENT` parameter
- verify resulting global configs match the refinement

## Testing
- `pytest tests/test_case_sweep.py::test_case_sweep_creates_projects -q`
- `pytest tests/test_cli_case_sweep.py::test_cli_case_sweep -q`
- `pytest -q` *(fails: TemplateNotFound in several tests)*

------
https://chatgpt.com/codex/tasks/task_e_6870d8c68d3483279008132e0b013dde