### PR TITLE
Introduce ProjectBuilder

### DIFF
--- a/glacium/api/__init__.py
+++ b/glacium/api/__init__.py
@@ -1,6 +1,7 @@
-__all__ = ["Project"]
+__all__ = ["Project", "ProjectBuilder"]
 
 from .project import Project
+from .project_builder import ProjectBuilder
 
 # Compatibility alias
 Run = Project

--- a/glacium/api/project.py
+++ b/glacium/api/project.py
@@ -6,11 +6,9 @@ import shutil
 import yaml
 
 from glacium.utils.JobIndex import JobFactory
-from glacium.utils.logging import log
 from glacium.utils import generate_global_defaults, global_default_config
 
 from glacium.managers.config_manager import ConfigManager
-
 from glacium.managers.project_manager import ProjectManager
 from glacium.managers.job_manager import JobManager
 from glacium.models.project import Project as ModelProject
@@ -19,51 +17,17 @@ __all__ = ["Project"]
 
 
 class Project:
-    """High level wrapper around :class:`~glacium.models.project.Project` as
-    well as a builder for new projects."""
+    """Runtime helper around :class:`~glacium.models.project.Project`."""
 
-    _default_airfoil = Path(__file__).resolve().parents[1] / "data" / "AH63K127.dat"
-
-    def __init__(self, source: ModelProject | str | Path) -> None:
-        if isinstance(source, ModelProject):
-            super().__setattr__("_project", source)
-            super().__setattr__("_builder", False)
-        else:
-            super().__setattr__("runs_root", Path(source))
-            super().__setattr__("_name", "project")
-            super().__setattr__("_airfoil", self._default_airfoil)
-            super().__setattr__("_params", {"RECIPE": "prep"})
-            super().__setattr__("_jobs", [])
-            super().__setattr__("tags", [])
-            super().__setattr__("_project", None)
-            super().__setattr__("_builder", True)
+    def __init__(self, source: ModelProject) -> None:
+        super().__setattr__("_project", source)
 
     # ------------------------------------------------------------------
-    # Builder helpers
+    # Config access
     # ------------------------------------------------------------------
-    def name(self, value: str) -> "Project":
-        self._name = value
-        return self
-
-    def select_airfoil(self, airfoil: str | Path) -> "Project":
-        self._airfoil = Path(airfoil)
-        return self
-
     def set(self, key: str, value: Any) -> "Project":
-        """Set a configuration parameter.
+        """Update a configuration parameter."""
 
-        When called on a builder instance, the value is stored until
-        :meth:`create` is invoked.  Otherwise ``case.yaml`` and the global
-        configuration of the loaded project are updated immediately.
-        """
-
-        ukey = key.upper()
-
-        if self._builder:
-            self._params[ukey] = value
-            return self
-
-        # operating on an existing project ------------------------------
         cfg_mgr = ConfigManager(self._project.paths)
         case_file = self._project.root / "case.yaml"
         case_data: Dict[str, Any] = {}
@@ -72,6 +36,7 @@ class Project:
 
         global_cfg = cfg_mgr.load_global()
 
+        ukey = key.upper()
         if ukey in {k.upper() for k in case_data.keys()}:
             case_data[ukey] = value
             case_file.write_text(yaml.safe_dump(case_data, sort_keys=False))
@@ -89,12 +54,6 @@ class Project:
         """Return value for ``key`` from case data or the global configuration."""
 
         ukey = key.upper()
-
-        if self._builder:
-            if ukey in self._params:
-                return self._params[ukey]
-            raise KeyError(key)
-
         cfg_mgr = ConfigManager(self._project.paths)
         case_file = self._project.root / "case.yaml"
         case_data: Dict[str, Any] = {}
@@ -132,12 +91,10 @@ class Project:
             self.set(k, v)
         return self
 
+    # ------------------------------------------------------------------
+    # Job management
+    # ------------------------------------------------------------------
     def add_job(self, name: str):
-        if self._builder:
-            self._jobs.append(name)
-            return self
-
-        # operating on an existing project ------------------------------
         proj = self._project
         if proj.job_manager is None:
             proj.job_manager = JobManager(proj)  # type: ignore[attr-defined]
@@ -170,7 +127,7 @@ class Project:
                 if JobFactory.get(jname) is None:
                     raise KeyError(f"Job '{jname}' not known")
                 job = JobFactory.create(jname, proj)
-            for dep in getattr(job, "deps", ()):
+            for dep in getattr(job, "deps", ()):  # type: ignore[attr-defined]
                 add_with_deps(dep)
             proj.jobs.append(job)
             proj.job_manager._jobs[jname] = job
@@ -198,92 +155,19 @@ class Project:
             self.add_job(n)
         return self
 
-    def tag(self, label: str) -> "Project":
-        self.tags.append(label)
+    # ------------------------------------------------------------------
+    def run(self, *jobs: str) -> "Project":
+        """Execute jobs via the project's :class:`JobManager`."""
+
+        job_list: Optional[Iterable[str]]
+        if jobs:
+            job_list = list(jobs)
+        else:
+            job_list = None
+        if self._project.job_manager is None:
+            self._project.job_manager = JobManager(self._project)  # type: ignore[attr-defined]
+        self._project.job_manager.run(job_list)  # type: ignore[arg-type]
         return self
-
-    def clone(self) -> "Project":
-        other = Project(self.runs_root)
-        other._name = self._name
-        other._airfoil = self._airfoil
-        other._params = dict(self._params)
-        other._jobs = list(self._jobs)
-        other.tags = list(self.tags)
-        return other
-
-    def preview(self) -> "Project":
-        log.info(f"Project name: {self._name}")
-        log.info(f"Airfoil: {self._airfoil}")
-        if self._params:
-            log.info("Parameters:")
-            for k, v in self._params.items():
-                log.info(f"  {k} = {v}")
-        if self._jobs:
-            log.info("Jobs: " + ", ".join(self._jobs))
-        if self.tags:
-            log.info("Tags: " + ", ".join(self.tags))
-        return self
-
-    def create(self):
-        recipe = str(self._params.get("RECIPE", "prep"))
-        multishots = self._params.get("MULTISHOT_COUNT")
-        pm = ProjectManager(self.runs_root)
-        project = pm.create(self._name, recipe, self._airfoil, multishots=multishots)
-
-        cfg_mgr = ConfigManager(project.paths)
-
-        case_file = project.root / "case.yaml"
-        case_data: Dict[str, Any] = {}
-        if case_file.exists():
-            case_data = yaml.safe_load(case_file.read_text()) or {}
-
-        global_cfg = cfg_mgr.load_global()
-        global_keys = {k.upper() for k in global_cfg.extras.keys()}
-        global_keys.update({"PROJECT_UID", "BASE_DIR", "RECIPE"})
-        case_keys = {k.upper() for k in case_data.keys()}
-
-        global_updates: Dict[str, Any] = {}
-        case_changed = False
-
-        for k, v in self._params.items():
-            if k in {"RECIPE", "PROJECT_NAME", "MULTISHOT_COUNT"}:
-                continue
-
-            key = k.upper()
-            if key in case_keys:
-                if case_data.get(key) != v:
-                    case_changed = True
-                case_data[key] = v
-            elif key in global_keys:
-                global_updates[key] = v
-            else:
-                raise KeyError(k)
-
-        if case_file.exists():
-            case_file.write_text(yaml.safe_dump(case_data, sort_keys=False))
-
-        if case_changed:
-            defaults = generate_global_defaults(case_file, global_default_config())
-            global_cfg.extras.update(defaults)
-
-        for k, v in global_updates.items():
-            global_cfg[k] = v
-
-        cfg_mgr.dump_global()
-        project.config = global_cfg
-
-        for name in self._jobs:
-            try:
-                job = JobFactory.create(name, project)
-                project.jobs.append(job)
-                try:
-                    job.prepare()
-                except Exception:
-                    log.warning(f"Failed to prepare job {name}")
-            except Exception as err:
-                log.error(f"{name}: {err}")
-        project.job_manager = JobManager(project)
-        return Project(project)
 
     # ------------------------------------------------------------------
     @property
@@ -311,27 +195,11 @@ class Project:
         return self._project.job_manager  # type: ignore[return-value]
 
     # ------------------------------------------------------------------
-    def run(self, *jobs: str) -> "Project":
-        """Execute jobs via the project's :class:`JobManager`."""
-
-        job_list: Optional[Iterable[str]]
-        if jobs:
-            job_list = list(jobs)
-        else:
-            job_list = None
-        if self._project.job_manager is None:
-            self._project.job_manager = JobManager(self._project)  # type: ignore[attr-defined]
-        self._project.job_manager.run(job_list)  # type: ignore[arg-type]
-        return self
-
-    # ------------------------------------------------------------------
     def __getattr__(self, name: str):
-        if self._builder:
-            raise AttributeError(name)
         return getattr(self._project, name)
 
     def __setattr__(self, name: str, value):
-        if name in {"_project", "_builder", "runs_root", "_name", "_airfoil", "_params", "_jobs", "tags"}:
+        if name == "_project":
             super().__setattr__(name, value)
         else:
             setattr(self._project, name, value)
@@ -344,11 +212,6 @@ class Project:
         pm = ProjectManager(Path(runs_root))
         proj = pm.load(uid)
         return cls(proj)
-
-    def load_project(self, uid: str) -> "Project":
-        """Instance helper using the builder's ``runs_root``."""
-
-        return self.__class__.load(self.runs_root, uid)
 
     # ------------------------------------------------------------------
     @staticmethod
@@ -393,3 +256,4 @@ class Project:
         if "ICE_GRID_FILE" in cfg:
             cfg["ICE_GRID_FILE"] = str(rel)
         cfg_mgr.dump_global()
+

--- a/glacium/api/project_builder.py
+++ b/glacium/api/project_builder.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Dict, Any
+import shutil
+import yaml
+
+from glacium.utils.JobIndex import JobFactory
+from glacium.utils.logging import log
+from glacium.utils import generate_global_defaults, global_default_config
+
+from glacium.managers.config_manager import ConfigManager
+from glacium.managers.project_manager import ProjectManager
+from glacium.managers.job_manager import JobManager
+from glacium.models.project import Project as ModelProject
+
+from .project import Project
+
+__all__ = ["ProjectBuilder"]
+
+
+class ProjectBuilder:
+    """Build :class:`~glacium.api.project.Project` instances."""
+
+    _default_airfoil = Path(__file__).resolve().parents[1] / "data" / "AH63K127.dat"
+
+    def __init__(self, runs_root: str | Path) -> None:
+        self.runs_root = Path(runs_root)
+        self._name = "project"
+        self._airfoil = self._default_airfoil
+        self._params: Dict[str, Any] = {"RECIPE": "prep"}
+        self._jobs: list[str] = []
+        self.tags: list[str] = []
+
+    # ------------------------------------------------------------------
+    # Builder helpers
+    # ------------------------------------------------------------------
+    def name(self, value: str) -> "ProjectBuilder":
+        self._name = value
+        return self
+
+    def select_airfoil(self, airfoil: str | Path) -> "ProjectBuilder":
+        self._airfoil = Path(airfoil)
+        return self
+
+    def set(self, key: str, value: Any) -> "ProjectBuilder":
+        self._params[key.upper()] = value
+        return self
+
+    def get(self, key: str) -> Any:
+        ukey = key.upper()
+        if ukey in self._params:
+            return self._params[ukey]
+        raise KeyError(key)
+
+    def set_bulk(self, data: Dict[str, Any]) -> "ProjectBuilder":
+        for k, v in data.items():
+            self.set(k, v)
+        return self
+
+    def add_job(self, name: str) -> "ProjectBuilder":
+        self._jobs.append(name)
+        return self
+
+    def jobs(self, names: Iterable[str]) -> "ProjectBuilder":
+        for n in names:
+            self.add_job(n)
+        return self
+
+    def tag(self, label: str) -> "ProjectBuilder":
+        self.tags.append(label)
+        return self
+
+    def clone(self) -> "ProjectBuilder":
+        other = ProjectBuilder(self.runs_root)
+        other._name = self._name
+        other._airfoil = self._airfoil
+        other._params = dict(self._params)
+        other._jobs = list(self._jobs)
+        other.tags = list(self.tags)
+        return other
+
+    def preview(self) -> "ProjectBuilder":
+        log.info(f"Project name: {self._name}")
+        log.info(f"Airfoil: {self._airfoil}")
+        if self._params:
+            log.info("Parameters:")
+            for k, v in self._params.items():
+                log.info(f"  {k} = {v}")
+        if self._jobs:
+            log.info("Jobs: " + ", ".join(self._jobs))
+        if self.tags:
+            log.info("Tags: " + ", ".join(self.tags))
+        return self
+
+    def create(self) -> Project:
+        recipe = str(self._params.get("RECIPE", "prep"))
+        multishots = self._params.get("MULTISHOT_COUNT")
+        pm = ProjectManager(self.runs_root)
+        project = pm.create(self._name, recipe, self._airfoil, multishots=multishots)
+
+        cfg_mgr = ConfigManager(project.paths)
+
+        case_file = project.root / "case.yaml"
+        case_data: Dict[str, Any] = {}
+        if case_file.exists():
+            case_data = yaml.safe_load(case_file.read_text()) or {}
+
+        global_cfg = cfg_mgr.load_global()
+        global_keys = {k.upper() for k in global_cfg.extras.keys()}
+        global_keys.update({"PROJECT_UID", "BASE_DIR", "RECIPE"})
+        case_keys = {k.upper() for k in case_data.keys()}
+
+        global_updates: Dict[str, Any] = {}
+        case_changed = False
+
+        for k, v in self._params.items():
+            if k in {"RECIPE", "PROJECT_NAME", "MULTISHOT_COUNT"}:
+                continue
+
+            key = k.upper()
+            if key in case_keys:
+                if case_data.get(key) != v:
+                    case_changed = True
+                case_data[key] = v
+            elif key in global_keys:
+                global_updates[key] = v
+            else:
+                raise KeyError(k)
+
+        if case_file.exists():
+            case_file.write_text(yaml.safe_dump(case_data, sort_keys=False))
+
+        if case_changed:
+            defaults = generate_global_defaults(case_file, global_default_config())
+            global_cfg.extras.update(defaults)
+
+        for k, v in global_updates.items():
+            global_cfg[k] = v
+
+        cfg_mgr.dump_global()
+        project.config = global_cfg
+
+        for name in self._jobs:
+            try:
+                job = JobFactory.create(name, project)
+                project.jobs.append(job)
+                try:
+                    job.prepare()
+                except Exception:
+                    log.warning(f"Failed to prepare job {name}")
+            except Exception as err:
+                log.error(f"{name}: {err}")
+        project.job_manager = JobManager(project)
+        return Project(project)
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def get_mesh(project: Project) -> Path:
+        """Return the path of ``mesh.grid`` inside ``project``."""
+
+        return project.paths.mesh_dir() / "mesh.grid"
+
+    @staticmethod
+    def set_mesh(mesh: Path, project: Project) -> None:
+        """Copy ``mesh`` into the project and update config paths."""
+
+        dest = ProjectBuilder.get_mesh(project)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(mesh, dest)
+
+        rel = Path("..") / dest.relative_to(project.root)
+        cfg_mgr = ConfigManager(project.paths)
+        cfg = cfg_mgr.load_global()
+        cfg["FSP_FILES_GRID"] = str(rel)
+        if "ICE_GRID_FILE" in cfg:
+            cfg["ICE_GRID_FILE"] = str(rel)
+        cfg_mgr.dump_global()
+

--- a/glacium/cli/init.py
+++ b/glacium/cli/init.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import click
 from glacium.utils.logging import log_call
 
-from glacium.api import Project
+from glacium.api import ProjectBuilder
 
 DEFAULT_NAME = "project"
 DEFAULT_RECIPE = "prep"
@@ -22,7 +22,7 @@ DEFAULT_AIRFOIL = Path(__file__).resolve().parents[1] / "data" / "AH63K127.dat"
 def cli_init(name: str, recipe: str, output: Path) -> None:
     """Create a new project below ``output`` using default settings."""
 
-    proj_builder = Project(output)
+    proj_builder = ProjectBuilder(output)
     proj_builder.name(name).select_airfoil(DEFAULT_AIRFOIL)
     proj_builder.set("recipe", recipe)
     project = proj_builder.create()

--- a/glacium/cli/new.py
+++ b/glacium/cli/new.py
@@ -17,7 +17,7 @@ from pathlib import Path
 import click
 
 from glacium.utils.logging import log, log_call
-from glacium.api import Project
+from glacium.api import ProjectBuilder
 
 # Paket-Ressourcen ---------------------------------------------------------
 PKG_ROOT = Path(__file__).resolve().parents[2]
@@ -68,7 +68,7 @@ def cli_new(
 ) -> None:
     """Erstellt ein neues Glacium-Projekt."""
 
-    builder = Project(output)
+    builder = ProjectBuilder(output)
     builder.name(name).select_airfoil(airfoil)
     builder.set("recipe", recipe)
     if multishots is not None:

--- a/tests/test_project_api.py
+++ b/tests/test_project_api.py
@@ -4,7 +4,7 @@ import yaml
 import sys
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from glacium.api import Project
+from glacium.api import ProjectBuilder, Project
 from glacium.managers.template_manager import TemplateManager
 from glacium.managers.job_manager import JobManager
 from glacium.utils import generate_global_defaults, global_default_config
@@ -13,7 +13,7 @@ import pytest
 
 def test_project_api_run(tmp_path, monkeypatch):
     TemplateManager(Path(__file__).resolve().parents[1] / "glacium" / "templates")
-    run = Project(tmp_path)
+    run = ProjectBuilder(tmp_path)
     project = run.create()
 
     called = {}
@@ -32,7 +32,7 @@ def test_project_api_run(tmp_path, monkeypatch):
 
 def test_run_load(tmp_path):
     TemplateManager(Path(__file__).resolve().parents[1] / "glacium" / "templates")
-    run = Project(tmp_path)
+    run = ProjectBuilder(tmp_path)
     project = run.create()
 
     loaded = Project.load(tmp_path, project.uid)
@@ -41,7 +41,7 @@ def test_run_load(tmp_path):
 
 def test_project_add_job(tmp_path):
     TemplateManager(Path(__file__).resolve().parents[1] / "glacium" / "templates")
-    run = Project(tmp_path)
+    run = ProjectBuilder(tmp_path)
     project = run.create()
 
     added = project.add_job("CONVERGENCE_STATS")
@@ -60,7 +60,7 @@ def test_project_add_job(tmp_path):
 
 def test_load_add_job_and_run(tmp_path, monkeypatch):
     TemplateManager(Path(__file__).resolve().parents[1] / "glacium" / "templates")
-    run = Project(tmp_path)
+    run = ProjectBuilder(tmp_path)
     project = run.create()
 
     uid = project.uid
@@ -88,7 +88,7 @@ def test_load_add_job_and_run(tmp_path, monkeypatch):
 
 def test_project_mesh_grid(tmp_path):
     TemplateManager(Path(__file__).resolve().parents[1] / "glacium" / "templates")
-    run = Project(tmp_path)
+    run = ProjectBuilder(tmp_path)
     project = run.create()
 
     grid_src = tmp_path / "input.grid"
@@ -107,7 +107,7 @@ def test_project_mesh_grid(tmp_path):
 
 def test_project_update_non_case_key(tmp_path):
     TemplateManager(Path(__file__).resolve().parents[1] / "glacium" / "templates")
-    run = Project(tmp_path)
+    run = ProjectBuilder(tmp_path)
     project = run.create()
 
     project.set("FSP_MAX_TIME_STEPS_PER_CYCLE", 999)
@@ -119,7 +119,7 @@ def test_project_update_non_case_key(tmp_path):
 
 def test_project_update_case_key(tmp_path):
     TemplateManager(Path(__file__).resolve().parents[1] / "glacium" / "templates")
-    run = Project(tmp_path)
+    run = ProjectBuilder(tmp_path)
     project = run.create()
 
     project.set("CASE_VELOCITY", 123.0)
@@ -137,6 +137,6 @@ def test_project_update_case_key(tmp_path):
 
 def test_project_update_unknown_key(tmp_path):
     TemplateManager(Path(__file__).resolve().parents[1] / "glacium" / "templates")
-    project = Project(tmp_path).create()
+    project = ProjectBuilder(tmp_path).create()
     with pytest.raises(KeyError):
         project.set("UNKNOWN_KEY", 1)

--- a/tests/test_project_get.py
+++ b/tests/test_project_get.py
@@ -4,13 +4,13 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import pytest
 
-from glacium.api import Project
+from glacium.api import ProjectBuilder
 from glacium.managers.template_manager import TemplateManager
 
 
 def test_project_get(tmp_path):
     TemplateManager(Path(__file__).resolve().parents[1] / "glacium" / "templates")
-    proj = Project(tmp_path).set("CASE_VELOCITY", 42).set("FSP_MAX_TIME_STEPS_PER_CYCLE", 7).create()
+    proj = ProjectBuilder(tmp_path).set("CASE_VELOCITY", 42).set("FSP_MAX_TIME_STEPS_PER_CYCLE", 7).create()
 
     assert proj.get("case_velocity") == 42
     assert proj.get("fsp_max_time_steps_per_cycle") == 7
@@ -21,7 +21,7 @@ def test_project_get(tmp_path):
 
 def test_project_get_results(tmp_path):
     TemplateManager(Path(__file__).resolve().parents[1] / "glacium" / "templates")
-    proj = Project(tmp_path).create()
+    proj = ProjectBuilder(tmp_path).create()
 
     (proj.root / "results.yaml").write_text("CL_MEAN: 2.5\n")
 

--- a/tests/test_run_builder.py
+++ b/tests/test_run_builder.py
@@ -4,7 +4,7 @@ import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from glacium.api import Project
+from glacium.api import ProjectBuilder, Project
 from glacium.managers.template_manager import TemplateManager
 from glacium.utils import generate_global_defaults, global_default_config
 import pytest
@@ -13,7 +13,7 @@ import pytest
 def test_run_builder_creates_files(tmp_path):
     TemplateManager(Path(__file__).resolve().parents[1] / "glacium" / "templates")
     run = (
-        Project(tmp_path)
+        ProjectBuilder(tmp_path)
         .name("demo")
         .set("MULTISHOT_COUNT", 3)
         .add_job("POINTWISE_MESH2")
@@ -33,7 +33,7 @@ def test_run_builder_creates_files(tmp_path):
 
 def test_run_clone_independent(tmp_path):
     TemplateManager(Path(__file__).resolve().parents[1] / "glacium" / "templates")
-    base = Project(tmp_path).name("base").set("MULTISHOT_COUNT", 1).add_job("POINTWISE_MESH2")
+    base = ProjectBuilder(tmp_path).name("base").set("MULTISHOT_COUNT", 1).add_job("POINTWISE_MESH2")
     clone = base.clone().name("clone").set("MULTISHOT_COUNT", 2).add_job("CONVERGENCE_STATS")
 
     base_proj = base.create()
@@ -52,14 +52,14 @@ def test_run_clone_independent(tmp_path):
 
 def test_run_builder_unknown_key(tmp_path):
     TemplateManager(Path(__file__).resolve().parents[1] / "glacium" / "templates")
-    run = Project(tmp_path).set("UNKNOWN_PARAM", 123)
+    run = ProjectBuilder(tmp_path).set("UNKNOWN_PARAM", 123)
     with pytest.raises(KeyError):
         run.create()
 
 
 def test_run_builder_updates_case_key(tmp_path):
     TemplateManager(Path(__file__).resolve().parents[1] / "glacium" / "templates")
-    run = Project(tmp_path).set("CASE_VELOCITY", 123)
+    run = ProjectBuilder(tmp_path).set("CASE_VELOCITY", 123)
 
     project = run.create()
 
@@ -70,7 +70,7 @@ def test_run_builder_updates_case_key(tmp_path):
 
 def test_run_builder_mesh_helpers(tmp_path):
     TemplateManager(Path(__file__).resolve().parents[1] / "glacium" / "templates")
-    run = Project(tmp_path)
+    run = ProjectBuilder(tmp_path)
 
     project = run.create()
 
@@ -88,7 +88,7 @@ def test_run_builder_mesh_helpers(tmp_path):
 
 def test_run_builder_regenerates_global_config(tmp_path):
     TemplateManager(Path(__file__).resolve().parents[1] / "glacium" / "templates")
-    run = Project(tmp_path).set("CASE_VELOCITY", 150)
+    run = ProjectBuilder(tmp_path).set("CASE_VELOCITY", 150)
 
     project = run.create()
 


### PR DESCRIPTION
## Summary
- move builder logic to `ProjectBuilder`
- strip builder code from `Project`
- adapt CLI commands to use the builder
- update tests to use `ProjectBuilder`

## Testing
- `pip install numpy pyyaml rich click jinja2 coloredlogs verboselogs matplotlib trimesh scipy fpdf2 pyvista`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6880fc0707ac8327a38797be066e321b