### PR TITLE
Update load_runs function

### DIFF
--- a/scripts/full_power_gci.py
+++ b/scripts/full_power_gci.py
@@ -23,7 +23,13 @@ def load_runs(root: Path) -> list[tuple[float, float, float, Project]]:
             factor = float(proj.get("PWS_REFINEMENT"))
         except Exception:
             continue
-        cl, _, cd, _ = project_cl_cd_stats(proj.root / "analysis" / "FENSAP")
+
+        try:
+            cl = float(proj.get("LIFT_COEFFICIENT"))
+            cd = float(proj.get("DRAG_COEFFICIENT"))
+        except Exception:
+            cl, _, cd, _ = project_cl_cd_stats(proj.root / "analysis" / "FENSAP")
+
         runs.append((factor, cl, cd, proj))
     return runs
 


### PR DESCRIPTION
## Summary
- use LIFT_COEFFICIENT and DRAG_COEFFICIENT when available
- fall back to FENSAP stats if coefficients are missing

## Testing
- `pytest -q` *(fails: 25 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68810e853a60832781cbe4e7b5f7eff2