### PR TITLE
Add CLI wrappers for post-analysis modules

### DIFF
--- a/glacium/post/analysis/cp.py
+++ b/glacium/post/analysis/cp.py
@@ -118,3 +118,27 @@ def plot_cp(df: pd.DataFrame, outfile: str | Path, upper_label: str = "Upper", l
     fig.savefig(outfile, dpi=300)
     plt.close(fig)
     return outfile
+
+
+def main() -> None:
+    """Small CLI wrapper for Cp computation and plotting."""
+    import argparse
+
+    ap = argparse.ArgumentParser(description="Compute Cp distribution from Tecplot ASCII export.")
+    ap.add_argument("input", type=Path, help="Tecplot ASCII file")
+    ap.add_argument("-o", "--output", type=Path, default="cp.png", help="Output image file")
+    ap.add_argument("--p-inf", type=float, required=True, help="Free-stream pressure [Pa]")
+    ap.add_argument("--rho-inf", type=float, required=True, help="Free-stream density [kg/m^3]")
+    ap.add_argument("--u-inf", type=float, required=True, help="Free-stream velocity [m/s]")
+    ap.add_argument("--chord", type=float, required=True, help="Chord length [m]")
+    ap.add_argument("--wall-tol", type=float, default=1e-4, help="Wall distance tolerance [m]")
+    ap.add_argument("--rel-pct", type=float, default=2.0, help="Relative tolerance if no points within wall-tol [%]")
+    args = ap.parse_args()
+
+    df = read_tec_ascii(args.input)
+    cp_df = compute_cp(df, args.p_inf, args.rho_inf, args.u_inf, args.chord, args.wall_tol, args.rel_pct)
+    plot_cp(cp_df, args.output)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()

--- a/glacium/post/analysis/ice_contours.py
+++ b/glacium/post/analysis/ice_contours.py
@@ -108,3 +108,28 @@ def animate_growth(segments: Iterable[np.ndarray], outfile: str | Path, *, fps: 
     ani.save(outfile, writer=writer, dpi=dpi)
     plt.close(fig)
     return outfile
+
+
+def main() -> None:
+    """CLI entry point for contour overlay and animation."""
+    import argparse
+
+    ap = argparse.ArgumentParser(description="Visualise a series of STL ice contours")
+    ap.add_argument("pattern", help="Glob pattern for STL files")
+    ap.add_argument("-o", "--output", type=Path, required=True, help="Output file")
+    ap.add_argument("--animate", action="store_true", help="Create animation instead of static overlay")
+    ap.add_argument("--fps", type=int, default=10, help="Frames per second for animation")
+    ap.add_argument("--alpha", type=float, default=0.9, help="Line alpha value")
+    ap.add_argument("--linewidth", type=float, default=1.2, help="Line width")
+    ap.add_argument("--dpi", type=int, default=150, help="Figure resolution")
+    args = ap.parse_args()
+
+    segments = load_contours(args.pattern)
+    if args.animate:
+        animate_growth(segments, args.output, fps=args.fps, alpha=args.alpha, linewidth=args.linewidth, dpi=args.dpi)
+    else:
+        plot_overlay(segments, args.output, alpha=args.alpha, linewidth=args.linewidth, dpi=args.dpi)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()

--- a/glacium/post/analysis/ice_thickness.py
+++ b/glacium/post/analysis/ice_thickness.py
@@ -102,3 +102,23 @@ def plot_ice_thickness(df: pd.DataFrame, unit: str, outfile: str | Path, upper_l
     fig.savefig(outfile, dpi=300)
     plt.close(fig)
     return outfile
+
+
+def main() -> None:
+    """CLI helper to visualise ice thickness distributions."""
+    import argparse
+
+    ap = argparse.ArgumentParser(description="Plot ice thickness from Tecplot surface export")
+    ap.add_argument("input", type=Path, help="Tecplot ASCII file")
+    ap.add_argument("--chord", type=float, required=True, help="Chord length [m]")
+    ap.add_argument("-o", "--output", type=Path, default="ice_thickness.png", help="Output image file")
+    ap.add_argument("-u", "--unit", default="mm", help="Output unit (m|mm|micron)")
+    args = ap.parse_args()
+
+    df = read_wall_zone(args.input)
+    proc, unit = process_wall_zone(df, args.chord, args.unit)
+    plot_ice_thickness(proc, unit, args.output)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [project.scripts]
 glacium = "glacium.cli:cli"
+glacium-cp = "glacium.post.analysis.cp:main"
+glacium-ice-thickness = "glacium.post.analysis.ice_thickness:main"
+glacium-ice-contours = "glacium.post.analysis.ice_contours:main"
 
 [tool.poetry]
 exclude = [


### PR DESCRIPTION
## Summary
- enable running Cp/ice thickness/ice contour analysis modules directly
- implement `main()` functions using `argparse`
- expose new console entry points in `pyproject.toml`

## Testing
- `pytest -q` *(fails: FileNotFoundError in tests/test_converters.py::test_single_shot_converter)*

------
https://chatgpt.com/codex/tasks/task_e_6878fd25eaf88327b58f4c1d4a282bcb