### PR TITLE
Update docs for new convergence report helper

### DIFF
--- a/docs/glacium.utils.rst
+++ b/docs/glacium.utils.rst
@@ -90,6 +90,20 @@ You can run it manually with:
 
    python -m glacium.utils.convergence analysis_file run_FENSAP/converg analysis
 
+Report creation
+---------------
+
+After generating the convergence statistics you can turn the results
+into a PDF report using :mod:`glacium.utils.report_converg_fensap`.  The
+command reads ``analysis/stats.csv`` in the analysis directory and writes
+``analysis/report.pdf``.  If the required fonts are not found, set the
+``FPDF_FONT_DIR`` environment variable to the directory containing the
+fonts before running the helper.
+
+.. code-block:: bash
+
+   python -m glacium.utils.report_converg_fensap analysis
+
 Module contents
 ---------------
 

--- a/docs/pipeline.rst
+++ b/docs/pipeline.rst
@@ -28,8 +28,11 @@ UIDs.  Additional layouts can be registered by placing modules in the
 Meta Report Generation
 ----------------------
 
-Passing ``--pdf`` merges the ``analysis/report.pdf`` files of all
-pipeline projects into a single document.  A summary page with lift and
-drag statistics is prepended to the merged PDF which is written to
-``<runs>_summary.pdf`` in the parent directory of the runs root.  Use
-``--no-pdf`` to disable this behaviour.
+Individual projects can create ``analysis/report.pdf`` with
+``python -m glacium.utils.report_converg_fensap analysis`` after
+the solver statistics have been written.  Set ``FPDF_FONT_DIR`` if you
+need to use custom fonts.  Passing ``--pdf`` merges those reports into a
+single document.  A summary page with lift and drag statistics is
+prepended to the merged PDF which is written to ``<runs>_summary.pdf`` in
+the parent directory of the runs root.  Use ``--no-pdf`` to disable this
+behaviour.


### PR DESCRIPTION
## Summary
- document generating PDF reports via `report_converg_fensap`
- explain how to set `FPDF_FONT_DIR` when using custom fonts
- show how pipeline merges the generated PDF reports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68750d5079ac832789b6c0f2567e63a7