### PR TITLE
Add API usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,14 @@ glacium select 1
 
 The selected UID is stored in `~/.glacium_current` and used by other
 commands. Projects can also be reopened programmatically with
-``Run.load(uid)`` from the API.
+``Run.load(uid)`` from the API. A minimal end-to-end example looks like::
+
+   from glacium.api import Run, Project
+
+   uid = Run("runs").create().uid
+   proj = Project.load("runs", uid)       # or Run("runs").load(uid)
+   proj.add_job("POINTWISE_MESH2")
+   proj.run()
 
 ### Run jobs
 

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -190,6 +190,17 @@ configuration:
 .. code-block:: bash
 
    glacium info
+Programmatic example
+--------------------
+
+The API can create and run projects directly from Python (see :doc:`high_level_api/index`)::
+
+   from glacium.api import Run, Project
+
+   uid = Run("runs").create().uid
+   proj = Project.load("runs", uid)       # or Run("runs").load(uid)
+   proj.add_job("POINTWISE_MESH2")
+   proj.run()
 
 Logging
 -------


### PR DESCRIPTION
## Summary
- document a short API-based workflow in README
- add the same example to the quick start guide

## Testing
- `make -C docs html`

------
https://chatgpt.com/codex/tasks/task_e_687b7c8260dc83279a515633395e7e12