### PR TITLE
Refactor CLI with service layer

### DIFF
--- a/glacium/cli/case_sweep.py
+++ b/glacium/cli/case_sweep.py
@@ -2,17 +2,13 @@
 
 from __future__ import annotations
 
-import itertools
 from pathlib import Path
-import yaml
 import click
 
-from glacium.managers.project_manager import ProjectManager
-from glacium.cli.update import cli_update
+from glacium.services import CaseSweepService
 from glacium.utils.logging import log_call
 
 DEFAULT_RECIPE = "multishot"
-DEFAULT_AIRFOIL = Path(__file__).resolve().parents[1] / "data" / "AH63K127.dat"
 
 
 @click.command("case-sweep")
@@ -44,35 +40,15 @@ DEFAULT_AIRFOIL = Path(__file__).resolve().parents[1] / "data" / "AH63K127.dat"
     help="Number of MULTISHOT runs",
 )
 @log_call
-def cli_case_sweep(params: tuple[str], recipe: str, output: Path, multishots: int | None) -> None:
+def cli_case_sweep(
+    params: tuple[str], recipe: str, output: Path, multishots: int | None
+) -> None:
     """Create projects for all parameter combinations."""
 
-    def _parse_value(v: str):
-        try:
-            return yaml.safe_load(v)
-        except Exception:
-            return v
-
-    param_map: dict[str, list] = {}
-    for item in params:
-        if "=" not in item:
-            raise click.ClickException(f"Invalid --param value: {item}")
-        key, values = item.split("=", 1)
-        param_map[key] = [_parse_value(x) for x in values.split(",")]
-
-    keys = list(param_map)
-    pm = ProjectManager(output)
-
-    for combo in itertools.product(*(param_map[k] for k in keys)):
-        proj = pm.create("case", recipe, DEFAULT_AIRFOIL, multishots=multishots)
-        proj.config.dump(proj.paths.global_cfg_file())
-        case_file = proj.root / "case.yaml"
-        case = yaml.safe_load(case_file.read_text()) or {}
-        for k, v in zip(keys, combo):
-            case[k] = v
-        case_file.write_text(yaml.safe_dump(case, sort_keys=False))
-        cli_update.callback(proj.uid, None)
-        click.echo(proj.uid)
+    service = CaseSweepService(output)
+    uids = service.create_projects(params, recipe, multishots=multishots)
+    for uid in uids:
+        click.echo(uid)
 
 
 __all__ = ["cli_case_sweep"]

--- a/glacium/cli/init.py
+++ b/glacium/cli/init.py
@@ -1,29 +1,39 @@
 """Create a default project in the current directory."""
+
 from pathlib import Path
 import click
 from glacium.utils.logging import log_call
 
-from glacium.api import ProjectBuilder
+from glacium.services import ProjectService
 
 DEFAULT_NAME = "project"
 DEFAULT_RECIPE = "prep"
 DEFAULT_AIRFOIL = Path(__file__).resolve().parents[1] / "data" / "AH63K127.dat"
 
+
 @click.command("init")
-@click.option("-n", "--name", default=DEFAULT_NAME, show_default=True,
-              help="Name of the project")
-@click.option("-r", "--recipe", default=DEFAULT_RECIPE, show_default=True,
-              help="Recipe to use")
-@click.option("-o", "--output", default="runs", show_default=True,
-              type=click.Path(file_okay=False, dir_okay=True, path_type=Path,
-                              writable=True),
-              help="Root directory for projects")
+@click.option(
+    "-n", "--name", default=DEFAULT_NAME, show_default=True, help="Name of the project"
+)
+@click.option(
+    "-r", "--recipe", default=DEFAULT_RECIPE, show_default=True, help="Recipe to use"
+)
+@click.option(
+    "-o",
+    "--output",
+    default="runs",
+    show_default=True,
+    type=click.Path(file_okay=False, dir_okay=True, path_type=Path, writable=True),
+    help="Root directory for projects",
+)
 @log_call
 def cli_init(name: str, recipe: str, output: Path) -> None:
     """Create a new project below ``output`` using default settings."""
 
-    proj_builder = ProjectBuilder(output)
-    proj_builder.name(name).select_airfoil(DEFAULT_AIRFOIL)
-    proj_builder.set("recipe", recipe)
-    project = proj_builder.create()
+    service = ProjectService(output)
+    project = service.create_project(
+        name,
+        recipe,
+        DEFAULT_AIRFOIL,
+    )
     click.echo(project.uid)

--- a/glacium/cli/new.py
+++ b/glacium/cli/new.py
@@ -10,6 +10,7 @@ Funktionen
 • Alle Templates einmalig rendern
 • Recipe auswählen → Jobs erzeugen → jobs.yaml schreiben
 """
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -17,7 +18,7 @@ from pathlib import Path
 import click
 
 from glacium.utils.logging import log, log_call
-from glacium.api import ProjectBuilder
+from glacium.services import ProjectService
 
 # Paket-Ressourcen ---------------------------------------------------------
 PKG_ROOT = Path(__file__).resolve().parents[2]
@@ -29,16 +30,20 @@ DEFAULT_AIRFOIL = PKG_PKG / "data" / "AH63K127.dat"
 
 # ------------------------------------------------------------------------
 
+
 # ------------------------------------------------------------------------
 # Click-Command
 # ------------------------------------------------------------------------
 @click.command("new")
 @click.argument("name")
-@click.option("-a", "--airfoil",
-              type=click.Path(path_type=Path),
-              default=DEFAULT_AIRFOIL,
-              show_default=True,
-              help="Pfad zur Profil-Datei")
+@click.option(
+    "-a",
+    "--airfoil",
+    type=click.Path(path_type=Path),
+    default=DEFAULT_AIRFOIL,
+    show_default=True,
+    help="Pfad zur Profil-Datei",
+)
 @click.option(
     "-r",
     "--recipe",
@@ -46,17 +51,26 @@ DEFAULT_AIRFOIL = PKG_PKG / "data" / "AH63K127.dat"
     show_default=True,
     help="Recipe name or multiple names joined with '+'",
 )
-@click.option("-o", "--output", default=str(RUNS_ROOT), show_default=True,
-              type=click.Path(file_okay=False, dir_okay=True, writable=True, path_type=Path),
-              help="Root-Ordner für Projekte")
+@click.option(
+    "-o",
+    "--output",
+    default=str(RUNS_ROOT),
+    show_default=True,
+    type=click.Path(file_okay=False, dir_okay=True, writable=True, path_type=Path),
+    help="Root-Ordner für Projekte",
+)
 @click.option(
     "-m",
     "--multishots",
     type=int,
     help="Anzahl der MULTISHOT Durchläufe",
 )
-@click.option("-y", "--yes", is_flag=True,
-              help="Existierenden Ordner ohne Rückfrage überschreiben")
+@click.option(
+    "-y",
+    "--yes",
+    is_flag=True,
+    help="Existierenden Ordner ohne Rückfrage überschreiben",
+)
 @log_call
 def cli_new(
     name: str,
@@ -68,12 +82,13 @@ def cli_new(
 ) -> None:
     """Erstellt ein neues Glacium-Projekt."""
 
-    builder = ProjectBuilder(output)
-    builder.name(name).select_airfoil(airfoil)
-    builder.set("recipe", recipe)
-    if multishots is not None:
-        builder.set("multishot_count", multishots)
-    project = builder.create()
+    service = ProjectService(output)
+    project = service.create_project(
+        name,
+        recipe,
+        airfoil,
+        multishots=multishots,
+    )
     log.success(f"Projekt angelegt: {project.root}")
     click.echo(project.uid)
 

--- a/glacium/services/__init__.py
+++ b/glacium/services/__init__.py
@@ -1,0 +1,5 @@
+from .project_service import ProjectService
+from .case_sweep_service import CaseSweepService
+from .run_service import RunService
+
+__all__ = ["ProjectService", "CaseSweepService", "RunService"]

--- a/glacium/services/case_sweep_service.py
+++ b/glacium/services/case_sweep_service.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import itertools
+from pathlib import Path
+import yaml
+
+from glacium.managers.project_manager import ProjectManager
+from glacium.services.project_service import ProjectService
+
+DEFAULT_AIRFOIL = Path(__file__).resolve().parents[1] / "data" / "AH63K127.dat"
+
+
+class CaseSweepService:
+    """Create multiple projects from parameter sweeps."""
+
+    def __init__(self, root: Path = Path("runs")) -> None:
+        self.root = root
+        self.project_service = ProjectService(root)
+
+    def create_projects(
+        self,
+        params: tuple[str],
+        recipe: str,
+        *,
+        multishots: int | None = None,
+    ) -> list[str]:
+        def _parse(v: str):
+            try:
+                return yaml.safe_load(v)
+            except Exception:
+                return v
+
+        param_map: dict[str, list] = {}
+        for item in params:
+            if "=" not in item:
+                raise ValueError(f"Invalid parameter: {item}")
+            key, values = item.split("=", 1)
+            param_map[key] = [_parse(x) for x in values.split(",")]
+
+        keys = list(param_map)
+        pm = ProjectManager(self.root)
+        uids: list[str] = []
+
+        for combo in itertools.product(*(param_map[k] for k in keys)):
+            proj = pm.create("case", recipe, DEFAULT_AIRFOIL, multishots=multishots)
+            proj.config.dump(proj.paths.global_cfg_file())
+            case_file = proj.root / "case.yaml"
+            case = yaml.safe_load(case_file.read_text()) or {}
+            for k, v in zip(keys, combo):
+                case[k] = v
+            case_file.write_text(yaml.safe_dump(case, sort_keys=False))
+            self.project_service.update_config(proj.uid, None)
+            uids.append(proj.uid)
+
+        return uids

--- a/glacium/services/project_service.py
+++ b/glacium/services/project_service.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+import yaml
+
+from glacium.api import ProjectBuilder
+from glacium.managers.project_manager import ProjectManager
+from glacium.utils import generate_global_defaults, global_default_config
+
+
+class ProjectService:
+    """High level project operations used by the CLI."""
+
+    def __init__(self, root: Path = Path("runs")) -> None:
+        self.root = root
+
+    def create_project(
+        self,
+        name: str,
+        recipe: str,
+        airfoil: Path,
+        *,
+        multishots: int | None = None,
+    ):
+        builder = ProjectBuilder(self.root)
+        builder.name(name).select_airfoil(airfoil)
+        builder.set("recipe", recipe)
+        if multishots is not None:
+            builder.set("multishot_count", multishots)
+        return builder.create()
+
+    def update_config(self, uid: str, case_file: Path | None = None) -> Path:
+        pm = ProjectManager(self.root)
+        proj = pm.load(uid)
+        src = case_file or (proj.root / "case.yaml")
+        cfg = generate_global_defaults(src, global_default_config())
+        dest = proj.paths.global_cfg_file()
+        existing = yaml.safe_load(dest.read_text()) if dest.exists() else {}
+        merged = dict(existing)
+        merged.update(cfg)
+        dest.write_text(yaml.safe_dump(merged, sort_keys=False))
+        return dest

--- a/glacium/services/run_service.py
+++ b/glacium/services/run_service.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from glacium.utils.current import load as load_current
+from glacium.managers.project_manager import ProjectManager
+from glacium.utils.logging import log
+
+
+class RunService:
+    """Execute project jobs."""
+
+    def __init__(self, root: Path = Path("runs")) -> None:
+        self.root = root
+
+    def run(self, jobs: tuple[str], run_all: bool) -> list[str]:
+        pm = ProjectManager(self.root)
+        executed: list[str] = []
+
+        if run_all:
+            for uid in pm.list_uids():
+                try:
+                    pm.load(uid).job_manager.run(jobs or None)
+                    executed.append(uid)
+                except FileNotFoundError:
+                    log.error(f"{uid}: not found")
+                except Exception as err:  # noqa: BLE001
+                    log.error(f"{uid}: {err}")
+            return executed
+
+        uid = load_current()
+        if uid is None:
+            raise RuntimeError("Kein Projekt ausgewaehlt")
+
+        pm.load(uid).job_manager.run(jobs or None)
+        executed.append(uid)
+        return executed

--- a/tests/test_case_sweep.py
+++ b/tests/test_case_sweep.py
@@ -1,13 +1,14 @@
 import sys
 from pathlib import Path
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import yaml
 
 
-from click.testing import CliRunner
-from glacium.cli.case_sweep import cli_case_sweep
+from glacium.services import CaseSweepService
 from glacium.managers.project_manager import ProjectManager
+
 
 def test_case_sweep_creates_projects(tmp_path, monkeypatch):
     counter = 0
@@ -19,44 +20,42 @@ def test_case_sweep_creates_projects(tmp_path, monkeypatch):
 
     monkeypatch.setattr(ProjectManager, "_uid", staticmethod(fake_uid))
 
-    runner = CliRunner()
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        cli_case_sweep.callback(
-            (
-                "CASE_AOA=0,4",
-                "CASE_VELOCITY=50,100",
-                "PWS_REFINEMENT=1,2",
-            ),
-            recipe="multishot",
-            output=Path("runs"),
-            multishots=10,
-        )
+    monkeypatch.chdir(tmp_path)
+    Path("runs").mkdir()
+    service = CaseSweepService(Path("runs"))
+    service.create_projects(
+        (
+            "CASE_AOA=0,4",
+            "CASE_VELOCITY=50,100",
+            "PWS_REFINEMENT=1,2",
+        ),
+        recipe="multishot",
+        multishots=10,
+    )
 
-        uids = [p.name for p in Path("runs").iterdir() if p.is_dir()]
-        assert len(uids) == 8
+    uids = [p.name for p in Path("runs").iterdir() if p.is_dir()]
+    assert len(uids) == 8
 
-        combos = set()
-        for uid in uids:
-            case_file = Path("runs") / uid / "case.yaml"
-            cfg_file = Path("runs") / uid / "_cfg" / "global_config.yaml"
-            assert case_file.exists()
-            assert cfg_file.exists()
-            case = yaml.safe_load(case_file.read_text())
-            cfg = yaml.safe_load(cfg_file.read_text())
-            combos.add((case["CASE_AOA"], case["CASE_VELOCITY"], case["PWS_REFINEMENT"]))
-            assert cfg["CASE_AOA"] == case["CASE_AOA"]
-            assert cfg["CASE_VELOCITY"] == case["CASE_VELOCITY"]
-            assert cfg["PWS_REFINEMENT"] == case["PWS_REFINEMENT"]
+    combos = set()
+    for uid in uids:
+        case_file = Path("runs") / uid / "case.yaml"
+        cfg_file = Path("runs") / uid / "_cfg" / "global_config.yaml"
+        assert case_file.exists()
+        assert cfg_file.exists()
+        case = yaml.safe_load(case_file.read_text())
+        cfg = yaml.safe_load(cfg_file.read_text())
+        combos.add((case["CASE_AOA"], case["CASE_VELOCITY"], case["PWS_REFINEMENT"]))
+        assert cfg["CASE_AOA"] == case["CASE_AOA"]
+        assert cfg["CASE_VELOCITY"] == case["CASE_VELOCITY"]
+        assert cfg["PWS_REFINEMENT"] == case["PWS_REFINEMENT"]
 
-        assert combos == {
-            (0, 50, 1),
-            (0, 50, 2),
-            (0, 100, 1),
-            (0, 100, 2),
-            (4, 50, 1),
-            (4, 50, 2),
-            (4, 100, 1),
-            (4, 100, 2),
-        }
-
-
+    assert combos == {
+        (0, 50, 1),
+        (0, 50, 2),
+        (0, 100, 1),
+        (0, 100, 2),
+        (4, 50, 1),
+        (4, 50, 2),
+        (4, 100, 1),
+        (4, 100, 2),
+    }


### PR DESCRIPTION
## Summary
- add new `glacium.services` package with `ProjectService`, `CaseSweepService` and `RunService`
- refactor CLI commands to delegate heavy logic to services
- update unit test to use service layer

## Testing
- `pytest tests/test_cli.py tests/test_cli_projects.py tests/test_cli_projects_results.py tests/test_cli_case_sweep.py tests/test_cli_update.py tests/test_run_all.py tests/test_case_sweep.py::test_case_sweep_creates_projects -q`

------
https://chatgpt.com/codex/tasks/task_e_688102d913188327a84c8b2846c0d5f9