### PR TITLE
Add CL/CD statistics to convergence analysis

### DIFF
--- a/tests/test_convergence_stats.py
+++ b/tests/test_convergence_stats.py
@@ -17,7 +17,7 @@ from glacium.models.job import JobStatus
 
 
 def _setup_report(tmp_path):
-    report = tmp_path / "report"
+    report = tmp_path / "run_FENSAP"
     report.mkdir()
     arr1 = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
     arr2 = np.array([[2.0, 4.0], [4.0, 8.0], [6.0, 12.0]])
@@ -34,10 +34,11 @@ def test_analysis_returns_expected_stats(tmp_path, monkeypatch):
 
     captured = {}
 
-    def fake_plot(idx, means, stds, out):
+    def fake_plot(idx, means, stds, out, labels=None):
         captured["idx"] = list(idx)
         captured["means"] = means
         captured["stds"] = stds
+        captured["labels"] = labels
 
     monkeypatch.setattr(convergence, "plot_stats", fake_plot)
 
@@ -46,6 +47,7 @@ def test_analysis_returns_expected_stats(tmp_path, monkeypatch):
     assert captured["idx"] == [1, 2]
     assert np.allclose(captured["means"], exp_means)
     assert np.allclose(captured["stds"], exp_stds)
+    assert captured["labels"] == []
 
 
 def test_convergence_stats_job_creates_plots(tmp_path):


### PR DESCRIPTION
## Summary
- enhance `plot_stats` to label plots using parsed column names
- extend `analysis` with CL/CD statistics and plotting
- adjust tests for new signatures and data locations

## Testing
- `pytest tests/test_convergence_stats.py tests/test_cl_cd_stats.py -q`
- `pytest -q` *(fails: TemplateNotFound errors)*

------
https://chatgpt.com/codex/tasks/task_e_6871ee3453a483278712ee7ea92669e1