### PR TITLE
Add manifest support to PostProcessor

### DIFF
--- a/glacium/post/__init__.py
+++ b/glacium/post/__init__.py
@@ -1,8 +1,10 @@
-from .processor import PostProcessor
+from .processor import PostProcessor, write_manifest, index_from_dict
 from .importers import FensapSingleImporter, FensapMultiImporter
 
 __all__ = [
     "PostProcessor",
+    "write_manifest",
+    "index_from_dict",
     "FensapSingleImporter",
     "FensapMultiImporter",
 ]

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -2,7 +2,7 @@ import sys
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from glacium.post import PostProcessor
+from glacium.post import PostProcessor, write_manifest
 from glacium.post.artifact import ArtifactSet, Artifact
 
 
@@ -37,3 +37,31 @@ def test_postprocessor_indexing(tmp_path):
 
     mapped = set(pp.map("*.dat"))
     assert mapped == {run1 / "a.dat", run2 / "b.dat", run2 / "c.dat"}
+
+
+def test_postprocessor_manifest(tmp_path, monkeypatch):
+    run = tmp_path / "run1"
+    run.mkdir()
+    (run / "a.dat").write_text("1")
+
+    class DummyImporter:
+        def detect(self, root: Path) -> bool:
+            return True
+
+        def parse(self, root: Path) -> ArtifactSet:
+            aset = ArtifactSet(root.name)
+            for p in root.glob("*.dat"):
+                aset.add(Artifact(p, p.stem))
+            return aset
+
+    pp = PostProcessor(tmp_path, importers=[DummyImporter], recursive=True)
+    write_manifest(pp.index, tmp_path / "manifest.json")
+
+    def fail_scan(self):
+        raise AssertionError("_scan called")
+
+    monkeypatch.setattr(PostProcessor, "_scan", fail_scan)
+
+    pp2 = PostProcessor(tmp_path, importers=[DummyImporter], recursive=True)
+    assert len(pp2.index) == 1
+    assert pp2.get("run1").get_first("a") is not None


### PR DESCRIPTION
## Summary
- extend `PostProcessor` to load an existing `manifest.json`
- add helpers `index_from_dict` and `write_manifest`
- export helpers from package
- test loading from a manifest instead of scanning

## Testing
- `pytest tests/test_postprocessor.py::test_postprocessor_indexing tests/test_postprocessor.py::test_postprocessor_manifest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878c4c585a4832788a5c0f1947c07ee