### PR TITLE
Add refinement checks in config generation tests

### DIFF
--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -31,6 +31,7 @@ def test_cli_update(tmp_path):
         expected = generate_global_defaults(case_file, global_default_config())
         assert data["CASE_VELOCITY"] == 123.0
         assert data["FSP_MACH_NUMBER"] == pytest.approx(expected["FSP_MACH_NUMBER"])
+        assert data["PWS_REFINEMENT"] == expected["PWS_REFINEMENT"]
         assert data["RECIPE"] == "prep"
         assert data["PROJECT_NAME"] == "project"
 
@@ -59,5 +60,6 @@ def test_cli_update_preserves_recipe(tmp_path):
         expected = generate_global_defaults(case_file, global_default_config())
         assert data["CASE_VELOCITY"] == 321.0
         assert data["FSP_MACH_NUMBER"] == pytest.approx(expected["FSP_MACH_NUMBER"])
+        assert data["PWS_REFINEMENT"] == expected["PWS_REFINEMENT"]
         assert data["RECIPE"] == "hello"
         assert data["PROJECT_NAME"] == "project"

--- a/tests/test_project_config_generation.py
+++ b/tests/test_project_config_generation.py
@@ -27,3 +27,4 @@ def test_project_config_generation(tmp_path):
     expected = generate_global_defaults(case_file, global_default_config())
     assert cfg["FSP_MACH_NUMBER"] == pytest.approx(expected["FSP_MACH_NUMBER"])
     assert cfg["PWS_AIRFOIL_FILE"] == expected["PWS_AIRFOIL_FILE"]
+    assert cfg["PWS_REFINEMENT"] == expected["PWS_REFINEMENT"]


### PR DESCRIPTION
## Summary
- ensure project config records mesh refinement
- verify refinement gets updated through CLI

## Testing
- `pytest -q` *(fails: TemplateNotFound and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6870e1e2759083279c8e3f09d97aec2b