### PR TITLE
Improve Job discovery error handling

### DIFF
--- a/glacium/utils/JobIndex.py
+++ b/glacium/utils/JobIndex.py
@@ -9,7 +9,13 @@ from typing import Iterable, Dict, Optional, Type
 from glacium.models.job import Job
 from glacium.utils.logging import log
 
-__all__ = ["JobFactory", "list_jobs", "get_job_class", "create_job"]
+__all__ = [
+    "JobFactory",
+    "list_jobs",
+    "get_job_class",
+    "create_job",
+    "get_import_errors",
+]
 
 
 class JobFactory:
@@ -18,6 +24,7 @@ class JobFactory:
     _jobs: Dict[str, Type[Job]] | None = None
     _loaded: bool = False
     _PACKAGES: Iterable[str] = ["glacium.jobs", "glacium.engines", "glacium.recipes"]
+    _import_errors: Dict[str, Exception] | None = None
 
     # ------------------------------------------------------------------
     @classmethod
@@ -40,6 +47,11 @@ class JobFactory:
 
         cls._load()
         if name not in cls._jobs:  # type: ignore[arg-type]
+            if cls._import_errors:
+                mods = ", ".join(sorted(cls._import_errors))
+                raise RuntimeError(
+                    f"Job '{name}' nicht bekannt. Fehler beim Import folgender Module: {mods}"
+                )
             raise KeyError(f"Job '{name}' nicht bekannt.")
         return cls._jobs[name](project)  # type: ignore[index]
 
@@ -64,6 +76,8 @@ class JobFactory:
     def _load(cls) -> None:
         if cls._jobs is None:
             cls._jobs = {}
+        if cls._import_errors is None:
+            cls._import_errors = {}
         if not cls._loaded:
             cls._discover()
             cls._loaded = True
@@ -72,17 +86,27 @@ class JobFactory:
     def _discover(cls) -> None:
         """Import all modules from known packages to populate registry."""
 
+        cls._import_errors.clear()
+
         for pkg_name in cls._PACKAGES:
             try:
                 pkg = importlib.import_module(pkg_name)
-            except ModuleNotFoundError:
+            except ModuleNotFoundError as err:
+                cls._import_errors[pkg_name] = err
+                log.warning(f"Failed to import {pkg_name}: {err}")
                 continue
             for mod in pkgutil.walk_packages(pkg.__path__, pkg_name + "."):
                 try:
                     importlib.import_module(mod.name)
-                except Exception:
-                    # ignore faulty modules during discovery
-                    pass
+                except Exception as err:
+                    cls._import_errors[mod.name] = err
+                    log.warning(f"Failed to import {mod.name}: {err}")
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def get_import_errors(cls) -> Dict[str, Exception]:
+        cls._load()
+        return dict(cls._import_errors)
 
 
 # Backwards compatible helper functions --------------------------------------
@@ -96,3 +120,7 @@ def get_job_class(name: str) -> Optional[Type[Job]]:
 
 def create_job(name: str, project) -> Job:
     return JobFactory.create(name, project)
+
+
+def get_import_errors() -> Dict[str, Exception]:
+    return JobFactory.get_import_errors()

--- a/tests/test_job_import_errors.py
+++ b/tests/test_job_import_errors.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from glacium.utils.JobIndex import JobFactory
+
+
+def test_missing_dependency_runtime_error(tmp_path, monkeypatch):
+    pkg = tmp_path / "fake_pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "bad_job.py").write_text(
+        "import nonexistent_dependency\nfrom glacium.models.job import Job\nclass BadJob(Job):\n    name = 'BAD_JOB'\n"
+    )
+
+    monkeypatch.syspath_prepend(tmp_path)
+    monkeypatch.setattr(JobFactory, "_PACKAGES", ["fake_pkg"])
+    monkeypatch.setattr(JobFactory, "_jobs", None)
+    monkeypatch.setattr(JobFactory, "_loaded", False)
+    monkeypatch.setattr(JobFactory, "_import_errors", None)
+
+    with pytest.raises(RuntimeError) as exc:
+        JobFactory.create("BAD_JOB", None)
+
+    msg = str(exc.value)
+    assert "fake_pkg.bad_job" in msg
+    assert "BAD_JOB" in msg


### PR DESCRIPTION
## Summary
- record import errors during job discovery
- surface import errors in `JobFactory.create`
- add helper to inspect import errors
- test runtime failure from missing job dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874f5d342b88327981a0710b4091d83