### PR TITLE
Add post-processing jobs

### DIFF
--- a/glacium/jobs/__init__.py
+++ b/glacium/jobs/__init__.py
@@ -23,6 +23,7 @@ from .xfoil_jobs import (
 from glacium.engines.fluent2fensap import Fluent2FensapJob
 from glacium.engines.xfoil_convert_job import XfoilConvertJob
 from glacium.recipes.hello_world import HelloJob
+from .postprocess_jobs import PostprocessSingleFensapJob, PostprocessMultishotJob
 
 __all__ = [
     "FensapRunJob",
@@ -43,4 +44,6 @@ __all__ = [
     "Fluent2FensapJob",
     "XfoilConvertJob",
     "HelloJob",
+    "PostprocessSingleFensapJob",
+    "PostprocessMultishotJob",
 ]

--- a/glacium/jobs/postprocess_jobs.py
+++ b/glacium/jobs/postprocess_jobs.py
@@ -1,0 +1,42 @@
+"""Post-processing job classes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from glacium.models.job import Job
+from glacium.post.convert.single import SingleShotConverter
+from glacium.post.convert.multishot import MultiShotConverter
+from glacium.post import PostProcessor, write_manifest
+
+__all__ = ["PostprocessSingleFensapJob", "PostprocessMultishotJob"]
+
+
+class PostprocessSingleFensapJob(Job):
+    """Convert FENSAP single-shot results and write manifest."""
+
+    name = "POSTPROCESS_SINGLE_FENSAP"
+    deps = ("FENSAP_RUN", "DROP3D_RUN", "ICE3D_RUN")
+
+    def execute(self) -> None:  # noqa: D401
+        root = self.project.root
+        for dirname in ("run_FENSAP", "run_DROP3D", "run_ICE3D"):
+            run_dir = root / dirname
+            if run_dir.exists():
+                SingleShotConverter(run_dir).convert()
+        index = PostProcessor(root).index
+        write_manifest(index, root / "manifest.json")
+
+
+class PostprocessMultishotJob(Job):
+    """Convert MULTISHOT results and write manifest."""
+
+    name = "POSTPROCESS_MULTISHOT"
+    deps = ("MULTISHOT_RUN",)
+
+    def execute(self) -> None:  # noqa: D401
+        root = self.project.root
+        ms_dir = root / "analysis" / "run_MULTISHOT"
+        index = MultiShotConverter(ms_dir).convert_all()
+        write_manifest(index, root / "manifest.json")
+

--- a/tests/test_postprocess_jobs.py
+++ b/tests/test_postprocess_jobs.py
@@ -1,0 +1,98 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from glacium.jobs import postprocess_jobs
+from glacium.jobs.postprocess_jobs import (
+    PostprocessSingleFensapJob,
+    PostprocessMultishotJob,
+)
+from glacium.models.config import GlobalConfig
+from glacium.managers.path_manager import PathBuilder
+from glacium.models.project import Project
+
+
+def _project(tmp_path: Path) -> Project:
+    cfg = GlobalConfig(project_uid="uid", base_dir=tmp_path)
+    paths = PathBuilder(tmp_path).build()
+    paths.ensure()
+    return Project("uid", tmp_path, cfg, paths, [])
+
+
+def test_postprocess_single_fensap(tmp_path, monkeypatch):
+    root = tmp_path
+    (root / "run_FENSAP").mkdir()
+    (root / "run_DROP3D").mkdir()
+    project = _project(root)
+    job = PostprocessSingleFensapJob(project)
+
+    called = []
+
+    class DummyConv:
+        def __init__(self, p):
+            called.append(p)
+            self.root = p
+
+        def convert(self):
+            return self.root / "out.dat"
+
+    monkeypatch.setattr(postprocess_jobs, "SingleShotConverter", DummyConv)
+
+    written = {}
+
+    class DummyPP:
+        def __init__(self, root):
+            written["root"] = root
+            self.index = "IDX"
+
+    monkeypatch.setattr(postprocess_jobs, "PostProcessor", DummyPP)
+
+    def fake_write(index, dest):
+        written["dest"] = dest
+        written["index"] = index
+        return Path(dest)
+
+    monkeypatch.setattr(postprocess_jobs, "write_manifest", fake_write)
+
+    job.execute()
+
+    assert called == [root / "run_FENSAP", root / "run_DROP3D"]
+    assert written["dest"] == root / "manifest.json"
+    assert written["index"] == "IDX"
+    assert written["root"] == root
+
+
+def test_postprocess_multishot(tmp_path, monkeypatch):
+    root = tmp_path
+    ms_dir = root / "analysis" / "run_MULTISHOT"
+    ms_dir.mkdir(parents=True)
+    project = _project(root)
+    job = PostprocessMultishotJob(project)
+
+    called = {}
+
+    class DummyMSC:
+        def __init__(self, p):
+            called["path"] = p
+
+        def convert_all(self):
+            called["called"] = True
+            return "IDX"
+
+    monkeypatch.setattr(postprocess_jobs, "MultiShotConverter", DummyMSC)
+
+    written = {}
+
+    def fake_write(index, dest):
+        written["index"] = index
+        written["dest"] = dest
+        return Path(dest)
+
+    monkeypatch.setattr(postprocess_jobs, "write_manifest", fake_write)
+
+    job.execute()
+
+    assert called["path"] == ms_dir
+    assert called.get("called")
+    assert written["dest"] == root / "manifest.json"
+    assert written["index"] == "IDX"


### PR DESCRIPTION
## Summary
- add `PostprocessSingleFensapJob` and `PostprocessMultishotJob`
- expose the jobs through `glacium.jobs`
- test post-processing jobs

## Testing
- `pytest tests/test_postprocess_jobs.py -q`
- `pytest -k postprocess_jobs -q`

------
https://chatgpt.com/codex/tasks/task_e_6878c6cedb7483279f76f3faf72f4d42