### PR TITLE
Add convergence header parsing helper

### DIFF
--- a/glacium/utils/__init__.py
+++ b/glacium/utils/__init__.py
@@ -6,7 +6,9 @@ from .default_paths import global_default_config, default_case_file
 from .case_to_global import generate_global_defaults
 from .first_cellheight import from_case as first_cellheight
 from .convergence import (
+    parse_headers,
     read_history,
+    read_history_with_labels,
     stats_last_n,
     aggregate_report,
     plot_stats,

--- a/glacium/utils/convergence.py
+++ b/glacium/utils/convergence.py
@@ -4,14 +4,33 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Iterable
+import re
 
 __all__ = [
+    "parse_headers",
     "read_history",
+    "read_history_with_labels",
     "stats_last_n",
     "aggregate_report",
     "plot_stats",
     "analysis",
 ]
+
+# Regex for header lines: ``# <index> <label>``
+HEADER_RE = re.compile(r"^#\s*\d+\s+(.+)$")
+
+
+def parse_headers(path: Path) -> list[str]:
+    """Return column labels from the header section of ``path``."""
+
+    labels: list[str] = []
+    for line in path.read_text().splitlines():
+        if not line.lstrip().startswith("#"):
+            break
+        m = HEADER_RE.match(line)
+        if m:
+            labels.append(m.group(1))
+    return labels
 
 
 def read_history(file: str | Path, nrows: int | None = None) -> "np.ndarray":
@@ -31,6 +50,31 @@ def read_history(file: str | Path, nrows: int | None = None) -> "np.ndarray":
     if nrows is not None:
         arr = arr[-nrows:]
     return arr
+
+
+def read_history_with_labels(file: str | Path, nrows: int | None = None) -> tuple[list[str], "np.ndarray"]:
+    """Return labels and data from ``file``.
+
+    Parameters
+    ----------
+    file:
+        Path to the convergence history file.
+    nrows:
+        If given, only the last ``nrows`` rows are returned.
+    """
+    import numpy as np
+
+    path = Path(file)
+    labels = parse_headers(path)
+    data = [
+        [float(val.replace("D", "E")) for val in line.split()]
+        for line in path.read_text().splitlines()
+        if not line.lstrip().startswith("#") and line.strip()
+    ]
+    arr = np.array(data, dtype=float)
+    if nrows is not None:
+        arr = arr[-nrows:]
+    return labels, arr
 
 
 def stats_last_n(data: "np.ndarray", n: int = 15) -> tuple["np.ndarray", "np.ndarray"]:

--- a/tests/test_convergence_headers.py
+++ b/tests/test_convergence_headers.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import numpy as np
+from glacium.utils import parse_headers, read_history_with_labels
+
+
+def test_parse_headers_and_read_history(tmp_path):
+    content = "\n".join([
+        "# 1 residual",
+        "#2 lift",
+        "1 2",
+        "3 4",
+    ])
+    file = tmp_path / "converg"
+    file.write_text(content)
+
+    labels = parse_headers(file)
+    assert labels == ["residual", "lift"]
+
+    labels2, data = read_history_with_labels(file)
+    assert labels2 == labels
+    assert np.allclose(data, np.array([[1.0, 2.0], [3.0, 4.0]]))
+
+    _, data_tail = read_history_with_labels(file, nrows=1)
+    assert data_tail.shape == (1, 2)
+    assert np.allclose(data_tail, np.array([[3.0, 4.0]]))


### PR DESCRIPTION
## Summary
- support reading column labels in convergence files
- expose `parse_headers` and `read_history_with_labels`
- test parsing a header section

## Testing
- `pytest tests/test_convergence_stats.py::test_analysis_returns_expected_stats tests/test_convergence_headers.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68712438b2e08327b4b56f113c173d83