### PR TITLE
Save solver convergence figures in analysis/figures

### DIFF
--- a/docs/glacium.utils.rst
+++ b/docs/glacium.utils.rst
@@ -64,7 +64,7 @@ If you see a warning about PyFPDF, uninstall the incompatible package:
 
    pip uninstall --yes pyfpdf
 
-This command creates ``analysis/cl_cd_stats.csv`` and ``analysis/cl_cd.png``.
+This command creates ``analysis/cl_cd_stats.csv`` and ``analysis/figures/cl_cd.png``.
 The CSV starts with headers ``index,CL,CD`` and might look like:
 
 .. code-block:: text

--- a/glacium/utils/convergence.py
+++ b/glacium/utils/convergence.py
@@ -244,7 +244,8 @@ def plot_stats(
     import numpy as np
 
     out = Path(out_dir)
-    out.mkdir(parents=True, exist_ok=True)
+    fig_dir = out / "figures"
+    fig_dir.mkdir(parents=True, exist_ok=True)
 
     ind = np.array(list(indices))
     lbls = list(labels or [])
@@ -256,7 +257,7 @@ def plot_stats(
         plt.ylabel(ylabel)
         plt.grid(True)
         plt.tight_layout()
-        plt.savefig(out / f"column_{col:02d}.png")
+        plt.savefig(fig_dir / f"column_{col:02d}.png")
         plt.close()
 
 
@@ -277,6 +278,7 @@ def analysis(cwd: Path, args: "Sequence[str | Path]") -> None:
 
     report_dir = Path(args[0])
     out_dir = Path(args[1])
+    fig_dir = out_dir / "figures"
 
     idx, means, stds = aggregate_report(report_dir)
 
@@ -292,6 +294,7 @@ def analysis(cwd: Path, args: "Sequence[str | Path]") -> None:
         import matplotlib.pyplot as plt
 
         out_dir.mkdir(parents=True, exist_ok=True)
+        fig_dir.mkdir(parents=True, exist_ok=True)
 
         np.savetxt(
             out_dir / "cl_cd_stats.csv",
@@ -309,7 +312,7 @@ def analysis(cwd: Path, args: "Sequence[str | Path]") -> None:
         plt.grid(True)
         plt.legend()
         plt.tight_layout()
-        plt.savefig(out_dir / "cl_cd.png")
+        plt.savefig(fig_dir / "cl_cd.png")
         plt.close()
 
 
@@ -330,6 +333,7 @@ def analysis_file(cwd: Path, args: "Sequence[str | Path]") -> None:
 
     file = Path(args[0])
     out_dir = Path(args[1])
+    fig_dir = out_dir / "figures"
 
     import numpy as np
     import matplotlib.pyplot as plt
@@ -337,6 +341,7 @@ def analysis_file(cwd: Path, args: "Sequence[str | Path]") -> None:
     labels, data = read_history_with_labels(file)
 
     out_dir.mkdir(parents=True, exist_ok=True)
+    fig_dir.mkdir(parents=True, exist_ok=True)
 
     iterations = np.arange(1, data.shape[0] + 1)
     for col in range(data.shape[1]):
@@ -347,7 +352,7 @@ def analysis_file(cwd: Path, args: "Sequence[str | Path]") -> None:
         plt.ylabel(ylabel)
         plt.grid(True)
         plt.tight_layout()
-        plt.savefig(out_dir / f"column_{col:02d}.png")
+        plt.savefig(fig_dir / f"column_{col:02d}.png")
         plt.close()
 
     mean, _ = stats_last_n(data, 15)
@@ -382,5 +387,5 @@ def analysis_file(cwd: Path, args: "Sequence[str | Path]") -> None:
     plt.grid(True)
     plt.legend()
     plt.tight_layout()
-    plt.savefig(out_dir / "cl_cd.png")
+    plt.savefig(fig_dir / "cl_cd.png")
     plt.close()

--- a/tests/test_convergence_stats.py
+++ b/tests/test_convergence_stats.py
@@ -73,8 +73,9 @@ def test_convergence_stats_job_creates_plots(report_dirs, tmp_path, monkeypatch)
     jm.run()
 
     assert job.status is JobStatus.DONE
-    assert (out_dir / "column_00.png").exists()
-    assert (out_dir / "column_01.png").exists()
+    fig_dir = out_dir / "figures"
+    assert (fig_dir / "column_00.png").exists()
+    assert (fig_dir / "column_01.png").exists()
     assert (out_dir / "report.pdf").exists()
 
 

--- a/tests/test_single_convergence_stats.py
+++ b/tests/test_single_convergence_stats.py
@@ -29,8 +29,9 @@ def test_single_convergence_stats(tmp_path):
 
     analysis_file(tmp_path, [conv_file, out_dir])
 
-    assert (out_dir / "column_00.png").exists()
-    assert (out_dir / "column_01.png").exists()
+    fig_dir = out_dir / "figures"
+    assert (fig_dir / "column_00.png").exists()
+    assert (fig_dir / "column_01.png").exists()
     stats_file = out_dir / "stats.csv"
     assert stats_file.exists()
 

--- a/tests/test_solver_convergence_stats_jobs.py
+++ b/tests/test_solver_convergence_stats_jobs.py
@@ -62,8 +62,9 @@ def test_solver_convergence_stats_jobs(tmp_path, job_cls, solver_dir, filename, 
 
     assert job.status is JobStatus.DONE
     out_dir = tmp_path / "analysis"
-    assert (out_dir / "column_00.png").exists()
-    assert (out_dir / "column_01.png").exists()
+    fig_dir = out_dir / "figures"
+    assert (fig_dir / "column_00.png").exists()
+    assert (fig_dir / "column_01.png").exists()
     assert (out_dir / "report.pdf").exists()
     stats_file = out_dir / "stats.csv"
     assert stats_file.exists()


### PR DESCRIPTION
## Summary
- store all generated PNGs inside an `analysis/figures` directory
- update analysis utilities to create and use the new folder
- expect figure output path inside tests
- document the new locations in the utils documentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874ed3489d883279a8ed339955088d6