### PR TITLE
Add MeshAnalysisJob for mesh screenshots and HTML reports

### DIFF
--- a/glacium/jobs/__init__.py
+++ b/glacium/jobs/__init__.py
@@ -11,6 +11,7 @@ from .analysis_jobs import (
     FensapConvergenceStatsJob,
     Drop3dConvergenceStatsJob,
     Ice3dConvergenceStatsJob,
+    MeshAnalysisJob,
 )
 from .pointwise_jobs import PointwiseGCIJob, PointwiseMesh2Job
 from .xfoil_jobs import (
@@ -34,6 +35,7 @@ __all__ = [
     "FensapConvergenceStatsJob",
     "Drop3dConvergenceStatsJob",
     "Ice3dConvergenceStatsJob",
+    "MeshAnalysisJob",
     "PointwiseGCIJob",
     "PointwiseMesh2Job",
     "XfoilRefineJob",

--- a/glacium/jobs/analysis_jobs.py
+++ b/glacium/jobs/analysis_jobs.py
@@ -4,6 +4,7 @@ from glacium.models.job import Job
 from glacium.engines.py_engine import PyEngine
 from glacium.utils.convergence import analysis, analysis_file
 from glacium.utils.report_converg_fensap import build_report
+from glacium.utils.mesh_analysis import mesh_analysis
 from glacium.post import analysis as post_analysis
 import pandas as pd
 import os
@@ -140,11 +141,27 @@ class AnalyzeMultishotJob(Job):
         post_analysis.animate_growth(segments, out_dir / "ice_growth.gif")
 
 
+class MeshAnalysisJob(Job):
+    """Generate mesh screenshots and HTML report."""
+
+    name = "MESH_ANALYSIS"
+    deps: tuple[str, ...] = ()
+
+    def execute(self) -> None:  # noqa: D401
+        project_root = self.project.root
+        meshfile = project_root / "run_MULTISHOT" / "lastwrap-remeshed.msh"
+        out_dir = project_root / "analysis" / "MESH"
+
+        engine = PyEngine(mesh_analysis)
+        engine.run([meshfile, out_dir, out_dir / "mesh_report.html"], cwd=project_root)
+
+
 __all__ = [
     "ConvergenceStatsJob",
     "FensapConvergenceStatsJob",
     "Drop3dConvergenceStatsJob",
     "Ice3dConvergenceStatsJob",
     "AnalyzeMultishotJob",
+    "MeshAnalysisJob",
 ]
 

--- a/glacium/utils/mesh_analysis.py
+++ b/glacium/utils/mesh_analysis.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Sequence
+import sys
+
+from . import postprocess_mesh_multi, postprocess_mesh_html
+
+
+def mesh_analysis(cwd: Path, args: Sequence[str | Path]) -> None:
+    """Run mesh screenshot and HTML report helpers.
+
+    Parameters
+    ----------
+    cwd:
+        Working directory supplied by :class:`~glacium.engines.py_engine.PyEngine`.
+        Unused but kept for API compatibility.
+    args:
+        Sequence containing ``meshfile``, ``out_dir`` and ``html_file``.
+        ``out_dir`` and ``html_file`` are optional.
+    """
+    if not args:
+        raise ValueError("mesh_analysis requires a mesh file path")
+
+    meshfile = str(args[0])
+    out_dir = Path(args[1]) if len(args) > 1 else Path("analysis/MESH")
+    html_file = Path(args[2]) if len(args) > 2 else out_dir / "mesh_report.html"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    argv_backup = sys.argv
+    try:
+        sys.argv = [
+            "postprocess_mesh_multi.py",
+            meshfile,
+            "--outdir",
+            str(out_dir),
+        ]
+        postprocess_mesh_multi.main()
+    finally:
+        sys.argv = argv_backup
+
+    argv_backup = sys.argv
+    try:
+        sys.argv = [
+            "postprocess_mesh_html.py",
+            meshfile,
+            "-o",
+            str(html_file),
+            "--png-dir",
+            str(out_dir),
+        ]
+        postprocess_mesh_html.main()
+    finally:
+        sys.argv = argv_backup
+

--- a/specs_postprocessing.md
+++ b/specs_postprocessing.md
@@ -210,8 +210,9 @@ class FensapMultiImporter:
 | `POSTPROCESS_SINGLE_FENSAP` | Calls `SingleShotConverter(root).convert()` *once* per single‑shot run directory.           | Attach to `run_FENSAP`, `run_DROP3D`, `run_ICE3D`. |
 | `POSTPROCESS_MULTISHOT`     | Calls `MultiShotConverter(root / "run_MULTISHOT").convert_all()` after the solver finishes. | Attach at pipeline end.                            |
 | `ANALYZE_MULTISHOT`         | Run analysis helpers on MULTISHOT data and store plots in `analysis/MULTISHOT`. | Attach after `POSTPROCESS_MULTISHOT`. |
+| `MESH_ANALYSIS`             | Create mesh quality screenshots and an HTML report using `mesh_analysis`. Results are written to `analysis/MESH`. | Run after meshing is complete. |
 
-Both jobs create a manifest (`manifest.json`) so the PostProcessor loads instantly:
+POSTPROCESS jobs create a manifest (`manifest.json`) so the PostProcessor loads instantly:
 
 ```python
 pp = PostProcessor(project_path)  # auto‑reads manifest if exists

--- a/tests/test_mesh_analysis_job.py
+++ b/tests/test_mesh_analysis_job.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from glacium.jobs.analysis_jobs import MeshAnalysisJob
+import glacium.jobs.analysis_jobs as analysis_jobs
+from glacium.models.config import GlobalConfig
+from glacium.managers.path_manager import PathBuilder
+from glacium.models.project import Project
+from glacium.managers.job_manager import JobManager
+
+
+def test_mesh_analysis_job(tmp_path, monkeypatch):
+    run_dir = tmp_path / "run_MULTISHOT"
+    run_dir.mkdir()
+    mesh = run_dir / "lastwrap-remeshed.msh"
+    mesh.write_text("")
+
+    cfg = GlobalConfig(project_uid="uid", base_dir=tmp_path)
+    paths = PathBuilder(tmp_path).build()
+    paths.ensure()
+
+    project = Project("uid", tmp_path, cfg, paths, [])
+    job = MeshAnalysisJob(project)
+    job.deps = ()
+    project.jobs = [job]
+
+    called = {}
+
+    def fake_mesh_analysis(cwd, args):
+        called["cwd"] = cwd
+        called["args"] = list(args)
+
+    monkeypatch.setattr(analysis_jobs, "mesh_analysis", fake_mesh_analysis)
+
+    jm = JobManager(project)
+    jm.run()
+
+    out_dir = tmp_path / "analysis" / "MESH"
+    assert called["cwd"] == tmp_path
+    assert called["args"][0] == mesh
+    assert called["args"][1] == out_dir
+    assert called["args"][2] == out_dir / "mesh_report.html"
+


### PR DESCRIPTION
## Summary
- create `mesh_analysis` utility combining mesh screenshot and HTML tools
- add `MeshAnalysisJob` calling the helper via `PyEngine`
- expose new job through `glacium.jobs` package
- document the job in `specs_postprocessing.md`
- cover behaviour with tests

## Testing
- `pytest tests/test_mesh_analysis_job.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68808f6a655883278ece34fc44e0f884