### PR TITLE
Add project-level CL/CD stats utility

### DIFF
--- a/glacium/utils/convergence.py
+++ b/glacium/utils/convergence.py
@@ -14,6 +14,7 @@ __all__ = [
     "cl_cd_stats",
     "execution_time",
     "cl_cd_summary",
+    "project_cl_cd_stats",
     "aggregate_report",
     "plot_stats",
     "analysis",
@@ -192,6 +193,42 @@ def aggregate_report(
         np.vstack(means) if means else np.empty((0, 0)),
         np.vstack(stds) if stds else np.empty((0, 0)),
     )
+
+
+def project_cl_cd_stats(report_dir: Path, n: int = 15) -> tuple[float, float, float, float]:
+    """Return overall mean and std deviation of lift/drag coefficients.
+
+    Parameters
+    ----------
+    report_dir:
+        Directory containing ``converg.fensap.*`` files.
+    n:
+        Number of trailing rows considered when computing statistics.
+    """
+
+    import numpy as np
+
+    first = next(iter(sorted(Path(report_dir).glob("converg.fensap.*"))), None)
+    if first is None:
+        return float("nan"), float("nan"), float("nan"), float("nan")
+
+    labels = parse_headers(first)
+    try:
+        cl_idx = labels.index("lift coefficient")
+        cd_idx = labels.index("drag coefficient")
+    except ValueError:
+        return float("nan"), float("nan"), float("nan"), float("nan")
+
+    _, means, stds = aggregate_report(report_dir, n)
+    if not means.size:
+        return float("nan"), float("nan"), float("nan"), float("nan")
+
+    cl_mean = float(np.mean(means[:, cl_idx]))
+    cl_std = float(np.mean(stds[:, cl_idx]))
+    cd_mean = float(np.mean(means[:, cd_idx]))
+    cd_std = float(np.mean(stds[:, cd_idx]))
+
+    return cl_mean, cl_std, cd_mean, cd_std
 
 
 def plot_stats(

--- a/tests/test_project_cl_cd_stats.py
+++ b/tests/test_project_cl_cd_stats.py
@@ -1,0 +1,49 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import numpy as np
+import pytest
+
+from glacium.utils.convergence import project_cl_cd_stats
+
+
+def test_project_cl_cd_stats(tmp_path):
+    report_dir = tmp_path / "report"
+    report_dir.mkdir()
+
+    data1 = np.array([
+        [1.0, 2.0],
+        [3.0, 4.0],
+        [5.0, 6.0],
+    ])
+    data2 = np.array([
+        [2.0, 4.0],
+        [4.0, 8.0],
+        [6.0, 12.0],
+    ])
+
+    lines = ["# 1 lift coefficient", "# 1 drag coefficient"]
+    (report_dir / "converg.fensap.000001").write_text(
+        "\n".join(lines + [" ".join(map(str, row)) for row in data1])
+    )
+    (report_dir / "converg.fensap.000002").write_text(
+        "\n".join(lines + [" ".join(map(str, row)) for row in data2])
+    )
+
+    cl_mean, cl_std, cd_mean, cd_std = project_cl_cd_stats(report_dir, n=2)
+
+    means1 = data1[-2:].mean(axis=0)
+    stds1 = data1[-2:].std(axis=0)
+    means2 = data2[-2:].mean(axis=0)
+    stds2 = data2[-2:].std(axis=0)
+
+    exp_cl_mean = np.mean([means1[0], means2[0]])
+    exp_cl_std = np.mean([stds1[0], stds2[0]])
+    exp_cd_mean = np.mean([means1[1], means2[1]])
+    exp_cd_std = np.mean([stds1[1], stds2[1]])
+
+    assert cl_mean == pytest.approx(exp_cl_mean)
+    assert cl_std == pytest.approx(exp_cl_std)
+    assert cd_mean == pytest.approx(exp_cd_mean)
+    assert cd_std == pytest.approx(exp_cd_std)


### PR DESCRIPTION
## Summary
- compute overall mean and std of lift and drag coefficients across convergence files
- expose function in utils package
- test project_cl_cd_stats with synthetic data

## Testing
- `pytest tests/test_project_cl_cd_stats.py::test_project_cl_cd_stats -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873940988308327b79545c4c11a3c7d