### PR TITLE
Add solver time parsing utility

### DIFF
--- a/glacium/utils/__init__.py
+++ b/glacium/utils/__init__.py
@@ -13,3 +13,4 @@ from .convergence import (
     aggregate_report,
     plot_stats,
 )
+from .solver_time import parse_execution_time

--- a/glacium/utils/solver_time.py
+++ b/glacium/utils/solver_time.py
@@ -1,0 +1,34 @@
+"""Parsing helpers for solver timing information."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from collections import deque
+import re
+
+__all__ = ["parse_execution_time"]
+
+# Pattern for lines like: "total simulation = 00:08:30.27"
+_TOTAL_RE = re.compile(r"total simulation\s*=\s*([0-9:.]+)")
+# Pattern for lines like: "Wall time for calculations:      508.852 s."
+_WALL_RE = re.compile(r"Wall time for calculations:\s*([0-9.]+\s*s)\.?")
+
+
+def parse_execution_time(path: Path, last_lines: int = 30) -> str | None:
+    """Return the solver execution time from ``path``.
+
+    Only the last ``last_lines`` of the file are scanned for known timing
+    patterns.  If no pattern is found, ``None`` is returned.
+    """
+
+    lines = deque(maxlen=last_lines)
+    with Path(path).open(encoding="utf-8", errors="ignore") as fh:
+        for line in fh:
+            lines.append(line)
+
+    tail = "".join(lines)
+    for regex in (_TOTAL_RE, _WALL_RE):
+        m = regex.search(tail)
+        if m:
+            return m.group(1).strip().rstrip(".")
+    return None

--- a/tests/test_solver_time.py
+++ b/tests/test_solver_time.py
@@ -1,0 +1,32 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from glacium.utils.solver_time import parse_execution_time
+
+
+def test_parse_execution_time_total_sim(tmp_path):
+    log = tmp_path / ".solvercmd.out"
+    lines = [
+        "some output",
+        "more output",
+        "     |               total simulation = 01:23:45.67 |",
+    ]
+    log.write_text("\n".join(lines))
+    assert parse_execution_time(log, last_lines=5) == "01:23:45.67"
+
+
+def test_parse_execution_time_wall_time(tmp_path):
+    log = tmp_path / ".solvercmd.out"
+    lines = [
+        "random line",
+        "     |  Wall time for calculations:      123.456 s. |",
+    ]
+    log.write_text("\n".join(lines))
+    assert parse_execution_time(log, last_lines=5) == "123.456 s"
+
+
+def test_parse_execution_time_none(tmp_path):
+    log = tmp_path / ".solvercmd.out"
+    log.write_text("no timing info here")
+    assert parse_execution_time(log) is None


### PR DESCRIPTION
## Summary
- add `parse_execution_time` in new `glacium/utils/solver_time.py`
- export the new helper from `glacium.utils`
- provide unit tests for parsing solver timing information

## Testing
- `pytest tests/test_solver_time.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687391e3c5588327a36f8b4bfab43b38