### PR TITLE
Add convergence stats to solver recipe

### DIFF
--- a/glacium/recipes/solver.py
+++ b/glacium/recipes/solver.py
@@ -14,6 +14,9 @@ class SolverRecipe(BaseRecipe):
     def build(self, project):
         return [
             JobFactory.create("FENSAP_RUN", project),
+            JobFactory.create("FENSAP_CONVERGENCE_STATS", project),
             JobFactory.create("DROP3D_RUN", project),
+            JobFactory.create("DROP3D_CONVERGENCE_STATS", project),
             JobFactory.create("ICE3D_RUN", project),
+            JobFactory.create("ICE3D_CONVERGENCE_STATS", project),
         ]

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -29,4 +29,4 @@ def test_composite_recipe_build(tmp_path):
     recipe = RecipeManager.create("prep+solver")
     jobs = recipe.build(project)
 
-    assert len(jobs) == 8
+    assert len(jobs) == 11


### PR DESCRIPTION
## Summary
- add convergence statistic jobs to the solver recipe
- update recipe test for new job count

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68737b0d8a848327b901b475695554db