### PR TITLE
Use csv writer for convergence stats

### DIFF
--- a/glacium/utils/convergence.py
+++ b/glacium/utils/convergence.py
@@ -337,6 +337,7 @@ def analysis_file(cwd: Path, args: "Sequence[str | Path]") -> None:
 
     import numpy as np
     import matplotlib.pyplot as plt
+    import csv
 
     labels, data = read_history_with_labels(file)
 
@@ -359,10 +360,11 @@ def analysis_file(cwd: Path, args: "Sequence[str | Path]") -> None:
     variance = np.var(data[-15:], axis=0)
 
     with (out_dir / "stats.csv").open("w", newline="") as fh:
-        fh.write("label,mean,variance\n")
+        writer = csv.writer(fh)
+        writer.writerow(["label", "mean", "variance"])
         for col in range(data.shape[1]):
             label = labels[col] if col < len(labels) else f"column {col}"
-            fh.write(f"{label},{mean[col]},{variance[col]}\n")
+            writer.writerow([label, mean[col], variance[col]])
 
     try:
         cl_idx = labels.index("lift coefficient")

--- a/tests/test_single_convergence_stats.py
+++ b/tests/test_single_convergence_stats.py
@@ -28,7 +28,7 @@ def test_single_convergence_stats(tmp_path):
         [7.0, 8.0],
         [9.0, 10.0],
     ])
-    labels = ["foo", "bar"]
+    labels = ["foo", "bar,baz"]
     lines = [f"# 1 {labels[0]}", f"# 2 {labels[1]}"]
     lines += [" ".join(map(str, row)) for row in data]
     conv_file.write_text("\n".join(lines))
@@ -48,6 +48,9 @@ def test_single_convergence_stats(tmp_path):
 
     with stats_file.open() as fh:
         rows = list(csv.DictReader(fh))
+
+    content = stats_file.read_text()
+    assert '"bar,baz"' in content
 
     expected_mean = data.mean(axis=0)
     expected_var = data.var(axis=0)


### PR DESCRIPTION
## Summary
- switch to `csv.writer` when creating stats.csv in `analysis_file`
- cover quoting behavior for comma labels in test

## Testing
- `pip install .`
- `pip install PyPDF2`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687512cc512c83278b8c38fdc482021a