### PR TITLE
Add individual CL and CD convergence plots

### DIFF
--- a/glacium/utils/convergence.py
+++ b/glacium/utils/convergence.py
@@ -304,6 +304,26 @@ def analysis(cwd: Path, args: "Sequence[str | Path]") -> None:
             comments="",
         )
 
+        # individual lift/drag plots
+        plt.figure()
+        plt.plot(clcd[:, 0], clcd[:, 1])
+        plt.xlabel("multishot index")
+        plt.ylabel("CL")
+        plt.grid(True)
+        plt.tight_layout()
+        plt.savefig(fig_dir / "cl.png")
+        plt.close()
+
+        plt.figure()
+        plt.plot(clcd[:, 0], clcd[:, 2])
+        plt.xlabel("multishot index")
+        plt.ylabel("CD")
+        plt.grid(True)
+        plt.tight_layout()
+        plt.savefig(fig_dir / "cd.png")
+        plt.close()
+
+        # combined plot
         plt.figure()
         plt.plot(clcd[:, 0], clcd[:, 1], label="CL")
         plt.plot(clcd[:, 0], clcd[:, 2], label="CD")
@@ -381,6 +401,26 @@ def analysis_file(cwd: Path, args: "Sequence[str | Path]") -> None:
         comments="",
     )
 
+    # individual lift/drag plots
+    plt.figure()
+    plt.plot(iterations, data[:, cl_idx])
+    plt.xlabel("iteration")
+    plt.ylabel("CL")
+    plt.grid(True)
+    plt.tight_layout()
+    plt.savefig(fig_dir / "cl.png")
+    plt.close()
+
+    plt.figure()
+    plt.plot(iterations, data[:, cd_idx])
+    plt.xlabel("iteration")
+    plt.ylabel("CD")
+    plt.grid(True)
+    plt.tight_layout()
+    plt.savefig(fig_dir / "cd.png")
+    plt.close()
+
+    # combined plot
     plt.figure()
     plt.plot(iterations, data[:, cl_idx], label="CL")
     plt.plot(iterations, data[:, cd_idx], label="CD")

--- a/glacium/utils/report_converg_fensap.py
+++ b/glacium/utils/report_converg_fensap.py
@@ -113,10 +113,11 @@ def build_report(
 
     pdf.add_table(labels, mean, var)
 
-    fig = analysis_dir / "figures" / "cl_cd.png"
-    if fig.exists():
-        pdf.ln(4)
-        pdf.image(str(fig), w=160)
+    for name in ("cl_cd.png", "cl.png", "cd.png"):
+        fig = analysis_dir / "figures" / name
+        if fig.exists():
+            pdf.ln(4)
+            pdf.image(str(fig), w=160)
 
     pdf.output(str(output_file))
     log.success(f"Report geschrieben → {output_file}")

--- a/tests/test_convergence_stats.py
+++ b/tests/test_convergence_stats.py
@@ -77,6 +77,9 @@ def test_convergence_stats_job_creates_plots(report_dirs, tmp_path, monkeypatch)
     fig_dir = out_dir / "figures"
     assert (fig_dir / "column_00.png").exists()
     assert (fig_dir / "column_01.png").exists()
+    assert (fig_dir / "cl_cd.png").exists()
+    assert (fig_dir / "cl.png").exists()
+    assert (fig_dir / "cd.png").exists()
     pdf_path = out_dir / "report.pdf"
     assert pdf_path.exists()
     reader = PdfReader(str(pdf_path))

--- a/tests/test_solver_convergence_stats_jobs.py
+++ b/tests/test_solver_convergence_stats_jobs.py
@@ -71,6 +71,9 @@ def test_solver_convergence_stats_jobs(tmp_path, job_cls, solver_dir, filename, 
     fig_dir = out_dir / "figures"
     assert (fig_dir / "column_00.png").exists()
     assert (fig_dir / "column_01.png").exists()
+    assert (fig_dir / "cl_cd.png").exists()
+    assert (fig_dir / "cl.png").exists()
+    assert (fig_dir / "cd.png").exists()
     pdf_path = out_dir / "report.pdf"
     assert pdf_path.exists()
     reader = PdfReader(str(pdf_path))


### PR DESCRIPTION
## Summary
- generate cl.png and cd.png in convergence analysis
- include new figures in FPDF report
- expect additional figures in convergence tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68752c0c261083278e64301e813618ed