### PR TITLE
Add Project.add_job method and docs

### DIFF
--- a/docs/high_level_api/project.rst
+++ b/docs/high_level_api/project.rst
@@ -18,3 +18,17 @@ The object forwards unknown attributes to the underlying dataclass so
 ``run(*jobs)``
     Execute the given job names via the project's :class:`~glacium.managers.job_manager.JobManager`.
     When called without arguments all pending jobs are processed.
+
+``load(runs_root, uid)``
+    Class method returning a project loaded from ``runs_root/uid``.
+
+``add_job(name)``
+    Append ``name`` and any missing dependencies.  The jobs configuration
+    and recipe are updated on disk.  Returns a list of added job names.
+
+Example::
+
+   from glacium.api import Project
+
+   project = Project.load("runs", "my-id")
+   project.add_job("POINTWISE_MESH2")

--- a/glacium/api/project.py
+++ b/glacium/api/project.py
@@ -73,3 +73,69 @@ class Project:
         pm = ProjectManager(Path(runs_root))
         proj = pm.load(uid)
         return cls(proj)
+
+    # ------------------------------------------------------------------
+    def add_job(self, name: str) -> list[str]:
+        """Append ``name`` and its missing dependencies.
+
+        The project configuration is updated and ``jobs.yaml`` is
+        persisted.  The return value lists all job names that were
+        actually appended to the project in dependency order.
+        """
+
+        proj = self._project
+        if proj.job_manager is None:
+            proj.job_manager = JobManager(proj)  # type: ignore[attr-defined]
+
+        from glacium.managers.recipe_manager import RecipeManager
+        from glacium.managers.config_manager import ConfigManager
+        from glacium.utils import list_jobs
+        from glacium.utils.JobIndex import JobFactory
+
+        if proj.config.recipe == "CUSTOM":
+            recipe_jobs = {}
+        else:
+            recipe = RecipeManager.create(proj.config.recipe)
+            recipe_jobs = {j.name: j for j in recipe.build(proj)}
+
+        if name.isdigit():
+            idx = int(name) - 1
+            all_jobs = list_jobs()
+            if idx < 0 or idx >= len(all_jobs):
+                raise ValueError("invalid job number")
+            target = all_jobs[idx]
+        else:
+            target = name.upper()
+
+        added: list[str] = []
+
+        def add_with_deps(jname: str) -> None:
+            if jname in proj.job_manager._jobs or jname in added:
+                return
+            job = recipe_jobs.get(jname)
+            if job is None:
+                if JobFactory.get(jname) is None:
+                    raise KeyError(f"Job '{jname}' not known")
+                job = JobFactory.create(jname, proj)
+            for dep in getattr(job, "deps", ()):
+                add_with_deps(dep)
+            proj.jobs.append(job)
+            proj.job_manager._jobs[jname] = job
+            try:
+                job.prepare()
+            except Exception:
+                pass
+            added.append(jname)
+
+        add_with_deps(target)
+
+        proj.job_manager._save_status()
+
+        proj.config.recipe = "CUSTOM"
+        cfg_mgr = ConfigManager(proj.paths)
+        cfg = cfg_mgr.load_global()
+        cfg.recipe = "CUSTOM"
+        cfg_mgr.dump_global()
+        cfg_mgr.set("RECIPE", "CUSTOM")
+
+        return added

--- a/tests/test_project_api.py
+++ b/tests/test_project_api.py
@@ -35,3 +35,22 @@ def test_run_load(tmp_path):
 
     loaded = run.load(project.uid)
     assert loaded.uid == project.uid
+
+
+def test_project_add_job(tmp_path):
+    TemplateManager(Path(__file__).resolve().parents[1] / "glacium" / "templates")
+    run = Run(tmp_path)
+    project = run.create()
+
+    added = project.add_job("CONVERGENCE_STATS")
+    assert "CONVERGENCE_STATS" in added
+    assert "MULTISHOT_RUN" in added
+
+    jobs_yaml = tmp_path / project.uid / "_cfg" / "jobs.yaml"
+    data = yaml.safe_load(jobs_yaml.read_text())
+    assert "CONVERGENCE_STATS" in data
+    assert "MULTISHOT_RUN" in data
+
+    cfg_file = tmp_path / project.uid / "_cfg" / "global_config.yaml"
+    cfg = yaml.safe_load(cfg_file.read_text())
+    assert cfg["RECIPE"] == "CUSTOM"


### PR DESCRIPTION
## Summary
- document `Project.load` and `Project.add_job`
- implement `Project.add_job` to match CLI behaviour
- show usage example in docs
- extend tests for API job addition

## Testing
- `pytest tests/test_project_api.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687b791c1e548327af39c615cb79e40b