### PR TITLE
Add convergence stats jobs for FENSAP, DROP3D and ICE3D

### DIFF
--- a/glacium/jobs/__init__.py
+++ b/glacium/jobs/__init__.py
@@ -6,7 +6,12 @@ from .fensap_jobs import (
     Ice3dRunJob,
     MultiShotRunJob,
 )
-from .analysis_jobs import ConvergenceStatsJob
+from .analysis_jobs import (
+    ConvergenceStatsJob,
+    FensapConvergenceStatsJob,
+    Drop3dConvergenceStatsJob,
+    Ice3dConvergenceStatsJob,
+)
 from .pointwise_jobs import PointwiseGCIJob, PointwiseMesh2Job
 from .xfoil_jobs import (
     XfoilRefineJob,
@@ -22,6 +27,9 @@ __all__ = [
     "Ice3dRunJob",
     "MultiShotRunJob",
     "ConvergenceStatsJob",
+    "FensapConvergenceStatsJob",
+    "Drop3dConvergenceStatsJob",
+    "Ice3dConvergenceStatsJob",
     "PointwiseGCIJob",
     "PointwiseMesh2Job",
     "XfoilRefineJob",

--- a/glacium/jobs/analysis_jobs.py
+++ b/glacium/jobs/analysis_jobs.py
@@ -2,7 +2,7 @@
 
 from glacium.models.job import Job
 from glacium.engines.py_engine import PyEngine
-from glacium.utils.convergence import analysis
+from glacium.utils.convergence import analysis, analysis_file
 
 
 class ConvergenceStatsJob(Job):
@@ -20,5 +20,55 @@ class ConvergenceStatsJob(Job):
         engine.run([report_dir, out_dir], cwd=project_root)
 
 
-__all__ = ["ConvergenceStatsJob"]
+class FensapConvergenceStatsJob(Job):
+    """Generate convergence plots for a FENSAP run."""
+
+    name = "FENSAP_CONVERGENCE_STATS"
+    deps = ("FENSAP_RUN",)
+
+    def execute(self) -> None:  # noqa: D401
+        project_root = self.project.root
+        converg_file = project_root / "run_FENSAP" / "converg"
+        out_dir = project_root / "analysis"
+
+        engine = PyEngine(analysis_file)
+        engine.run([converg_file, out_dir], cwd=project_root)
+
+
+class Drop3dConvergenceStatsJob(Job):
+    """Generate convergence plots for a DROP3D run."""
+
+    name = "DROP3D_CONVERGENCE_STATS"
+    deps = ("DROP3D_RUN",)
+
+    def execute(self) -> None:  # noqa: D401
+        project_root = self.project.root
+        converg_file = project_root / "run_DROP3D" / "converg"
+        out_dir = project_root / "analysis"
+
+        engine = PyEngine(analysis_file)
+        engine.run([converg_file, out_dir], cwd=project_root)
+
+
+class Ice3dConvergenceStatsJob(Job):
+    """Generate convergence plots for an ICE3D run."""
+
+    name = "ICE3D_CONVERGENCE_STATS"
+    deps = ("ICE3D_RUN",)
+
+    def execute(self) -> None:  # noqa: D401
+        project_root = self.project.root
+        converg_file = project_root / "run_ICE3D" / "iceconv.dat"
+        out_dir = project_root / "analysis"
+
+        engine = PyEngine(analysis_file)
+        engine.run([converg_file, out_dir], cwd=project_root)
+
+
+__all__ = [
+    "ConvergenceStatsJob",
+    "FensapConvergenceStatsJob",
+    "Drop3dConvergenceStatsJob",
+    "Ice3dConvergenceStatsJob",
+]
 


### PR DESCRIPTION
## Summary
- implement convergence analysis jobs for FENSAP, DROP3D and ICE3D
- export new jobs via `glacium.jobs`
- update module `__all__`

## Testing
- `pip install click pyyaml rich jinja2 coloredlogs verboselogs numpy matplotlib`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873747a05648327a78cd4c276286433