### PR TITLE
Fix multishot configuration handling

### DIFF
--- a/glacium/cli/case_sweep.py
+++ b/glacium/cli/case_sweep.py
@@ -40,13 +40,11 @@ DEFAULT_AIRFOIL = Path(__file__).resolve().parents[1] / "data" / "AH63K127.dat"
 )
 @click.option(
     "--multishots",
-    default=10,
-    show_default=True,
     type=int,
     help="Number of MULTISHOT runs",
 )
 @log_call
-def cli_case_sweep(params: tuple[str], recipe: str, output: Path, multishots: int) -> None:
+def cli_case_sweep(params: tuple[str], recipe: str, output: Path, multishots: int | None) -> None:
     """Create projects for all parameter combinations."""
 
     def _parse_value(v: str):
@@ -66,8 +64,7 @@ def cli_case_sweep(params: tuple[str], recipe: str, output: Path, multishots: in
     pm = ProjectManager(output)
 
     for combo in itertools.product(*(param_map[k] for k in keys)):
-        proj = pm.create("case", recipe, DEFAULT_AIRFOIL)
-        proj.config["MULTISHOT_COUNT"] = multishots
+        proj = pm.create("case", recipe, DEFAULT_AIRFOIL, multishots=multishots)
         proj.config.dump(proj.paths.global_cfg_file())
         case_file = proj.root / "case.yaml"
         case = yaml.safe_load(case_file.read_text()) or {}

--- a/glacium/cli/new.py
+++ b/glacium/cli/new.py
@@ -52,20 +52,17 @@ DEFAULT_AIRFOIL = PKG_PKG / "data" / "AH63K127.dat"
 @click.option(
     "-m",
     "--multishots",
-    default=10,
-    show_default=True,
     type=int,
     help="Anzahl der MULTISHOT Durchläufe",
 )
 @click.option("-y", "--yes", is_flag=True,
               help="Existierenden Ordner ohne Rückfrage überschreiben")
 @log_call
-def cli_new(name: str, airfoil: Path, recipe: str, output: Path, multishots: int, yes: bool) -> None:
+def cli_new(name: str, airfoil: Path, recipe: str, output: Path, multishots: int | None, yes: bool) -> None:
     """Erstellt ein neues Glacium-Projekt."""
 
     pm = ProjectManager(output)
-    project = pm.create(name, recipe, airfoil)
-    project.config["MULTISHOT_COUNT"] = multishots
+    project = pm.create(name, recipe, airfoil, multishots=multishots)
     project.config.dump(project.paths.global_cfg_file())
     log.success(f"Projekt angelegt: {project.root}")
     click.echo(project.uid)

--- a/glacium/engines/fensap.py
+++ b/glacium/engines/fensap.py
@@ -73,11 +73,10 @@ class FensapScriptJob(Job):
         return work / ".solvercmd"
 
     def _context(self) -> dict:
-        module_root = Path(sys.modules[self.__class__.__module__].__file__).resolve().parents[1]
-        defaults_file = module_root / "config" / "defaults" / "global_default.yaml"
-        defaults = (
-            yaml.safe_load(defaults_file.read_text()) if defaults_file.exists() else {}
-        )
+        from glacium.utils.default_paths import global_default_config
+
+        defaults_file = global_default_config()
+        defaults = yaml.safe_load(defaults_file.read_text()) if defaults_file.exists() else {}
         cfg = self.project.config
         return {**defaults, **cfg.extras}
 

--- a/glacium/managers/project_manager.py
+++ b/glacium/managers/project_manager.py
@@ -47,7 +47,14 @@ class ProjectManager:
     # ------------------------------------------------------------------
     # Create
     # ------------------------------------------------------------------
-    def create(self, name: str, recipe_name: str, airfoil: Path) -> Project:
+    def create(
+        self,
+        name: str,
+        recipe_name: str,
+        airfoil: Path,
+        *,
+        multishots: int | None = None,
+    ) -> Project:
         """Create a new project folder.
 
         Parameters
@@ -75,6 +82,8 @@ class ProjectManager:
         defaults = generate_global_defaults(case_file, global_default_config())
 
         cfg = GlobalConfig(**defaults, project_uid=uid, base_dir=root)
+        if multishots is not None:
+            cfg["MULTISHOT_COUNT"] = multishots
         cfg["PROJECT_NAME"] = name
         # Use path relative to solver directories so Pointwise and XFOIL can
         # locate the airfoil file correctly.


### PR DESCRIPTION
## Summary
- pass optional multishot count when creating projects
- avoid overriding global defaults in `glacium new` and `case-sweep`
- load config defaults using `global_default_config`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687616502f34832788172bdf84b482c4