### PR TITLE
Update pipeline follow-ups to run jobs and use multishot recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,9 @@ Run a grid convergence study and spawn follow-up projects::
 
 The call executes the ``grid-convergence`` pipeline layout which
 creates one project per grid level using the ``grid_dep`` recipe,
-selects the mesh with the lowest drag and then generates a single-shot
-and MULTISHOT project with the chosen grid.  Use ``--layout`` to select
+selects the mesh with the lowest drag and then generates and runs a
+single-shot project and optional MULTISHOT case with the chosen grid.
+Multishot projects use the ``multishot`` recipe. Use ``--layout`` to select
 another workflow and ``--pdf`` to merge all report PDFs into a single
 summary file.
 

--- a/docs/grid_dependency_study.rst
+++ b/docs/grid_dependency_study.rst
@@ -42,6 +42,6 @@ Create a three level study::
 
 After completion you can inspect the coefficients with
 :func:`glacium.utils.convergence.project_cl_cd_stats` or simply use the
-UID reported by :command:`glacium pipeline` to launch follow-up
-``prep+solver`` projects.
+UID reported by :command:`glacium pipeline` to launch additional
+``prep+solver`` or ``multishot`` projects if required.
 

--- a/docs/pipeline.rst
+++ b/docs/pipeline.rst
@@ -15,6 +15,9 @@ the following steps:
    the lowest drag (or highest lift) is selected.
 3. **Follow-up projects** – using the best grid, a single-shot
    ``prep+solver`` project and optional ``MULTISHOT`` cases are spawned.
+   The follow-up jobs are executed immediately.  Multishot projects use
+   the ``multishot`` recipe and their statistics are collected from the
+   ``run_MULTISHOT`` directory.
 
 Example::
 

--- a/tests/test_pipeline_manager.py
+++ b/tests/test_pipeline_manager.py
@@ -13,10 +13,15 @@ from glacium.cli import update as cli_update
 
 def _fake_run(self, jobs=None):
     level = int(self.project.config.get("PWS_REFINEMENT", 1))
-    run_dir = self.project.root / "run_FENSAP"
+    run_dir = (
+        self.project.root
+        / ("run_MULTISHOT" if self.project.config.recipe == "multishot" else "run_FENSAP")
+    )
     run_dir.mkdir(parents=True, exist_ok=True)
     (run_dir / "converg.fensap.000001").write_text(f"1 {level}\n1 {level}")
-    out_dir = self.project.root / "analysis" / "FENSAP"
+    out_dir = self.project.root / "analysis" / (
+        "MULTISHOT" if self.project.config.recipe == "multishot" else "FENSAP"
+    )
     out_dir.mkdir(parents=True, exist_ok=True)
     pdf = FPDF()
     pdf.add_page()
@@ -44,18 +49,19 @@ def test_pipeline_manager(tmp_path, monkeypatch):
 
     for idx, uid in enumerate(uids):
         assert (pm.runs_root / uid).exists()
-        pdf = pm.runs_root / uid / "analysis" / "FENSAP" / "report.pdf"
-        if idx < 2:  # grid projects were executed
-            assert pdf.exists()
-        else:
-            assert not pdf.exists()
+        pdf = pm.runs_root / uid / ("analysis/MULTISHOT" if idx >= 3 else "analysis/FENSAP") / "report.pdf"
+        assert pdf.exists()
 
     out = pipe.merge_pdfs(pm, uids, stats)
     assert out.exists()
 
     expected_pages = 1
-    for uid in uids[:2]:
-        reader = PdfReader(str(pm.runs_root / uid / "analysis" / "FENSAP" / "report.pdf"))
+    for uid in uids:
+        base = pm.runs_root / uid / "analysis"
+        pdf_path = base / "MULTISHOT" / "report.pdf"
+        if not pdf_path.exists():
+            pdf_path = base / "FENSAP" / "report.pdf"
+        reader = PdfReader(str(pdf_path))
         expected_pages += len(reader.pages)
     merged = PdfReader(str(out))
     assert len(merged.pages) == expected_pages


### PR DESCRIPTION
## Summary
- execute follow-up jobs within `grid_convergence` pipeline immediately
- use the `multishot` recipe for multishot projects
- gather follow-up statistics from `run_MULTISHOT`
- update CLI pipeline and manager tests for new behaviour
- document updated workflow in README and docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68752f31ddb48327b44525aae6ec5abe