### PR TITLE
Expose analysis helpers via glacium.post

### DIFF
--- a/docs/high_level_api/postprocessing.rst
+++ b/docs/high_level_api/postprocessing.rst
@@ -74,4 +74,35 @@ The snippet below mirrors the workflow in §8 of ``specs_postprocessing.md``::
    pp.plot("Cl", next(iter(pp.index)))      # first run
    pp.export("/tmp/results.zip")
 
+Analysis helpers
+----------------
+
+Small utilities for analysing Tecplot exports live in the
+:mod:`glacium.post.analysis` package.  They cover pressure coefficient
+computation, ice thickness extraction and visualisation of STL ice
+contours.
+
+Example usage::
+
+   from glacium.post import analysis
+
+   df = analysis.read_tec_ascii("soln.dat")
+   cp = analysis.compute_cp(
+       df,
+       p_inf=101325.0,
+       rho_inf=1.225,
+       u_inf=70.0,
+       chord=1.0,
+       wall_tol=1e-4,
+       rel_pct=2.0,
+   )
+   analysis.plot_cp(cp, "cp.png")
+
+   wall = analysis.read_wall_zone("wall.dat")
+   proc, unit = analysis.process_wall_zone(wall, chord=1.0, unit="mm")
+   analysis.plot_ice_thickness(proc, unit, "ice.png")
+
+   contours = analysis.load_contours("contours/*.stl")
+   analysis.animate_growth(contours, "growth.gif")
+
 

--- a/glacium/post/__init__.py
+++ b/glacium/post/__init__.py
@@ -1,5 +1,6 @@
 from .processor import PostProcessor, write_manifest, index_from_dict
 from .importers import FensapSingleImporter, FensapMultiImporter
+from . import analysis  # exposes glacium.post.analysis.compute_cp etc.
 
 __all__ = [
     "PostProcessor",
@@ -7,4 +8,5 @@ __all__ = [
     "index_from_dict",
     "FensapSingleImporter",
     "FensapMultiImporter",
+    "analysis",
 ]

--- a/glacium/post/convert/single.py
+++ b/glacium/post/convert/single.py
@@ -15,20 +15,20 @@ class SingleShotConverter:
     MAP = {
         "run_FENSAP": (
             "SOLN",            # nti2tec mode
-            "mesh.grid",       # name of grid file inside mesh/
-            "soln",     # raw solution
+            "grid.ice",        # name of grid file inside mesh/
+            "soln.fensap",     # raw solution
             "soln.fensap.dat"  # Tecplot output
         ),
         "run_DROP3D": (
             "DROPLET",
-            "mesh.grid",
-            "droplet",
+            "grid.ice",
+            "droplet.drop",
             "droplet.drop.dat"
         ),
         "run_ICE3D": (
             "SWIMSOL",
-            "ice.grid",
-            "swimsol",
+            "grid.ice",
+            "swimsol.ice",
             "swimsol.ice.dat"
         ),
     }
@@ -57,8 +57,8 @@ class SingleShotConverter:
         else:  # run_ICE3D
             grid_src = run_dir / grid_name  # already local
 
-        src      = run_dir / src_name
-        dst      = run_dir / dst_name
+        src = run_dir / src_name
+        dst = run_dir / dst_name
 
         if not src.exists():
             raise FileNotFoundError(src)
@@ -66,19 +66,15 @@ class SingleShotConverter:
         if dst.exists() and not self.overwrite:
             return dst
 
-        # Ensure grid is in the same folder as the solution
-        grid_local_name = self._ensure_local_grid(grid_src, run_dir)
-
-        # Build command using basenames only
         cmd = [
             str(self.exe),
             mode,
-            grid_local_name,
-            src_name,
-            dst_name,
+            str(grid_src),
+            str(src),
+            str(dst),
         ]
 
-        # Run inside the run directory
-        subprocess.run(cmd, cwd=run_dir, check=True)
+        # Run converter
+        subprocess.run(cmd, check=True)
 
         return dst


### PR DESCRIPTION
## Summary
- re-export `glacium.post.analysis` from the package
- document the new analysis utilities with examples
- fix SingleShotConverter to match spec

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878ff56578c832794668641dd4b7f57