### PR TITLE
Add CLI for Cp directional plots

### DIFF
--- a/glacium/post/analysis/__init__.py
+++ b/glacium/post/analysis/__init__.py
@@ -2,12 +2,14 @@ from .cp import read_tec_ascii, compute_cp, plot_cp, plot_cp_overlay
 from .ice_thickness import read_wall_zone, process_wall_zone, plot_ice_thickness
 from .ice_contours import load_contours, plot_overlay, animate_growth
 from .cp2 import load_stl_contour, resample_contour, map_cp_to_contour
+from .plot_cp import plot_cp_directional
 
 __all__ = [
     "read_tec_ascii",
     "compute_cp",
     "plot_cp",
     "plot_cp_overlay",
+    "plot_cp_directional",
     "read_wall_zone",
     "process_wall_zone",
     "plot_ice_thickness",

--- a/glacium/post/analysis/ice_contours.py
+++ b/glacium/post/analysis/ice_contours.py
@@ -18,14 +18,20 @@ __all__ = ["load_contours", "plot_overlay", "animate_growth"]
 
 
 import re
-DIGITS6 = re.compile(r"(\d{6})\.stl$", re.I)
+
+DIGITS = re.compile(r"(\d+)", re.I)
+
 
 def _sorted_files(pattern: str) -> list[str]:
-    files = [p for p in Path().glob(pattern) if DIGITS6.search(p.name)]
+    files = list(Path().glob(pattern))
     if not files:
         raise FileNotFoundError("No STL files found – check pattern")
 
-    return [str(p) for p in sorted(files, key=lambda p: int(DIGITS6.search(p.name).group(1)))]
+    def _sort_key(p: Path) -> tuple[int, str]:
+        m = DIGITS.search(p.stem)
+        return (int(m.group(1)) if m else 0, p.name)
+
+    return [str(p) for p in sorted(files, key=_sort_key)]
 
 
 def _boundary_edges_xy(mesh: trimesh.Trimesh) -> np.ndarray:

--- a/glacium/post/analysis/plot_cp.py
+++ b/glacium/post/analysis/plot_cp.py
@@ -1,19 +1,13 @@
-"""cp_vs_xc_dircolor.py
--------------------------------------------------
-Plot Cp versus x/c for the body surface, colouring each line segment by **direction**:
-• red   – segment moves to larger x/c (rightward)
-• black – segment moves to smaller x/c (leftward)
+"""Cp plotting colouring each segment by direction.
 
-The wall nodes are identified using the global minimum of "wall distance (m)".
-Nodes are then ordered with the same nearest‑neighbour walk used previously.
-
-Parameters to set below:
-• `FILEPATH`, freestream `P_INF`, `RHO_INF`, `V_INF`
-• `CHORD` – chord length for normalising x.
-• `OUTPUT_PNG` – optional filename for saving the figure.
-
-Dependencies: numpy, pandas, matplotlib, scipy.
+This module was originally written as a standalone script. The
+functionality has been wrapped into :func:`plot_cp_directional` which
+computes the Cp distribution from a Tecplot ASCII file and generates a
+plot with line segments coloured according to their x-direction.
 """
+
+from __future__ import annotations
+
 import re
 from pathlib import Path
 
@@ -23,121 +17,129 @@ import matplotlib.pyplot as plt
 from matplotlib.collections import LineCollection
 from scipy.spatial import KDTree
 
-# ────────────────────── USER INPUT ───────────────────────────────────────────
-FILEPATH = Path("soln.fensap.000016.dat")  # Tecplot ASCII file
-P_INF = 101_325.0       # Freestream static pressure [Pa]
-RHO_INF = 1.225         # Freestream density         [kg/m³]
-V_INF = 50.0            # Freestream velocity mag.   [m/s]
-CHORD = 0.431           # Chord length c [m]
-OUTPUT_PNG = Path("cp_vs_xc_dircolor.png")  # set to None to skip saving
-# ----------------------------------------------------------------------------
 
-# 1 ── Read VARIABLE list & first ZONE block (nodes only) ────────────────────
-with FILEPATH.open("r") as f:
-    # VARIABLES
-    for line in f:
-        if line.lstrip().startswith("VARIABLES"):
-            variables = [m.strip("\"") for m in re.findall(r"\"([^\"]+)\"", line)]
-            break
+def plot_cp_directional(
+    infile: str | Path,
+    p_inf: float,
+    rho_inf: float,
+    v_inf: float,
+    chord: float,
+    outfile: str | Path | None = None,
+) -> Path | None:
+    """Plot Cp versus ``x/c`` colouring each segment by direction."""
+    infile = Path(infile)
+    with infile.open("r") as f:
+        for line in f:
+            if line.lstrip().startswith("VARIABLES"):
+                variables = [m.strip("\"") for m in re.findall(r"\"([^\"]+)\"", line)]
+                break
+        else:
+            raise RuntimeError("VARIABLES line not found.")
+
+        for line in f:
+            if line.lstrip().startswith("ZONE"):
+                m = re.search(r"\bN\s*=\s*(\d+)", line)
+                if m is None:
+                    raise RuntimeError("Could not parse N= in ZONE header.")
+                n_nodes = int(m.group(1))
+                break
+        else:
+            raise RuntimeError("ZONE header not found.")
+
+        rows: list[list[float]] = []
+        for _ in range(n_nodes):
+            row = f.readline()
+            if not row:
+                raise RuntimeError("Unexpected EOF while reading node data.")
+            row = row.replace("D+", "E+").replace("D-", "E-")
+            rows.append([float(v) for v in row.split()])
+
+    df = pd.DataFrame(rows, columns=variables)
+
+    q_inf = 0.5 * rho_inf * v_inf ** 2
+    if q_inf == 0:
+        raise ValueError("q_inf is zero; check rho_inf or v_inf.")
+
+    df["Cp"] = (df["Pressure (N/m^2)"] - p_inf) / q_inf
+
+    wd_key = "wall distance (m)"
+    if wd_key not in df.columns:
+        raise KeyError(f"{wd_key!r} not found in variables.")
+
+    wd_min = df[wd_key].min()
+    wd_tol = abs(wd_min) * 1e-6 + 1e-12
+    wall = df[df[wd_key] <= wd_min + wd_tol].copy()
+
+    if wall.empty:
+        raise RuntimeError("No nodes at global minimum wall distance.")
+
+    coords = wall[["X", "Y"]].to_numpy()
+    start_idx = int(np.argmin(coords[:, 0]))
+    visited = np.zeros(len(coords), dtype=bool)
+    order = [start_idx]
+    visited[start_idx] = True
+    kd = KDTree(coords)
+
+    while visited.sum() < len(coords):
+        current = order[-1]
+        k_neigh = min(8, len(coords) - visited.sum())
+        _, idxs = kd.query(coords[current], k=k_neigh)
+        if np.isscalar(idxs):
+            idxs = [idxs]
+        next_idx = next((i for i in idxs if not visited[i]), None)
+        if next_idx is None:
+            remaining = np.where(~visited)[0]
+            deltas = coords[remaining] - coords[current]
+            next_idx = remaining[np.argmin(np.einsum("ij,ij->i", deltas, deltas))]
+        order.append(next_idx)
+        visited[next_idx] = True
+
+    wall_sorted = wall.iloc[order].reset_index(drop=True)
+
+    xc = wall_sorted["X"].to_numpy() / chord
+    cp = wall_sorted["Cp"].to_numpy()
+
+    dx = np.diff(xc)
+    colours = ["red" if d > 0 else "black" for d in dx]
+    segments = [((xc[i], cp[i]), (xc[i + 1], cp[i + 1])) for i in range(len(dx))]
+
+    fig, ax = plt.subplots(figsize=(8, 4))
+    lc = LineCollection(segments, colors=colours, linewidths=1.0)
+    ax.add_collection(lc)
+    ax.invert_yaxis()
+    ax.set_xlabel("x/c [-]")
+    ax.set_ylabel("Cp [-]")
+    ax.set_title("Cp vs x/c")
+    ax.grid(True)
+    ax.set_xlim(xc.min(), xc.max())
+    ax.set_ylim(cp.max(), cp.min())
+    fig.tight_layout()
+
+    if outfile is not None:
+        outfile = Path(outfile)
+        fig.savefig(outfile, dpi=1200)
+        plt.close(fig)
+        return outfile
     else:
-        raise RuntimeError("VARIABLES line not found.")
+        plt.show()
+        return None
 
-    # ZONE
-    for line in f:
-        if line.lstrip().startswith("ZONE"):
-            m = re.search(r"\bN\s*=\s*(\d+)", line)
-            if m is None:
-                raise RuntimeError("Could not parse N= in ZONE header.")
-            n_nodes = int(m.group(1))
-            break
-    else:
-        raise RuntimeError("ZONE header not found.")
 
-    rows: list[list[float]] = []
-    for _ in range(n_nodes):
-        row = f.readline()
-        if not row:
-            raise RuntimeError("Unexpected EOF while reading node data.")
-        row = row.replace("D+", "E+").replace("D-", "E-")
-        rows.append([float(v) for v in row.split()])
+def main() -> None:
+    """CLI entry point for :func:`plot_cp_directional`."""
+    import argparse
 
-df = pd.DataFrame(rows, columns=variables)
+    ap = argparse.ArgumentParser(description="Plot Cp with direction-coloured segments")
+    ap.add_argument("infile", type=Path, help="Tecplot ASCII file")
+    ap.add_argument("--p-inf", type=float, required=True, help="Free-stream pressure [Pa]")
+    ap.add_argument("--rho-inf", type=float, required=True, help="Free-stream density [kg/m^3]")
+    ap.add_argument("--v-inf", type=float, required=True, help="Free-stream velocity [m/s]")
+    ap.add_argument("--chord", type=float, required=True, help="Chord length [m]")
+    ap.add_argument("-o", "--output", type=Path, help="Output PNG file")
+    args = ap.parse_args()
 
-# 2 ── Compute Cp ─────────────────────────────────────────────────-----------
-q_inf = 0.5 * RHO_INF * V_INF ** 2
-if q_inf == 0:
-    raise ValueError("q_inf is zero; check RHO_INF or V_INF.")
+    plot_cp_directional(args.infile, args.p_inf, args.rho_inf, args.v_inf, args.chord, args.output)
 
-df["Cp"] = (df["Pressure (N/m^2)"] - P_INF) / q_inf
 
-# 3 ── Select wall nodes (minimum wall distance) ───────────────────────────--
-wd_key = "wall distance (m)"
-if wd_key not in df.columns:
-    raise KeyError(f"{wd_key!r} not found in variables.")
-
-wd_min = df[wd_key].min()
-wd_tol = abs(wd_min) * 1e-6 + 1e-12
-wall = df[df[wd_key] <= wd_min + wd_tol].copy()
-
-if wall.empty:
-    raise RuntimeError("No nodes at global minimum wall distance.")
-
-# 4 ── Order wall nodes with nearest‑neighbour walk ─────────────────────────-
-coords = wall[["X", "Y"]].to_numpy()
-start_idx = int(np.argmin(coords[:, 0]))  # most upstream
-visited = np.zeros(len(coords), dtype=bool)
-order = [start_idx]
-visited[start_idx] = True
-kd = KDTree(coords)
-
-while visited.sum() < len(coords):
-    current = order[-1]
-    k_neigh = min(8, len(coords) - visited.sum())
-    dists, idxs = kd.query(coords[current], k=k_neigh)
-    if np.isscalar(idxs):
-        idxs = [idxs]
-    next_idx = next((i for i in idxs if not visited[i]), None)
-    if next_idx is None:
-        remaining = np.where(~visited)[0]
-        deltas = coords[remaining] - coords[current]
-        next_idx = remaining[np.argmin(np.einsum("ij,ij->i", deltas, deltas))]
-    order.append(next_idx)
-    visited[next_idx] = True
-
-wall_sorted = wall.iloc[order].reset_index(drop=True)
-
-# 5 ── Prepare x/c, Cp and colours by direction ─────────────────────────────
-xc = wall_sorted["X"].to_numpy() / CHORD
-cp = wall_sorted["Cp"].to_numpy()
-
-# Determine colour per segment based on delta x
-dx = np.diff(xc)
-colours = ["red" if d > 0 else "black" for d in dx]
-segments = [((xc[i], cp[i]), (xc[i+1], cp[i+1])) for i in range(len(dx))]
-
-# 6 ── Plot Cp(x/c) with colour‑coded segments ─────────────────────────------
-fig, ax = plt.subplots(figsize=(8, 4))
-
-lc = LineCollection(segments, colors=colours, linewidths=1.0)
-ax.add_collection(lc)
-
-# add markers for visibility
-#ax.scatter(xc, cp, color="k", s=6, zorder=2)
-
-ax.invert_yaxis()
-ax.set_xlabel("x/c [-]")
-ax.set_ylabel("Cp [-]")
-ax.set_title("Cp vs x/c")
-ax.grid(True)
-
-# Adjust x/y limits
-ax.set_xlim(xc.min(), xc.max())
-ax.set_ylim(cp.max(), cp.min())
-
-plt.tight_layout()
-
-if OUTPUT_PNG is not None:
-    fig.savefig(OUTPUT_PNG, dpi=1200)
-    print(f"Saved figure → {OUTPUT_PNG}")
-
-plt.show()
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()

--- a/glacium/utils/convergence.py
+++ b/glacium/utils/convergence.py
@@ -244,6 +244,7 @@ def plot_stats(
     import numpy as np
     import scienceplots
     plt.style.use(["science", "ieee"])
+    plt.rcParams["text.usetex"] = False
 
     out = Path(out_dir)
     fig_dir = out / "figures"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ glacium = "glacium.cli:cli"
 glacium-cp = "glacium.post.analysis.cp:main"
 glacium-ice-thickness = "glacium.post.analysis.ice_thickness:main"
 glacium-ice-contours = "glacium.post.analysis.ice_contours:main"
+glacium-plot-cp = "glacium.post.analysis.plot_cp:main"
 
 [tool.poetry]
 exclude = [


### PR DESCRIPTION
## Summary
- refactor Cp plotting script into a callable
- expose `plot_cp_directional` through package init
- provide CLI entry `glacium-plot-cp`
- allow STL contour loading without 6‑digit numbering
- disable LaTeX in convergence stats plotting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880895e937883279defd9d8ec4a0afc