### PR TITLE
Add PDF reporting to solver convergence jobs

### DIFF
--- a/glacium/jobs/analysis_jobs.py
+++ b/glacium/jobs/analysis_jobs.py
@@ -3,6 +3,7 @@
 from glacium.models.job import Job
 from glacium.engines.py_engine import PyEngine
 from glacium.utils.convergence import analysis, analysis_file
+from glacium.utils.report_converg_fensap import build_report
 
 
 class ConvergenceStatsJob(Job):
@@ -19,6 +20,11 @@ class ConvergenceStatsJob(Job):
         engine = PyEngine(analysis)
         engine.run([report_dir, out_dir], cwd=project_root)
 
+        if self.project.config.get("CONVERGENCE_PDF"):
+            files = sorted(report_dir.glob("converg.fensap.*"))
+            if files:
+                build_report(files[-1], out_dir / "report.pdf")
+
 
 class FensapConvergenceStatsJob(Job):
     """Generate convergence plots for a FENSAP run."""
@@ -33,6 +39,9 @@ class FensapConvergenceStatsJob(Job):
 
         engine = PyEngine(analysis_file)
         engine.run([converg_file, out_dir], cwd=project_root)
+
+        if self.project.config.get("CONVERGENCE_PDF"):
+            build_report(converg_file, out_dir / "report.pdf")
 
 
 class Drop3dConvergenceStatsJob(Job):
@@ -49,6 +58,9 @@ class Drop3dConvergenceStatsJob(Job):
         engine = PyEngine(analysis_file)
         engine.run([converg_file, out_dir], cwd=project_root)
 
+        if self.project.config.get("CONVERGENCE_PDF"):
+            build_report(converg_file, out_dir / "report.pdf")
+
 
 class Ice3dConvergenceStatsJob(Job):
     """Generate convergence plots for an ICE3D run."""
@@ -63,6 +75,9 @@ class Ice3dConvergenceStatsJob(Job):
 
         engine = PyEngine(analysis_file)
         engine.run([converg_file, out_dir], cwd=project_root)
+
+        if self.project.config.get("CONVERGENCE_PDF"):
+            build_report(converg_file, out_dir / "report.pdf")
 
 
 __all__ = [

--- a/tests/test_convergence_stats.py
+++ b/tests/test_convergence_stats.py
@@ -54,10 +54,14 @@ def test_analysis_returns_expected_stats(report_dirs, tmp_path, monkeypatch):
     assert (out_dir / "cl_cd_stats.csv").exists()
 
 
-def test_convergence_stats_job_creates_plots(report_dirs, tmp_path):
+def test_convergence_stats_job_creates_plots(report_dirs, tmp_path, monkeypatch):
+    monkeypatch.setenv("FPDF_FONT_DIR", "/usr/share/fonts/truetype/dejavu")
+    from fpdf import fpdf
+    monkeypatch.setattr(fpdf, "FPDF_FONT_DIR", "/usr/share/fonts/truetype/dejavu", raising=False)
     report, out_dir, _, _ = report_dirs
 
     cfg = GlobalConfig(project_uid="uid", base_dir=tmp_path)
+    cfg["CONVERGENCE_PDF"] = True
     paths = PathBuilder(tmp_path).build()
     paths.ensure()
     project = Project("uid", tmp_path, cfg, paths, [])
@@ -71,6 +75,7 @@ def test_convergence_stats_job_creates_plots(report_dirs, tmp_path):
     assert job.status is JobStatus.DONE
     assert (out_dir / "column_00.png").exists()
     assert (out_dir / "column_01.png").exists()
+    assert (out_dir / "report.pdf").exists()
 
 
 def test_cl_cd_stats_returns_means(report_dirs):

--- a/tests/test_solver_convergence_stats_jobs.py
+++ b/tests/test_solver_convergence_stats_jobs.py
@@ -28,7 +28,10 @@ from glacium.models.job import JobStatus
         (Ice3dConvergenceStatsJob, "run_ICE3D", "iceconv.dat"),
     ],
 )
-def test_solver_convergence_stats_jobs(tmp_path, job_cls, solver_dir, filename):
+def test_solver_convergence_stats_jobs(tmp_path, job_cls, solver_dir, filename, monkeypatch):
+    monkeypatch.setenv("FPDF_FONT_DIR", "/usr/share/fonts/truetype/dejavu")
+    from fpdf import fpdf
+    monkeypatch.setattr(fpdf, "FPDF_FONT_DIR", "/usr/share/fonts/truetype/dejavu", raising=False)
     run_dir = tmp_path / solver_dir
     run_dir.mkdir()
     conv_file = run_dir / filename
@@ -46,6 +49,7 @@ def test_solver_convergence_stats_jobs(tmp_path, job_cls, solver_dir, filename):
     conv_file.write_text("\n".join(lines))
 
     cfg = GlobalConfig(project_uid="uid", base_dir=tmp_path)
+    cfg["CONVERGENCE_PDF"] = True
     paths = PathBuilder(tmp_path).build()
     paths.ensure()
     project = Project("uid", tmp_path, cfg, paths, [])
@@ -60,6 +64,7 @@ def test_solver_convergence_stats_jobs(tmp_path, job_cls, solver_dir, filename):
     out_dir = tmp_path / "analysis"
     assert (out_dir / "column_00.png").exists()
     assert (out_dir / "column_01.png").exists()
+    assert (out_dir / "report.pdf").exists()
     stats_file = out_dir / "stats.csv"
     assert stats_file.exists()
 


### PR DESCRIPTION
## Summary
- generate a convergence PDF in `analysis_jobs` when `CONVERGENCE_PDF` flag is enabled
- expect the PDF in unit tests
- adjust tests to configure FPDF font directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874bf37cb308327a0aa5d10b3c8bd32