### PR TITLE
Use packaged DejaVu font

### DIFF
--- a/glacium/utils/default_paths.py
+++ b/glacium/utils/default_paths.py
@@ -32,3 +32,18 @@ def default_case_file() -> Path:
     a = repo_root / "config" / "defaults" / "case.yaml"
     b = pkg_root / "config" / "defaults" / "case.yaml"
     return a if a.exists() else b
+
+
+def dejavu_font_file() -> Path:
+    """Return the path to ``DejaVuSans.ttf`` used for PDF reports.
+
+    The copy at the repository root is preferred over the installed package
+    directory.
+    """
+
+    repo_root = Path(__file__).resolve().parents[2]
+    pkg_root = Path(__file__).resolve().parents[1]
+
+    a = repo_root / "glacium" / "DejaVuSans.ttf"
+    b = pkg_root / "DejaVuSans.ttf"
+    return a if a.exists() else b

--- a/glacium/utils/report_config.py
+++ b/glacium/utils/report_config.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Dict, List, Tuple
 
 from fpdf import FPDF            # fpdf2 ≥ 2.x  (pip install fpdf2)
+from glacium.utils.default_paths import dejavu_font_file
 
 # -------------------------------------------------------------------------
 # 1) Konfiguration: Filter + optionale Beschreibungen/Einheiten
@@ -78,7 +79,7 @@ class IcePDF(FPDF):
         super().__init__(format="A4")
         self.set_auto_page_break(True, margin=15)
         # eingebettete Unicode-Schrift
-        self.add_font("DejaVu", "", "DejaVuSans.ttf", uni=True)
+        self.add_font("DejaVu", "", str(dejavu_font_file()), uni=True)
 
     # Kopf- und Fußzeile
     def header(self):

--- a/glacium/utils/report_converg_fensap.py
+++ b/glacium/utils/report_converg_fensap.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import numpy as np
 from fpdf import FPDF  # fpdf2 ≥ 2.x
 from glacium.utils.logging import log
+from glacium.utils.default_paths import dejavu_font_file
 
 # -------------------------------------------------------------------------
 # 1)  Statistikdatei einlesen
@@ -37,7 +38,7 @@ class ConvPDF(FPDF):
         super().__init__(orientation="P", unit="mm", format="A4")
         self.n = n
         self.set_auto_page_break(True, 15)
-        self.add_font("DejaVu", "", "DejaVuSans.ttf", uni=True)
+        self.add_font("DejaVu", "", str(dejavu_font_file()), uni=True)
 
     def header(self):
         self.set_font("DejaVu", "", 14)


### PR DESCRIPTION
## Summary
- centralize lookup for DejaVuSans.ttf in utils.default_paths
- use the helper when adding fonts to FPDF in report modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687517cd83ec832792ce40db8639c71c