### PR TITLE
Use Run API in CLI project creation

### DIFF
--- a/glacium/cli/init.py
+++ b/glacium/cli/init.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import click
 from glacium.utils.logging import log_call
 
-from glacium.managers.project_manager import ProjectManager
+from glacium.api import Run
 
 DEFAULT_NAME = "project"
 DEFAULT_RECIPE = "prep"
@@ -22,6 +22,8 @@ DEFAULT_AIRFOIL = Path(__file__).resolve().parents[1] / "data" / "AH63K127.dat"
 def cli_init(name: str, recipe: str, output: Path) -> None:
     """Create a new project below ``output`` using default settings."""
 
-    pm = ProjectManager(output)
-    proj = pm.create(name, recipe, DEFAULT_AIRFOIL)
-    click.echo(proj.uid)
+    run = Run(output)
+    run.name(name).select_airfoil(DEFAULT_AIRFOIL)
+    run.set("recipe", recipe)
+    project = run.create()
+    click.echo(project.uid)

--- a/glacium/cli/new.py
+++ b/glacium/cli/new.py
@@ -17,7 +17,7 @@ from pathlib import Path
 import click
 
 from glacium.utils.logging import log, log_call
-from glacium.managers.project_manager import ProjectManager
+from glacium.api import Run
 
 # Paket-Ressourcen ---------------------------------------------------------
 PKG_ROOT = Path(__file__).resolve().parents[2]
@@ -58,12 +58,22 @@ DEFAULT_AIRFOIL = PKG_PKG / "data" / "AH63K127.dat"
 @click.option("-y", "--yes", is_flag=True,
               help="Existierenden Ordner ohne Rückfrage überschreiben")
 @log_call
-def cli_new(name: str, airfoil: Path, recipe: str, output: Path, multishots: int | None, yes: bool) -> None:
+def cli_new(
+    name: str,
+    airfoil: Path,
+    recipe: str,
+    output: Path,
+    multishots: int | None,
+    yes: bool,
+) -> None:
     """Erstellt ein neues Glacium-Projekt."""
 
-    pm = ProjectManager(output)
-    project = pm.create(name, recipe, airfoil, multishots=multishots)
-    project.config.dump(project.paths.global_cfg_file())
+    run = Run(output)
+    run.name(name).select_airfoil(airfoil)
+    run.set("recipe", recipe)
+    if multishots is not None:
+        run.set("multishot_count", multishots)
+    project = run.create()
     log.success(f"Projekt angelegt: {project.root}")
     click.echo(project.uid)
 


### PR DESCRIPTION
## Summary
- use `Run` builder for the `new` and `init` commands
- keep recipe and multishot options mapped to `Run.set`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687755cafc748327b27ff86eacf3b545