### PR TITLE
Centralize jinja filters

### DIFF
--- a/glacium/managers/template_manager.py
+++ b/glacium/managers/template_manager.py
@@ -16,6 +16,8 @@ from typing import Dict, Iterable
 
 from jinja2 import Environment, FileSystemLoader, BaseLoader, Template
 
+from glacium.templating import register_filters
+
 __all__ = ["TemplateManager"]
 
 # ---------------------------------------------------------------------------
@@ -58,6 +60,7 @@ class TemplateManager(_SharedState):
 
         self._loader = loader
         self._env = Environment(loader=self._loader, autoescape=False)
+        register_filters(self._env)
         self._cache.clear()
 
     def _ensure_loader(self):

--- a/glacium/templates/__init__.py
+++ b/glacium/templates/__init__.py
@@ -1,0 +1,1 @@
+"""Jinja2 templates and custom filters."""

--- a/glacium/templates/filters.py
+++ b/glacium/templates/filters.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+"""Custom Jinja filters used across templates."""
+
+from pathlib import Path
+import shlex
+from typing import Any
+
+__all__ = ["posix_path", "shell_quote"]
+
+
+def posix_path(value: str | Path) -> str:
+    """Return ``value`` as a POSIX style path string."""
+    return str(Path(value).as_posix())
+
+
+def shell_quote(value: Any) -> str:
+    """Return ``value`` safely quoted for shell usage."""
+    return shlex.quote(str(value))

--- a/glacium/templating.py
+++ b/glacium/templating.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+"""Utilities for working with Jinja templates."""
+
+from jinja2 import Environment
+
+from .templates import filters as _filters
+
+__all__ = ["register_filters"]
+
+
+def register_filters(env: Environment) -> None:
+    """Register custom filters on ``env``."""
+    for name in _filters.__all__:
+        env.filters[name] = getattr(_filters, name)

--- a/tests/test_template_filters.py
+++ b/tests/test_template_filters.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+from jinja2 import Environment
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from glacium.templating import register_filters
+from glacium.templates import filters
+
+
+def test_register_filters():
+    env = Environment()
+    register_filters(env)
+    for name in filters.__all__:
+        assert name in env.filters


### PR DESCRIPTION
## Summary
- add package for template filters
- provide register_filters helper
- register filters in `TemplateManager`
- add regression test for registering filters

## Testing
- `pytest tests/test_template_filters.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68810e2f2a2c832796611bda7e6fecb1