### PR TITLE
Add PyFPDF warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ Install the package with `pip` (Python 3.12 or newer is required):
 pip install .
 ```
 
+**Warning**: make sure the old `pyfpdf` package is **not** installed alongside
+`fpdf2`. The two libraries conflict and can lead to runtime errors. If you see a
+warning about PyFPDF, run:
+
+```bash
+pip uninstall --yes pyfpdf
+```
+
 This exposes a `glacium` command via the console script entry point.
 
 ## Usage

--- a/docs/glacium.utils.rst
+++ b/docs/glacium.utils.rst
@@ -56,7 +56,13 @@ analysed manually:
 
 .. code-block:: bash
 
-   python -m glacium.utils.convergence analysis run_MULTISHOT analysis
+    python -m glacium.utils.convergence analysis run_MULTISHOT analysis
+
+If you see a warning about PyFPDF, uninstall the incompatible package:
+
+.. code-block:: bash
+
+   pip uninstall --yes pyfpdf
 
 This command creates ``analysis/cl_cd_stats.csv`` and ``analysis/cl_cd.png``.
 The CSV starts with headers ``index,CL,CD`` and might look like:


### PR DESCRIPTION
## Summary
- warn about PyFPDF in README and mention how to remove it
- mention the same note in convergence analysis docs

## Testing
- `pip install .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874d5148d288327b198d7280f94d497