### PR TITLE
Ensure stable pipeline ordering

### DIFF
--- a/glacium/pipeline.py
+++ b/glacium/pipeline.py
@@ -314,21 +314,22 @@ class Pipeline:
     def _topological_sort(self) -> list[Run]:
         from collections import defaultdict, deque
 
-        graph = defaultdict(set)
+        graph = defaultdict(list)
         indeg = defaultdict(int)
         for r in self._runs:
             indeg[r.id] = 0
         for r in self._runs:
             for d in r.dependencies:
-                graph[d].add(r.id)
+                if r.id not in graph[d]:
+                    graph[d].append(r.id)
                 indeg[r.id] += 1
 
-        q = deque([rid for rid, deg in indeg.items() if deg == 0])
+        q = deque([r.id for r in self._runs if indeg[r.id] == 0])
         order: list[str] = []
         while q:
             n = q.popleft()
             order.append(n)
-            for m in graph.get(n, set()):
+            for m in graph.get(n, []):
                 indeg[m] -= 1
                 if indeg[m] == 0:
                     q.append(m)

--- a/tests/test_topological_sort.py
+++ b/tests/test_topological_sort.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from glacium import Run, Pipeline
+
+
+def test_topological_sort_fifo_order():
+    root = Run()
+    a = Run().depends_on(root)
+    b = Run().depends_on(root)
+    c = Run().depends_on(root)
+
+    pipe = Pipeline([root, b, a, c])
+    order = [r.id for r in pipe._topological_sort()]
+    assert order == [root.id, b.id, a.id, c.id]


### PR DESCRIPTION
## Summary
- keep FIFO order during topological sort
- add regression test for deterministic run order

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877e0da30b483278b3877fc02b30dba