### PR TITLE
Add mesh helper API to Run

### DIFF
--- a/docs/run_builder.rst
+++ b/docs/run_builder.rst
@@ -29,6 +29,12 @@ Fluent methods
 ``tag(label)``
     Attach a tag to the project directory.
 
+``get_mesh(project)``
+    Return ``Path`` to ``mesh.grid`` inside ``project``.
+
+``set_mesh(path, project)``
+    Copy a mesh file into the project and update configuration keys.
+
 ``clone()``
     Return a copy of the builder with the same settings.
 

--- a/tests/test_run_builder.py
+++ b/tests/test_run_builder.py
@@ -65,3 +65,21 @@ def test_run_builder_updates_case_key(tmp_path):
     case_file = tmp_path / project.uid / "case.yaml"
     case = yaml.safe_load(case_file.read_text())
     assert case["CASE_VELOCITY"] == 123
+
+
+def test_run_builder_mesh_helpers(tmp_path):
+    TemplateManager(Path(__file__).resolve().parents[1] / "glacium" / "templates")
+    run = Run(tmp_path)
+
+    project = run.create()
+
+    mesh_src = tmp_path / "input.grid"
+    mesh_src.write_text("meshdata")
+    run.set_mesh(mesh_src, project)
+
+    dest = run.get_mesh(project)
+    assert dest.read_text() == "meshdata"
+
+    cfg = yaml.safe_load((tmp_path / project.uid / "_cfg" / "global_config.yaml").read_text())
+    assert cfg["FSP_FILES_GRID"] == "../mesh/mesh.grid"
+    assert cfg["ICE_GRID_FILE"] == "../mesh/mesh.grid"


### PR DESCRIPTION
## Summary
- extend docs for new Run helper methods
- implement `get_mesh` and `set_mesh` on Run
- test mesh helpers

## Testing
- `pytest tests/test_run_builder.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687a0de439e88327876e793a0fc1d3ea