### PR TITLE
Fix multishot config rendering

### DIFF
--- a/glacium/jobs/fensap_jobs.py
+++ b/glacium/jobs/fensap_jobs.py
@@ -118,6 +118,7 @@ class MultiShotRunJob(FensapScriptJob):
                 "ICE_GUI_INITIAL_TIME": start,
                 "ICE_GUI_TOTAL_TIME": total,
                 "FSP_GUI_INITIAL_TYPE": 1 if i == 1 else 2,
+                "DRP_GUI_INITIAL_TYPE": 1 if i == 1 else 2,
                 "FSP_GUI_ROUGHNESS_TYPE": 1 if i == 1 else 4,
                 "FSP_WALL_ROUGHNESS_SWITCH": 1 if i == 1 else 2,
             }
@@ -125,6 +126,7 @@ class MultiShotRunJob(FensapScriptJob):
                 shot_ctx.pop("FSP_MAX_LAPLACE_ITERATIONS", None)
             else:
                 shot_ctx["FSP_MAX_LAPLACE_ITERATIONS"] = 3
+                shot_ctx["FSP_GUI_NO_TIMEBC"] = 1
             start += total if total is not None else 0
             for tpl, name_fmt in self.shot_templates.items():
                 dest_name = name_fmt.format(idx=f"{i:06d}")

--- a/glacium/templates/config.drop.j2
+++ b/glacium/templates/config.drop.j2
@@ -14,6 +14,9 @@
  FSP_FILE_CRYSTAL_SOLUTION crystal.drop.{{ shot_index }}
  FSP_FILE_CRYSTAL_SOLUTION_MULTI "drop.*.Distribution.*/crystal.drop.{{ shot_index }}"
  FSP_FILE_DISPLACEMENT timebc.dat
+{% if FSP_GUI_NO_TIMEBC is defined %}
+ FSP_GUI_NO_TIMEBC {{ FSP_GUI_NO_TIMEBC }}
+{% endif %}
  FSP_FILE_GMRES_DATA gmres.out.drop.{{ shot_index }}
  FSP_FILE_OUTPUT_LOG out.drop.{{ shot_index }}
  FSP_FILE_SOLUTION_RESTART soln.fensap.{{ shot_index }}

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -385,6 +385,7 @@ def test_multishot_initial_type(monkeypatch, tmp_path):
         "MULTISHOT.remeshing.jou.j2",
         "MULTISHOT.fluent_config.jou.j2",
         "config.drop.j2",
+        "config.fensap.j2",
         "files.drop.j2",
         "files.fensap.j2",
     ]
@@ -414,6 +415,58 @@ def test_multishot_initial_type(monkeypatch, tmp_path):
     assert first == "1"
     assert second == "2"
     assert third == "2"
+
+
+def test_multishot_drop_initial_type_and_timebc(monkeypatch, tmp_path):
+    """Check DRP_GUI_INITIAL_TYPE and FSP_GUI_NO_TIMEBC handling."""
+    template_root = tmp_path / "templates"
+    template_root.mkdir()
+    monkeypatch.setattr(fensap_jobs, "__file__", str(tmp_path / "pkg" / "fensap_jobs.py"))
+
+    names = [
+        "MULTISHOT.meshingSizes.scm.j2",
+        "MULTISHOT.custom_remeshing.sh.j2",
+        "MULTISHOT.solvercmd.j2",
+        "MULTISHOT.files.j2",
+        "MULTISHOT.config.par.j2",
+        "MULTISHOT.fensap.par.j2",
+        "MULTISHOT.drop.par.j2",
+        "MULTISHOT.ice.par.j2",
+        "MULTISHOT.create-2.5D-mesh.bin.j2",
+        "MULTISHOT.remeshing.jou.j2",
+        "MULTISHOT.fluent_config.jou.j2",
+        "files.drop.j2",
+        "files.fensap.j2",
+    ]
+    for n in names:
+        content = "exit 0" if n == "MULTISHOT.solvercmd.j2" else "x"
+        (template_root / n).write_text(content)
+
+    (template_root / "config.ice.j2").write_text("x")
+    (template_root / "config.fensap.j2").write_text("x")
+    (template_root / "config.drop.j2").write_text(
+        "{{ DRP_GUI_INITIAL_TYPE }}{% if FSP_GUI_NO_TIMEBC is defined %} {{ FSP_GUI_NO_TIMEBC }}{% endif %}"
+    )
+
+    cfg = GlobalConfig(project_uid="uid", base_dir=tmp_path)
+    cfg["FENSAP_EXE"] = "sh"
+    cfg["MULTISHOT_COUNT"] = 3
+
+    paths = PathBuilder(tmp_path).build()
+    paths.ensure()
+    TemplateManager(template_root)
+
+    project = Project("uid", tmp_path, cfg, paths, [])
+    job = MultiShotRunJob(project)
+    job.execute()
+
+    work = paths.solver_dir("run_MULTISHOT")
+    first = (work / "config.drop.000001").read_text().strip()
+    second = (work / "config.drop.000002").read_text().strip()
+    third = (work / "config.drop.000003").read_text().strip()
+    assert first == "1"
+    assert second == "2 1"
+    assert third == "2 1"
 
 
 def test_multishot_roughness_and_laplace(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- ensure `config.drop` renders `FSP_GUI_NO_TIMEBC` only on shots after the first
- set `DRP_GUI_INITIAL_TYPE` per shot
- test the new behaviour

## Testing
- `pytest tests/test_engines.py::test_multishot_drop_initial_type_and_timebc -q`

------
https://chatgpt.com/codex/tasks/task_e_6875f5469af8832790e576fed331613c