### PR TITLE
Support results in Project.get

### DIFF
--- a/glacium/api/project.py
+++ b/glacium/api/project.py
@@ -116,6 +116,15 @@ class Project:
         if ukey in cfg.extras:
             return cfg.extras[ukey]
 
+        res_file = self._project.root / "results.yaml"
+        res_data: Dict[str, Any] = {}
+        if res_file.exists():
+            res_data = yaml.safe_load(res_file.read_text()) or {}
+
+        res_map = {k.upper(): v for k, v in res_data.items()}
+        if ukey in res_map:
+            return res_map[ukey]
+
         raise KeyError(key)
 
     def set_bulk(self, data: Dict[str, Any]) -> "Project":

--- a/tests/test_project_get.py
+++ b/tests/test_project_get.py
@@ -17,3 +17,12 @@ def test_project_get(tmp_path):
 
     with pytest.raises(KeyError):
         proj.get("unknown_key")
+
+
+def test_project_get_results(tmp_path):
+    TemplateManager(Path(__file__).resolve().parents[1] / "glacium" / "templates")
+    proj = Project(tmp_path).create()
+
+    (proj.root / "results.yaml").write_text("CL_MEAN: 2.5\n")
+
+    assert proj.get("cl_mean") == 2.5


### PR DESCRIPTION
## Summary
- expand `Project.get` to read from `results.yaml`
- add tests for reading from results

## Testing
- `pytest tests/test_project_get.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880da03b8008327a7881529b9661b7b