### PR TITLE
Update convergence report API usage

### DIFF
--- a/glacium/jobs/analysis_jobs.py
+++ b/glacium/jobs/analysis_jobs.py
@@ -24,7 +24,7 @@ class ConvergenceStatsJob(Job):
             files = sorted(report_dir.glob("converg.fensap.*"))
             if files:
                 PyEngine(analysis_file).run([files[-1], out_dir], cwd=project_root)
-            build_report(out_dir, out_dir / "report.pdf")
+            build_report(out_dir)
 
 
 class FensapConvergenceStatsJob(Job):
@@ -42,7 +42,7 @@ class FensapConvergenceStatsJob(Job):
         engine.run([converg_file, out_dir], cwd=project_root)
 
         if self.project.config.get("CONVERGENCE_PDF"):
-            build_report(out_dir, out_dir / "report.pdf")
+            build_report(out_dir)
 
 
 class Drop3dConvergenceStatsJob(Job):
@@ -60,7 +60,7 @@ class Drop3dConvergenceStatsJob(Job):
         engine.run([converg_file, out_dir], cwd=project_root)
 
         if self.project.config.get("CONVERGENCE_PDF"):
-            build_report(out_dir, out_dir / "report.pdf")
+            build_report(out_dir)
 
 
 class Ice3dConvergenceStatsJob(Job):
@@ -78,7 +78,7 @@ class Ice3dConvergenceStatsJob(Job):
         engine.run([converg_file, out_dir], cwd=project_root)
 
         if self.project.config.get("CONVERGENCE_PDF"):
-            build_report(out_dir, out_dir / "report.pdf")
+            build_report(out_dir)
 
 
 __all__ = [

--- a/glacium/utils/report_converg_fensap.py
+++ b/glacium/utils/report_converg_fensap.py
@@ -78,7 +78,11 @@ class ConvPDF(FPDF):
 # -------------------------------------------------------------------------
 # 5)  Hauptfunktion
 # -------------------------------------------------------------------------
-def build_report(analysis_dir: Path, output_file: Path, n: int = 15) -> None:
+def build_report(
+    analysis_dir: Path,
+    output_file: Path | None = None,
+    n: int = 15,
+) -> Path:
     """Create a PDF report from ``analysis_dir``.
 
     Parameters
@@ -90,6 +94,9 @@ def build_report(analysis_dir: Path, output_file: Path, n: int = 15) -> None:
     n:
         Number of trailing iterations represented in ``stats.csv``.
     """
+
+    if output_file is None:
+        output_file = analysis_dir / "report.pdf"
 
     stats_file = analysis_dir / "stats.csv"
     labels, mean, var = read_stats(stats_file)
@@ -112,6 +119,8 @@ def build_report(analysis_dir: Path, output_file: Path, n: int = 15) -> None:
 
     pdf.output(str(output_file))
     log.success(f"Report geschrieben → {output_file}")
+
+    return output_file
 
 # -------------------------------------------------------------------------
 # 6)  CLI-Wrapper


### PR DESCRIPTION
## Summary
- adapt `build_report()` to accept the analysis directory alone
- call new `build_report()` API from convergence stats jobs

## Testing
- `pytest -q`
- `pytest tests/test_solver_convergence_stats_jobs.py::test_solver_convergence_stats_jobs -q`


------
https://chatgpt.com/codex/tasks/task_e_687505369034832789b86b30edf67745