### PR TITLE
Add Run.load method and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ glacium select 1
 ```
 
 The selected UID is stored in `~/.glacium_current` and used by other
-commands.
+commands. Projects can also be reopened programmatically with
+``Run.load(uid)`` from the API.
 
 ### Run jobs
 

--- a/docs/high_level_api/run.rst
+++ b/docs/high_level_api/run.rst
@@ -57,5 +57,8 @@ Utility methods
 ``from_dict(mapping)``
     Recreate a run from serialised data.
 
+``load(uid)``
+    Load an existing project by UID and return a :class:`~glacium.api.Project`.
+
 For the authoritative specification see lines 1–93 of
 ``tasks.md``.

--- a/docs/run_builder.rst
+++ b/docs/run_builder.rst
@@ -45,6 +45,10 @@ Fluent methods
     Build the project on disk and return a
     :class:`~glacium.models.project.Project` instance.
 
+``load(uid)``
+    Open an existing project from ``runs_root`` and return a
+    :class:`~glacium.api.Project` object.
+
 Only keys present in ``case.yaml`` or the generated
 ``global_config.yaml`` can be modified. Unknown keys cause
 ``Run.create()`` to raise a ``KeyError``.

--- a/glacium/api/run.py
+++ b/glacium/api/run.py
@@ -129,6 +129,14 @@ class Run:
         return Project(project)
 
     # ------------------------------------------------------------------
+    def load(self, uid: str) -> Project:
+        """Load an existing project by ``uid`` from ``runs_root``."""
+
+        pm = ProjectManager(self.runs_root)
+        proj = pm.load(uid)
+        return Project(proj)
+
+    # ------------------------------------------------------------------
     def get_mesh(self, project) -> Path:
         """Return the path of ``mesh.grid`` inside ``project``."""
 

--- a/tests/test_project_api.py
+++ b/tests/test_project_api.py
@@ -26,3 +26,12 @@ def test_project_api_run(tmp_path, monkeypatch):
 
     project.run("XFOIL_REFINE")
     assert called["jobs"] == ["XFOIL_REFINE"]
+
+
+def test_run_load(tmp_path):
+    TemplateManager(Path(__file__).resolve().parents[1] / "glacium" / "templates")
+    run = Run(tmp_path)
+    project = run.create()
+
+    loaded = run.load(project.uid)
+    assert loaded.uid == project.uid


### PR DESCRIPTION
## Summary
- implement `Run.load` to load projects using `ProjectManager`
- document project loading in Run API docs and builder docs
- note API loading capability in README
- test that `Run.load` returns a project with the same UID as `Run.create`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687b757fb358832799276be0f9ae256a