### PR TITLE
Add Project API for easier project control

### DIFF
--- a/docs/high_level_api/index.rst
+++ b/docs/high_level_api/index.rst
@@ -6,4 +6,5 @@ High Level API
 
    intro
    run
+   project
    postprocessing

--- a/docs/high_level_api/intro.rst
+++ b/docs/high_level_api/intro.rst
@@ -1,9 +1,10 @@
 Introduction
 =============
    Module: glacium.api
-   Primary class: Run
+   Primary classes: Run and Project
    Purpose: Declarative, chainable DSL for defining and creating aerodynamic
-            simulation cases without exposing low-level managers.
+            simulation cases without exposing low-level managers.  Projects can
+            be executed programmatically via their ``run`` method.
    All methods return self (or a new object) to enable fluent chaining,
    except for pure accessors such as `preview`, `to_dict`, etc.
 
@@ -11,4 +12,5 @@ This section provides an overview of the available classes and helper
 functions.  See the following pages for details:
 
 - :doc:`run`
+- :doc:`project`
 - :doc:`postprocessing`

--- a/docs/high_level_api/project.rst
+++ b/docs/high_level_api/project.rst
@@ -1,0 +1,20 @@
+Project
+=======
+
+:class:`glacium.api.Project` wraps a low level
+:class:`glacium.models.project.Project` instance and exposes a small
+convenience API.  It is returned by :meth:`glacium.api.Run.create` and
+lets you execute jobs programmatically::
+
+   from glacium.api import Run
+
+   project = Run("runs").create()
+   project.run()                # run all jobs
+   project.run("XFOIL_REFINE")  # run a single job by name
+
+The object forwards unknown attributes to the underlying dataclass so
+``project.uid`` and ``project.paths`` work as before.
+
+``run(*jobs)``
+    Execute the given job names via the project's :class:`~glacium.managers.job_manager.JobManager`.
+    When called without arguments all pending jobs are processed.

--- a/glacium/api/__init__.py
+++ b/glacium/api/__init__.py
@@ -1,3 +1,4 @@
-__all__ = ["Run"]
+__all__ = ["Run", "Project"]
 
 from .run import Run
+from .project import Project

--- a/glacium/api/project.py
+++ b/glacium/api/project.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Optional
+
+from glacium.managers.project_manager import ProjectManager
+from glacium.managers.job_manager import JobManager
+from glacium.models.project import Project as ModelProject
+
+__all__ = ["Project"]
+
+
+class Project:
+    """High level wrapper around :class:`~glacium.models.project.Project`."""
+
+    def __init__(self, project: ModelProject) -> None:
+        super().__setattr__("_project", project)
+
+    # ------------------------------------------------------------------
+    @property
+    def uid(self) -> str:
+        return self._project.uid
+
+    @property
+    def root(self) -> Path:
+        return self._project.root
+
+    @property
+    def config(self):
+        return self._project.config
+
+    @property
+    def paths(self):
+        return self._project.paths
+
+    @property
+    def jobs(self):
+        return self._project.jobs
+
+    @property
+    def job_manager(self) -> JobManager:
+        return self._project.job_manager  # type: ignore[return-value]
+
+    # ------------------------------------------------------------------
+    def run(self, *jobs: str) -> "Project":
+        """Execute jobs via the project's :class:`JobManager`."""
+
+        job_list: Optional[Iterable[str]]
+        if jobs:
+            job_list = list(jobs)
+        else:
+            job_list = None
+        if self._project.job_manager is None:
+            self._project.job_manager = JobManager(self._project)  # type: ignore[attr-defined]
+        self._project.job_manager.run(job_list)  # type: ignore[arg-type]
+        return self
+
+    # ------------------------------------------------------------------
+    def __getattr__(self, name: str):
+        return getattr(self._project, name)
+
+    def __setattr__(self, name: str, value):
+        if name == "_project":
+            super().__setattr__(name, value)
+        else:
+            setattr(self._project, name, value)
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def load(cls, runs_root: str | Path, uid: str) -> "Project":
+        """Load an existing project from ``runs_root`` by ``uid``."""
+
+        pm = ProjectManager(Path(runs_root))
+        proj = pm.load(uid)
+        return cls(proj)

--- a/glacium/api/run.py
+++ b/glacium/api/run.py
@@ -11,6 +11,7 @@ from glacium.managers.config_manager import ConfigManager
 from glacium.managers.job_manager import JobManager
 from glacium.utils.JobIndex import JobFactory
 from glacium.utils.logging import log
+from .project import Project
 
 
 class Run:
@@ -125,7 +126,7 @@ class Run:
             except Exception as err:
                 log.error(f"{name}: {err}")
         project.job_manager = JobManager(project)
-        return project
+        return Project(project)
 
     # ------------------------------------------------------------------
     def get_mesh(self, project) -> Path:

--- a/tests/test_project_api.py
+++ b/tests/test_project_api.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+import yaml
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from glacium.api import Run
+from glacium.managers.template_manager import TemplateManager
+from glacium.managers.job_manager import JobManager
+
+
+def test_project_api_run(tmp_path, monkeypatch):
+    TemplateManager(Path(__file__).resolve().parents[1] / "glacium" / "templates")
+    run = Run(tmp_path)
+    project = run.create()
+
+    called = {}
+
+    def fake_run(self, jobs=None):
+        called["jobs"] = jobs
+
+    monkeypatch.setattr(JobManager, "run", fake_run)
+
+    project.run()
+    assert called["jobs"] is None
+
+    project.run("XFOIL_REFINE")
+    assert called["jobs"] == ["XFOIL_REFINE"]


### PR DESCRIPTION
## Summary
- implement `glacium.api.Project` as high level wrapper around the project dataclass
- return the new Project object from `Run.create`
- expose `Project` from `glacium.api`
- document Project API and update intro/index docs
- test Project API `run()` method

## Testing
- `pytest -k project_api_run -q`
- `pytest -k run_builder -q`

------
https://chatgpt.com/codex/tasks/task_e_687a3a0e9ff08327b674936b1a3fa66a