### PR TITLE
Add converters for FENSAP postprocessing

### DIFF
--- a/glacium/post/convert/__init__.py
+++ b/glacium/post/convert/__init__.py
@@ -1,0 +1,4 @@
+from .single import SingleShotConverter
+from .multishot import MultiShotConverter
+
+__all__ = ["SingleShotConverter", "MultiShotConverter"]

--- a/glacium/post/convert/multishot.py
+++ b/glacium/post/convert/multishot.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import subprocess
+from concurrent.futures import ThreadPoolExecutor
+
+from ..processor import PostProcessor
+from ..artifact import ArtifactIndex
+
+
+@dataclass
+class MultiShotConverter:
+    root: Path
+    exe: Path = Path("nti2tecplot.exe")
+    overwrite: bool = False
+    concurrency: int = 4
+
+    PATTERNS = {
+        "SOLN": ("soln.fensap.{id}", "soln.fensap.{id}.dat"),
+        "DROPLET": ("droplet.drop.{id}", "droplet.drop.{id}.dat"),
+        "SWIMSOL": ("swimsol.ice.{id}", "swimsol.ice.{id}.dat"),
+    }
+
+    def _convert_one(self, shot: str) -> list[Path]:
+        grid = self.root.parent.parent / "mesh" / f"grid.ice.{shot}"
+        out: list[Path] = []
+        for mode, (src_tpl, dst_tpl) in self.PATTERNS.items():
+            src = self.root / src_tpl.format(id=shot)
+            dst = self.root / dst_tpl.format(id=shot)
+            if not src.exists():
+                continue
+            if dst.exists() and not self.overwrite:
+                out.append(dst)
+                continue
+            subprocess.run([str(self.exe), mode, str(grid), str(src), str(dst)], check=True)
+            out.append(dst)
+        return out
+
+    def convert_all(self) -> ArtifactIndex:
+        shots = sorted({p.suffix[-6:] for p in self.root.glob("*.??????")})
+        with ThreadPoolExecutor(max_workers=self.concurrency) as ex:
+            list(ex.map(self._convert_one, shots))
+        return PostProcessor(self.root.parent).index

--- a/glacium/post/convert/single.py
+++ b/glacium/post/convert/single.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import subprocess
+
+
+@dataclass
+class SingleShotConverter:
+    root: Path
+    exe: Path = Path("nti2tecplot.exe")
+    overwrite: bool = False
+
+    MAP = {
+        "run_FENSAP": ("SOLN", "grid.ice", "soln.fensap", "soln.fensap.dat"),
+        "run_DROP3D": ("DROPLET", "grid.ice", "droplet.drop", "droplet.drop.dat"),
+        "run_ICE3D": ("SWIMSOL", "grid.ice", "swimsol.ice", "swimsol.ice.dat"),
+    }
+
+    def convert(self) -> Path:
+        run_dir = self.root.name
+        mode, grid_name, src_name, dst_name = self.MAP[run_dir]
+        grid = self.root.parent / "mesh" / grid_name
+        src = self.root / src_name
+        dst = self.root / dst_name
+        if dst.exists() and not self.overwrite:
+            return dst
+        subprocess.run([str(self.exe), mode, str(grid), str(src), str(dst)], check=True)
+        return dst


### PR DESCRIPTION
## Summary
- add SingleShotConverter for single-shot runs
- add MultiShotConverter for multi-shot runs
- export the converters via `glacium.post.convert`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878b90625cc83278bdd6700aee17280