### PR TITLE
Refactor cp2 utils and expose contour helpers

### DIFF
--- a/glacium/post/analysis/__init__.py
+++ b/glacium/post/analysis/__init__.py
@@ -1,6 +1,7 @@
 from .cp import read_tec_ascii, compute_cp, plot_cp
 from .ice_thickness import read_wall_zone, process_wall_zone, plot_ice_thickness
 from .ice_contours import load_contours, plot_overlay, animate_growth
+from .cp2 import load_stl_contour, resample_contour, map_cp_to_contour
 
 __all__ = [
     "read_tec_ascii",
@@ -12,4 +13,7 @@ __all__ = [
     "load_contours",
     "plot_overlay",
     "animate_growth",
+    "load_stl_contour",
+    "resample_contour",
+    "map_cp_to_contour",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ dependencies = [
     "verboselogs>=1",
     "numpy>=1",
     "matplotlib>=3",
+    "trimesh>=4",
+    "scipy>=1",
     "fpdf2 (>=2.8.3,<3.0.0)",
 ]
 


### PR DESCRIPTION
## Summary
- refactor `cp2` to reuse functions from `cp`
- expose STL contour helpers through `glacium.post.analysis`
- update dependencies list
- test contour loading/resampling and Cp mapping

## Testing
- `pytest tests/test_analysis_tools.py::test_load_and_resample_contour -q`
- `pytest -q` *(fails: RuntimeError: Failed to process string with tex because latex could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_6879493287808327b99ce018bd5a68cf