### PR TITLE
Fix FSP_GUI_INITIAL_TYPE for multishot configs

### DIFF
--- a/glacium/jobs/fensap_jobs.py
+++ b/glacium/jobs/fensap_jobs.py
@@ -117,6 +117,7 @@ class MultiShotRunJob(FensapScriptJob):
                 "next_shot_index": f"{i+1:06d}",
                 "ICE_GUI_INITIAL_TIME": start,
                 "ICE_GUI_TOTAL_TIME": total,
+                "FSP_GUI_INITIAL_TYPE": 1 if i == 1 else 2,
             }
             start += total if total is not None else 0
             for tpl, name_fmt in self.shot_templates.items():

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -366,6 +366,56 @@ def test_multishot_run_job_renders_batch(monkeypatch, tmp_path, count):
         assert (work / f"config.drop.{idx}").exists()
 
 
+def test_multishot_initial_type(monkeypatch, tmp_path):
+    template_root = tmp_path / "templates"
+    template_root.mkdir()
+    monkeypatch.setattr(fensap_jobs, "__file__", str(tmp_path / "pkg" / "fensap_jobs.py"))
+
+    # minimal required templates
+    names = [
+        "MULTISHOT.meshingSizes.scm.j2",
+        "MULTISHOT.custom_remeshing.sh.j2",
+        "MULTISHOT.solvercmd.j2",
+        "MULTISHOT.files.j2",
+        "MULTISHOT.config.par.j2",
+        "MULTISHOT.fensap.par.j2",
+        "MULTISHOT.drop.par.j2",
+        "MULTISHOT.ice.par.j2",
+        "MULTISHOT.create-2.5D-mesh.bin.j2",
+        "MULTISHOT.remeshing.jou.j2",
+        "MULTISHOT.fluent_config.jou.j2",
+        "config.drop.j2",
+        "files.drop.j2",
+        "files.fensap.j2",
+    ]
+    for n in names:
+        content = "exit 0" if n == "MULTISHOT.solvercmd.j2" else "x"
+        (template_root / n).write_text(content)
+
+    (template_root / "config.ice.j2").write_text("x")
+    (template_root / "config.fensap.j2").write_text("{{ FSP_GUI_INITIAL_TYPE }}")
+
+    cfg = GlobalConfig(project_uid="uid", base_dir=tmp_path)
+    cfg["FENSAP_EXE"] = "sh"
+    cfg["MULTISHOT_COUNT"] = 3
+
+    paths = PathBuilder(tmp_path).build()
+    paths.ensure()
+    TemplateManager(template_root)
+
+    project = Project("uid", tmp_path, cfg, paths, [])
+    job = MultiShotRunJob(project)
+    job.execute()
+
+    work = paths.solver_dir("run_MULTISHOT")
+    first = (work / "config.fensap.000001").read_text().strip()
+    second = (work / "config.fensap.000002").read_text().strip()
+    third = (work / "config.fensap.000003").read_text().strip()
+    assert first == "1"
+    assert second == "2"
+    assert third == "2"
+
+
 def test_drop3d_run_job(tmp_path):
     template_root = tmp_path / "tmpl"
     template_root.mkdir()


### PR DESCRIPTION
## Summary
- ensure first multishot config.fensap gets `FSP_GUI_INITIAL_TYPE` of 1
- later shots get `FSP_GUI_INITIAL_TYPE` of 2
- add regression test for this behaviour

## Testing
- `pytest tests/test_engines.py::test_multishot_initial_type -q`
- `pytest tests/test_multishot_timings.py tests/test_engines.py::test_multishot_initial_type -q`


------
https://chatgpt.com/codex/tasks/task_e_6875e90f20dc83279bac797c25ac3e45