### PR TITLE
Improve Cp plots and animation defaults

### DIFF
--- a/glacium/jobs/analysis_jobs.py
+++ b/glacium/jobs/analysis_jobs.py
@@ -5,6 +5,7 @@ from glacium.engines.py_engine import PyEngine
 from glacium.utils.convergence import analysis, analysis_file
 from glacium.utils.report_converg_fensap import build_report
 from glacium.post import analysis as post_analysis
+import pandas as pd
 import os
 
 
@@ -105,6 +106,7 @@ class AnalyzeMultishotJob(Job):
         wall_tol = float(cfg.get("CP_WALL_TOL", 1e-4))
         rel_pct = float(cfg.get("CP_REL_PCT", 2.0))
 
+        cp_results: list[tuple[str, pd.DataFrame]] = []
         for dat in sorted(run_dir.glob("soln.fensap.??????.dat")):
             df = post_analysis.read_tec_ascii(dat)
             cp = post_analysis.compute_cp(
@@ -116,8 +118,12 @@ class AnalyzeMultishotJob(Job):
                 wall_tol,
                 rel_pct,
             )
+            cp_results.append((dat.stem, cp))
             img = out_dir / f"{dat.stem}_cp.png"
             post_analysis.plot_cp(cp, img)
+
+        if cp_results:
+            post_analysis.plot_cp_overlay(cp_results, out_dir / "all_cp.png")
 
         for dat in sorted(run_dir.glob("swimsol.ice.??????.dat")):
             df = post_analysis.read_wall_zone(dat)

--- a/glacium/post/analysis/__init__.py
+++ b/glacium/post/analysis/__init__.py
@@ -1,4 +1,4 @@
-from .cp import read_tec_ascii, compute_cp, plot_cp
+from .cp import read_tec_ascii, compute_cp, plot_cp, plot_cp_overlay
 from .ice_thickness import read_wall_zone, process_wall_zone, plot_ice_thickness
 from .ice_contours import load_contours, plot_overlay, animate_growth
 from .cp2 import load_stl_contour, resample_contour, map_cp_to_contour
@@ -7,6 +7,7 @@ __all__ = [
     "read_tec_ascii",
     "compute_cp",
     "plot_cp",
+    "plot_cp_overlay",
     "read_wall_zone",
     "process_wall_zone",
     "plot_ice_thickness",

--- a/glacium/post/analysis/cp.py
+++ b/glacium/post/analysis/cp.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List, Tuple
+from typing import Iterable, List, Tuple
 import re
 
 import numpy as np
@@ -11,7 +11,12 @@ import scienceplots
 
 plt.style.use(['science', 'ieee'])
 
-__all__ = ["read_tec_ascii", "compute_cp", "plot_cp"]
+__all__ = [
+    "read_tec_ascii",
+    "compute_cp",
+    "plot_cp",
+    "plot_cp_overlay",
+]
 
 
 def _parse_variable_names(lines: List[str]) -> Tuple[List[str], int]:
@@ -130,11 +135,24 @@ def compute_cp(
     return surf
 
 
-def plot_cp(df: pd.DataFrame, outfile: str | Path, upper_label: str = "Upper", lower_label: str = "Lower") -> Path:
+def plot_cp(df: pd.DataFrame, outfile: str | Path) -> Path:
     fig, ax = plt.subplots(figsize=(6, 4))
-    for surf, label in [("Upper", upper_label), ("Lower", lower_label)]:
-        sub = df[df["Surface"] == surf]
-        ax.plot(sub["x_c"], sub["Cp"], "o-", markersize=3, linewidth=0.8, label=label)
+    ax.plot(df["x_c"], df["Cp"], "o-", markersize=2, linewidth=0.8)
+    ax.invert_yaxis()
+    ax.set_xlabel(r"$x/c$")
+    ax.set_ylabel(r"$C_p$")
+    ax.grid(True, ls=":", lw=0.5)
+    fig.tight_layout()
+    outfile = Path(outfile)
+    fig.savefig(outfile, dpi=300)
+    plt.close(fig)
+    return outfile
+
+
+def plot_cp_overlay(cps: Iterable[tuple[str, pd.DataFrame]], outfile: str | Path) -> Path:
+    fig, ax = plt.subplots(figsize=(6, 4))
+    for label, df in cps:
+        ax.plot(df["x_c"], df["Cp"], "o-", markersize=2, linewidth=0.8, label=label)
     ax.invert_yaxis()
     ax.set_xlabel(r"$x/c$")
     ax.set_ylabel(r"$C_p$")

--- a/glacium/post/analysis/ice_contours.py
+++ b/glacium/post/analysis/ice_contours.py
@@ -74,7 +74,15 @@ def plot_overlay(segments: Iterable[np.ndarray], outfile: str | Path, *, alpha: 
     return outfile
 
 
-def animate_growth(segments: Iterable[np.ndarray], outfile: str | Path, *, fps: int = 10, alpha: float = 0.9, linewidth: float = 1.2, dpi: int = 150) -> Path:
+def animate_growth(
+    segments: Iterable[np.ndarray],
+    outfile: str | Path,
+    *,
+    fps: int = 10,
+    alpha: float = 0.9,
+    linewidth: float = 1.2,
+    dpi: int = 300,
+) -> Path:
     segments = list(segments)
     cmap = plt.get_cmap("viridis", len(segments))
     fig, ax = plt.subplots(dpi=dpi)
@@ -132,7 +140,7 @@ def main() -> None:
     ap.add_argument("--fps", type=int, default=10, help="Frames per second for animation")
     ap.add_argument("--alpha", type=float, default=0.9, help="Line alpha value")
     ap.add_argument("--linewidth", type=float, default=1.2, help="Line width")
-    ap.add_argument("--dpi", type=int, default=150, help="Figure resolution")
+    ap.add_argument("--dpi", type=int, default=300, help="Figure resolution")
     args = ap.parse_args()
 
     segments = load_contours(args.pattern)

--- a/tests/test_analyze_multishot_job.py
+++ b/tests/test_analyze_multishot_job.py
@@ -37,6 +37,7 @@ def test_analyze_multishot_job(tmp_path, monkeypatch):
     monkeypatch.setattr(post_analysis, "read_tec_ascii", rec("read_tec_ascii", "DF"))
     monkeypatch.setattr(post_analysis, "compute_cp", rec("compute_cp", "CP"))
     monkeypatch.setattr(post_analysis, "plot_cp", rec("plot_cp"))
+    monkeypatch.setattr(post_analysis, "plot_cp_overlay", rec("plot_cp_overlay"))
     monkeypatch.setattr(post_analysis, "read_wall_zone", rec("read_wall_zone", "WZ"))
     monkeypatch.setattr(post_analysis, "process_wall_zone", rec("process_wall_zone", ("PROC", "mm")))
     monkeypatch.setattr(post_analysis, "plot_ice_thickness", rec("plot_ice_thickness"))
@@ -50,6 +51,7 @@ def test_analyze_multishot_job(tmp_path, monkeypatch):
     assert calls["read_tec_ascii"][0] == run_dir / "soln.fensap.000001.dat"
     assert calls["compute_cp"][0] == "DF"
     assert calls["plot_cp"][1] == out_dir / "soln.fensap.000001_cp.png"
+    assert calls["plot_cp_overlay"][1] == out_dir / "all_cp.png"
     assert calls["read_wall_zone"][0] == run_dir / "swimsol.ice.000001.dat"
     assert calls["process_wall_zone"][0] == "WZ"
     assert calls["plot_ice_thickness"][2] == out_dir / "swimsol.ice.000001_ice.png"


### PR DESCRIPTION
## Summary
- tweak Cp plot to not split by surface and reduce marker size
- add helper to overlay multiple Cp curves
- create combined Cp plot in `AnalyzeMultishotJob`
- bump animation DPI default to 300
- adjust tests for new overlay behaviour

## Testing
- `pytest tests/test_analyze_multishot_job.py::test_analyze_multishot_job -q`
- `pytest -q` *(fails: RuntimeError: Failed to process string with tex because latex could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68794c3606dc8327b44e80f08b2c5cf1