### PR TITLE
Fix multishot laplace iteration rendering

### DIFF
--- a/glacium/jobs/fensap_jobs.py
+++ b/glacium/jobs/fensap_jobs.py
@@ -121,7 +121,9 @@ class MultiShotRunJob(FensapScriptJob):
                 "FSP_GUI_ROUGHNESS_TYPE": 1 if i == 1 else 4,
                 "FSP_WALL_ROUGHNESS_SWITCH": 1 if i == 1 else 2,
             }
-            if i > 1:
+            if i == 1:
+                shot_ctx.pop("FSP_MAX_LAPLACE_ITERATIONS", None)
+            else:
                 shot_ctx["FSP_MAX_LAPLACE_ITERATIONS"] = 3
             start += total if total is not None else 0
             for tpl, name_fmt in self.shot_templates.items():

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -467,6 +467,57 @@ def test_multishot_roughness_and_laplace(monkeypatch, tmp_path):
     assert third == "4 2 3"
 
 
+def test_multishot_global_laplace_is_ignored_first_shot(monkeypatch, tmp_path):
+    """A globally defined ``FSP_MAX_LAPLACE_ITERATIONS`` must not appear in the first shot."""
+    template_root = tmp_path / "templates"
+    template_root.mkdir()
+    monkeypatch.setattr(fensap_jobs, "__file__", str(tmp_path / "pkg" / "fensap_jobs.py"))
+
+    names = [
+        "MULTISHOT.meshingSizes.scm.j2",
+        "MULTISHOT.custom_remeshing.sh.j2",
+        "MULTISHOT.solvercmd.j2",
+        "MULTISHOT.files.j2",
+        "MULTISHOT.config.par.j2",
+        "MULTISHOT.fensap.par.j2",
+        "MULTISHOT.drop.par.j2",
+        "MULTISHOT.ice.par.j2",
+        "MULTISHOT.create-2.5D-mesh.bin.j2",
+        "MULTISHOT.remeshing.jou.j2",
+        "MULTISHOT.fluent_config.jou.j2",
+        "config.drop.j2",
+        "files.drop.j2",
+        "files.fensap.j2",
+    ]
+    for n in names:
+        content = "exit 0" if n == "MULTISHOT.solvercmd.j2" else "x"
+        (template_root / n).write_text(content)
+
+    (template_root / "config.ice.j2").write_text("x")
+    (template_root / "config.fensap.j2").write_text(
+        "{{ FSP_GUI_ROUGHNESS_TYPE }} {{ FSP_WALL_ROUGHNESS_SWITCH }}{% if FSP_MAX_LAPLACE_ITERATIONS is defined %} {{ FSP_MAX_LAPLACE_ITERATIONS }}{% endif %}"
+    )
+
+    cfg = GlobalConfig(project_uid="uid", base_dir=tmp_path)
+    cfg["FENSAP_EXE"] = "sh"
+    cfg["MULTISHOT_COUNT"] = 2
+    cfg["FSP_MAX_LAPLACE_ITERATIONS"] = 9
+
+    paths = PathBuilder(tmp_path).build()
+    paths.ensure()
+    TemplateManager(template_root)
+
+    project = Project("uid", tmp_path, cfg, paths, [])
+    job = MultiShotRunJob(project)
+    job.execute()
+
+    work = paths.solver_dir("run_MULTISHOT")
+    first = (work / "config.fensap.000001").read_text().strip()
+    second = (work / "config.fensap.000002").read_text().strip()
+    assert first == "1 1"
+    assert second == "4 2 3"
+
+
 def test_drop3d_run_job(tmp_path):
     template_root = tmp_path / "tmpl"
     template_root.mkdir()


### PR DESCRIPTION
## Summary
- ensure FSP_MAX_LAPLACE_ITERATIONS is removed from the first multishot context
- add regression test verifying the setting is ignored for shot 1

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6875f1cd40e88327a4a9207e0cef692e