### PR TITLE
Add PostProcessor with artifact handling

### DIFF
--- a/glacium/__init__.py
+++ b/glacium/__init__.py
@@ -45,5 +45,5 @@ except PackageNotFoundError:  # package is not installed
 # -----------------------------------------------------------------------------
 
 from .pipeline import Run, Pipeline, sweep, grid, load, run
-
-__all__ = ["Run", "Pipeline", "sweep", "grid", "load", "run"]
+from .post import PostProcessor
+__all__ = ["Run", "Pipeline", "sweep", "grid", "load", "run", "PostProcessor"]

--- a/glacium/post/__init__.py
+++ b/glacium/post/__init__.py
@@ -1,0 +1,3 @@
+from .processor import PostProcessor
+
+__all__ = ["PostProcessor"]

--- a/glacium/post/artifact.py
+++ b/glacium/post/artifact.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, Iterator, List
+
+__all__ = [
+    "Artifact",
+    "ArtifactSet",
+    "ArtifactIndex",
+]
+
+
+@dataclass
+class Artifact:
+    """Single post-processing artifact on disk."""
+
+    path: Path
+    kind: str
+    meta: Dict[str, Any] = field(default_factory=dict)
+
+    # ------------------------------------------------------------------
+    def open(self, mode: str = "rb"):
+        """Open ``path`` with the given mode (default: binary read)."""
+        return self.path.open(mode)
+
+    # ------------------------------------------------------------------
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a serialisable representation of this artifact."""
+        return {"path": str(self.path), "kind": self.kind, "meta": dict(self.meta)}
+
+
+@dataclass
+class ArtifactSet:
+    """Collection of :class:`Artifact` objects belonging to one run."""
+
+    run_id: str
+    artifacts: List[Artifact] = field(default_factory=list)
+
+    # ------------------------------------------------------------------
+    def add(self, artifact: Artifact) -> None:
+        self.artifacts.append(artifact)
+
+    # ------------------------------------------------------------------
+    def filter(self, *, kind: str | None = None, **meta: Any) -> "ArtifactSet":
+        """Return a new :class:`ArtifactSet` filtered by ``kind`` and ``meta``."""
+
+        items = self.artifacts
+        if kind is not None:
+            items = [a for a in items if a.kind == kind]
+        for key, val in meta.items():
+            items = [a for a in items if a.meta.get(key) == val]
+        return ArtifactSet(self.run_id, list(items))
+
+    # ------------------------------------------------------------------
+    def get_first(self, kind: str) -> Artifact | None:
+        """Return the first artifact matching ``kind`` if present."""
+
+        for art in self.artifacts:
+            if art.kind == kind:
+                return art
+        return None
+
+    # ------------------------------------------------------------------
+    def to_dataframe(self):  # pragma: no cover - optional dependency
+        """Return the artifacts as a ``pandas.DataFrame``."""
+
+        try:
+            import pandas as pd
+        except Exception as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError("pandas required for to_dataframe") from exc
+        return pd.DataFrame([a.to_dict() for a in self.artifacts])
+
+
+@dataclass
+class ArtifactIndex:
+    """Mapping of run identifiers to :class:`ArtifactSet` objects."""
+
+    runs: Dict[str, ArtifactSet] = field(default_factory=dict)
+
+    # ------------------------------------------------------------------
+    def __iter__(self) -> Iterator[str]:  # pragma: no cover - trivial
+        return iter(self.runs)
+
+    # ------------------------------------------------------------------
+    def __getitem__(self, key: str) -> ArtifactSet:  # pragma: no cover - trivial
+        return self.runs[key]
+
+    # ------------------------------------------------------------------
+    def __setitem__(self, key: str, value: ArtifactSet) -> None:  # pragma: no cover - trivial
+        self.runs[key] = value
+
+    # ------------------------------------------------------------------
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self.runs)
+
+    # ------------------------------------------------------------------
+    def values(self) -> Iterable[ArtifactSet]:  # pragma: no cover - trivial
+        return self.runs.values()
+
+    # ------------------------------------------------------------------
+    def items(self):  # pragma: no cover - trivial
+        return self.runs.items()

--- a/glacium/post/processor.py
+++ b/glacium/post/processor.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterable, List, Type
+
+import yaml
+import matplotlib.pyplot as plt
+import numpy as np
+
+from .artifact import Artifact, ArtifactIndex, ArtifactSet
+
+__all__ = ["PostProcessor"]
+
+
+class PostProcessor:
+    """Lightweight access to post-processing artifacts."""
+
+    _registry: List[Type] = []
+
+    # ------------------------------------------------------------------
+    def __init__(self, source: str | Path, *, importers: Iterable[Type] | None = None, recursive: bool = True) -> None:
+        self.source = Path(source)
+        self.recursive = recursive
+        self.importers: List[Any] = [imp() for imp in (importers or self._registry)]
+        self._index = ArtifactIndex()
+        self._scan()
+
+    # ------------------------------------------------------------------
+    def _scan(self) -> None:
+        if not self.importers:
+            return
+        dirs: Iterable[Path]
+        if self.recursive:
+            dirs = (p for p in self.source.rglob("*") if p.is_dir())
+        else:
+            dirs = (p for p in self.source.iterdir() if p.is_dir())
+        for d in dirs:
+            for imp in self.importers:
+                try:
+                    detector = getattr(imp, "detect")
+                    parser = getattr(imp, "parse")
+                except AttributeError:
+                    continue
+                try:
+                    if detector(d):
+                        aset = parser(d)
+                        self._index[aset.run_id] = aset
+                        break
+                except Exception:
+                    continue
+
+    # ------------------------------------------------------------------
+    def map(self, pattern: str = "*.dat") -> List[Path]:
+        paths: List[Path]
+        if self.recursive:
+            paths = sorted(self.source.rglob(pattern))
+        else:
+            paths = sorted(self.source.glob(pattern))
+        return paths
+
+    # ------------------------------------------------------------------
+    @property
+    def index(self) -> ArtifactIndex:  # pragma: no cover - trivial
+        return self._index
+
+    # ------------------------------------------------------------------
+    def get(self, run_or_id: str | ArtifactSet) -> ArtifactSet:
+        if isinstance(run_or_id, ArtifactSet):
+            return run_or_id
+        if isinstance(run_or_id, Path):
+            run_or_id = run_or_id.name
+        return self._index[run_or_id]
+
+    # ------------------------------------------------------------------
+    def plot(self, var: str, run_or_id: str | ArtifactSet):
+        aset = self.get(run_or_id)
+        art = aset.get_first(var)
+        if art is None:
+            raise KeyError(f"{var} not found in run {aset.run_id}")
+        data = np.loadtxt(art.path)
+        plt.plot(data)
+        plt.xlabel("index")
+        plt.ylabel(var)
+        return plt.gca()
+
+    # ------------------------------------------------------------------
+    def export(self, dest: str | Path, format: str = "zip") -> Path:
+        dest = Path(dest)
+        if format == "zip":
+            import zipfile
+
+            with zipfile.ZipFile(dest, "w") as zf:
+                for aset in self._index.values():
+                    for art in aset.artifacts:
+                        zf.write(art.path, arcname=f"{aset.run_id}/{art.path.name}")
+        else:
+            raise ValueError(f"unknown format: {format}")
+        return dest
+
+    # ------------------------------------------------------------------
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {}
+        for run_id, aset in self._index.items():
+            out[run_id] = [a.to_dict() for a in aset.artifacts]
+        return out
+
+    def to_yaml(self) -> str:
+        return yaml.safe_dump(self.to_dict(), sort_keys=False)
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def register_importer(cls, importer: Type) -> Type:
+        if importer not in cls._registry:
+            cls._registry.append(importer)
+        return importer


### PR DESCRIPTION
## Summary
- add new `post` package
- implement `Artifact`, `ArtifactSet`, and `ArtifactIndex`
- create `PostProcessor` for post processing workflows
- expose PostProcessor from package root

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6878b57cbfe08327a28564dbef744453