### PR TITLE
Include font in wheel build

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ pip uninstall --yes pyfpdf
 
 This exposes a `glacium` command via the console script entry point.
 
+The DejaVuSans.ttf font used for PDF reports ships with the package.
+
 ## Usage
 
 Below is a quick tour through the most important CLI commands. Each

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ exclude = [
     "runs",
     "docs/_build",
 ]
+include = [
+    "glacium/DejaVuSans.ttf",
+]
 version = "0.0.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
## Summary
- include DejaVuSans font via `tool.poetry.include`
- document that the font ships with the package

## Testing
- `poetry build`
- `pytest -k import_package -q`

------
https://chatgpt.com/codex/tasks/task_e_6875198c34b08327a8619521c324401a