### PR TITLE
Document Project.set on loaded projects

### DIFF
--- a/docs/high_level_api/run.rst
+++ b/docs/high_level_api/run.rst
@@ -61,5 +61,14 @@ Utility methods
 ``load(uid)``
     Load an existing project by UID and return a :class:`~glacium.api.Project`.
 
+``set(key, value)`` on a loaded project updates ``global_config.yaml`` on disk.
+If the key is present in ``case.yaml`` the case file is modified and
+``case_to_global`` regenerates the global configuration.
+
+Example::
+
+   run = Project.load("runs", "my-id")
+   run.set("CASE_VELOCITY", 120.0)
+
 For the authoritative specification see lines 1–93 of
 ``tasks.md``.

--- a/docs/run_builder.rst
+++ b/docs/run_builder.rst
@@ -49,6 +49,12 @@ Fluent methods
     Open an existing project from ``runs_root`` and return a
     :class:`~glacium.api.Project` object.
 
+Values can be updated on loaded projects with ``set(key, value)``.  The
+corresponding entry in ``global_config.yaml`` is modified immediately.
+When the key also appears in ``case.yaml`` the file is rewritten and the
+complete ``global_config.yaml`` is regenerated via
+``case_to_global``.
+
 Only keys present in ``case.yaml`` or the generated
 ``global_config.yaml`` can be modified. Unknown keys cause
 ``Project.create()`` to raise a ``KeyError``.
@@ -70,4 +76,7 @@ Example usage
        .create()
    )
    print("Created", project.root)
+
+   loaded = Project("runs").load(project.uid)
+   loaded.set("CASE_VELOCITY", 100)
 


### PR DESCRIPTION
## Summary
- explain that `Project.set` can update configuration on loaded projects
- mention regeneration via `case_to_global`
- add example showing modification of a loaded project

## Testing
- `pytest -q` *(fails: latex not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f25e7b1b883279acd5ecae8143bf4