### PR TITLE
Add Project.get method with lookup logic

### DIFF
--- a/tests/test_project_get.py
+++ b/tests/test_project_get.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+from glacium.api import Project
+from glacium.managers.template_manager import TemplateManager
+
+
+def test_project_get(tmp_path):
+    TemplateManager(Path(__file__).resolve().parents[1] / "glacium" / "templates")
+    proj = Project(tmp_path).set("CASE_VELOCITY", 42).set("FSP_MAX_TIME_STEPS_PER_CYCLE", 7).create()
+
+    assert proj.get("case_velocity") == 42
+    assert proj.get("fsp_max_time_steps_per_cycle") == 7
+
+    with pytest.raises(KeyError):
+        proj.get("unknown_key")


### PR DESCRIPTION
## Summary
- implement `Project.get` that reads case.yaml and global config
- add unit test for retrieving values from case and global config

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6880d6c759008327a1ce3ef1d4e68b15