### PR TITLE
Add Fensap importers

### DIFF
--- a/glacium/post/__init__.py
+++ b/glacium/post/__init__.py
@@ -1,3 +1,8 @@
 from .processor import PostProcessor
+from .importers import FensapSingleImporter, FensapMultiImporter
 
-__all__ = ["PostProcessor"]
+__all__ = [
+    "PostProcessor",
+    "FensapSingleImporter",
+    "FensapMultiImporter",
+]

--- a/glacium/post/importers.py
+++ b/glacium/post/importers.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..pipeline import Run, Pipeline
+from .artifact import Artifact, ArtifactSet
+from .processor import PostProcessor
+
+__all__ = ["FensapSingleImporter", "FensapMultiImporter"]
+
+
+@PostProcessor.register_importer
+class FensapSingleImporter:
+    """Import artifacts from single-shot FENSAP runs."""
+
+    name = "fensap_single"
+
+    def detect(self, root: Path) -> bool:
+        return root.name in {"run_FENSAP", "run_DROP3D", "run_ICE3D"}
+
+    def parse(self, root: Path) -> ArtifactSet:
+        run_id = root.name
+        aset = ArtifactSet(run_id)
+        for p in root.iterdir():
+            kind = p.stem
+            aset.add(Artifact(p, kind))
+        return aset
+
+
+@PostProcessor.register_importer
+class FensapMultiImporter:
+    """Create a pipeline from MULTISHOT post-processing files."""
+
+    name = "fensap_multi"
+
+    def detect(self, root: Path) -> bool:
+        return root.name == "run_MULTISHOT"
+
+    def parse(self, root: Path) -> Pipeline:
+        pipe = Pipeline()
+        for dat in root.rglob("*.dat"):
+            shot = dat.suffixes[-2][-6:] if len(dat.suffixes) >= 2 else dat.stem[-6:]
+            run = (
+                Run()
+                .select_airfoil("imported")
+                .set("SHOT_ID", shot)
+                .tag("imported")
+            )
+            pipe.add(run)
+        return pipe

--- a/tests/test_fensap_importers.py
+++ b/tests/test_fensap_importers.py
@@ -1,0 +1,46 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from glacium.post import (
+    FensapSingleImporter,
+    FensapMultiImporter,
+    PostProcessor,
+)
+
+
+def test_importer_registration():
+    assert FensapSingleImporter in PostProcessor._registry
+    assert FensapMultiImporter in PostProcessor._registry
+
+
+def test_fensap_single_importer(tmp_path):
+    run_dir = tmp_path / "run_FENSAP"
+    run_dir.mkdir()
+    dat = run_dir / "Cl.dat"
+    dat.write_text("data")
+
+    imp = FensapSingleImporter()
+    assert imp.detect(run_dir)
+    aset = imp.parse(run_dir)
+    assert aset.run_id == "run_FENSAP"
+    art = aset.get_first("Cl")
+    assert art is not None
+    assert art.path == dat
+
+
+def test_fensap_multi_importer(tmp_path):
+    ms_dir = tmp_path / "run_MULTISHOT"
+    sub = ms_dir / "sub"
+    sub.mkdir(parents=True)
+    (ms_dir / "soln.fensap.000001.dat").write_text("a")
+    (sub / "droplet.drop.000002.dat").write_text("b")
+
+    imp = FensapMultiImporter()
+    assert imp.detect(ms_dir)
+    pipe = imp.parse(ms_dir)
+    shots = sorted(r.parameters["SHOT_ID"] for r in pipe)
+    assert shots == ["000001", "000002"]
+    for run in pipe:
+        assert "imported" in run.tags
+        assert run.airfoil == "imported"


### PR DESCRIPTION
## Summary
- implement FensapSingleImporter/FensapMultiImporter
- export new importers
- test importer registration and behaviour

## Testing
- `pytest tests/test_fensap_importers.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6878c1fbd40c832792e7046259cf2b25