### PR TITLE
Support per-shot timings in MultiShot runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ The command prints the generated project UID. All projects live below
 `./runs/<UID>` in the current working directory. ``glacium new`` and ``glacium init`` parse ``case.yaml`` and write ``global_config.yaml`` automatically.
 When running multishot jobs the template files for each shot are generated
 automatically. After editing ``case.yaml`` you can run ``glacium update`` to
-regenerate the configuration.
+regenerate the configuration.  Set ``CASE_MULTISHOT`` in ``case.yaml`` to a list
+of icing times for each shot.
 
 ### Case sweep
 

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -44,7 +44,8 @@ and ``glacium init`` the ``case.yaml`` file is parsed and the resulting
 ``global_config.yaml`` is written automatically.  If you change
 ``case.yaml`` later you can run ``glacium update`` to rebuild the
 configuration. When multishot jobs run, template files for each shot index are
-created automatically before launching the solver.
+created automatically before launching the solver.  Use ``CASE_MULTISHOT`` in
+``case.yaml`` to specify the icing time of each cycle.
 
 Case sweep
 ~~~~~~~~~~

--- a/glacium/jobs/fensap_jobs.py
+++ b/glacium/jobs/fensap_jobs.py
@@ -101,13 +101,24 @@ class MultiShotRunJob(FensapScriptJob):
             tm.render_to_file(tpl, ctx, work / dest)
 
         count = self.project.config.get("MULTISHOT_COUNT", 10)
+        timings = self.project.config.get("CASE_MULTISHOT")
+        start = 0.0
+        default_total = ctx.get("ICE_GUI_TOTAL_TIME")
         for i in range(1, count + 1):
+            total = (
+                timings[i - 1]
+                if isinstance(timings, list) and i - 1 < len(timings)
+                else default_total
+            )
             shot_ctx = {
                 **ctx,
                 "shot_index": f"{i:06d}",
                 "prev_shot_index": f"{i-1:06d}" if i > 1 else None,
                 "next_shot_index": f"{i+1:06d}",
+                "ICE_GUI_INITIAL_TIME": start,
+                "ICE_GUI_TOTAL_TIME": total,
             }
+            start += total if total is not None else 0
             for tpl, name_fmt in self.shot_templates.items():
                 dest_name = name_fmt.format(idx=f"{i:06d}")
                 tm.render_to_file(tpl, shot_ctx, work / dest_name)

--- a/glacium/utils/case_to_global.py
+++ b/glacium/utils/case_to_global.py
@@ -51,6 +51,7 @@ def generate_global_defaults(case_path: Path, template_path: Path) -> Dict[str, 
     lwc = float(case.get("CASE_LWC", 0.0))
     yplus = float(case.get("CASE_YPLUS", 1.0))
     refinement = float(case.get("PWS_REFINEMENT", cfg.get("PWS_REFINEMENT", 1)))
+    multishot = case.get("CASE_MULTISHOT")
 
     # Ambient conditions ------------------------------------------------------
     pressure = _ambient_pressure(altitude)
@@ -138,5 +139,7 @@ def generate_global_defaults(case_path: Path, template_path: Path) -> Dict[str, 
     cfg["CASE_MVD"] = mvd
     cfg["CASE_LWC"] = lwc
     cfg["CASE_YPLUS"] = yplus
+    if multishot is not None:
+        cfg["CASE_MULTISHOT"] = list(multishot)
 
     return cfg

--- a/tests/test_multishot_timings.py
+++ b/tests/test_multishot_timings.py
@@ -1,0 +1,67 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from glacium.jobs import fensap_jobs
+from glacium.jobs.fensap_jobs import MultiShotRunJob
+from glacium.managers.template_manager import TemplateManager
+from glacium.models.config import GlobalConfig
+from glacium.managers.path_manager import PathBuilder
+from glacium.models.project import Project
+
+
+def test_multishot_timings(monkeypatch, tmp_path):
+    template_root = tmp_path / "templates"
+    template_root.mkdir()
+    monkeypatch.setattr(fensap_jobs, "__file__", str(tmp_path / "pkg" / "fensap_jobs.py"))
+
+    # minimal required templates
+    names = [
+        "MULTISHOT.meshingSizes.scm.j2",
+        "MULTISHOT.custom_remeshing.sh.j2",
+        "MULTISHOT.solvercmd.j2",
+        "MULTISHOT.files.j2",
+        "MULTISHOT.config.par.j2",
+        "MULTISHOT.fensap.par.j2",
+        "MULTISHOT.drop.par.j2",
+        "MULTISHOT.ice.par.j2",
+        "MULTISHOT.create-2.5D-mesh.bin.j2",
+        "MULTISHOT.remeshing.jou.j2",
+        "MULTISHOT.fluent_config.jou.j2",
+        "config.fensap.j2",
+        "config.drop.j2",
+        "files.drop.j2",
+        "files.fensap.j2",
+    ]
+    for n in names:
+        content = "exit 0" if n == "MULTISHOT.solvercmd.j2" else "x"
+        (template_root / n).write_text(content)
+
+    # template under test prints timing values
+    (template_root / "config.ice.j2").write_text("{{ ICE_GUI_INITIAL_TIME }} {{ ICE_GUI_TOTAL_TIME }}")
+
+    cfg = GlobalConfig(project_uid="uid", base_dir=tmp_path)
+    cfg["FENSAP_EXE"] = "sh"
+    cfg["MULTISHOT_COUNT"] = 3
+    cfg["CASE_MULTISHOT"] = [1, 2, 3]
+
+    paths = PathBuilder(tmp_path).build()
+    paths.ensure()
+    TemplateManager(template_root)
+
+    project = Project("uid", tmp_path, cfg, paths, [])
+    job = MultiShotRunJob(project)
+    job.execute()
+
+    work = paths.solver_dir("run_MULTISHOT")
+    expect = [
+        (0, 1),
+        (1, 2),
+        (3, 3),
+    ]
+    for i, pair in enumerate(expect, 1):
+        idx = f"{i:06d}"
+        text = (work / f"config.ice.{idx}").read_text().strip()
+        nums = [float(x) for x in text.split()]
+        assert nums == [float(pair[0]), float(pair[1])]
+


### PR DESCRIPTION
## Summary
- support optional `CASE_MULTISHOT` list when generating global defaults
- adjust `MultiShotRunJob.prepare` to use the list for `ICE_GUI_INITIAL_TIME` and `ICE_GUI_TOTAL_TIME`
- add regression test verifying shot timing handling
- document `CASE_MULTISHOT` briefly in README and quick_start

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687405acdf88832791380e30bf73b84b