### PR TITLE
Inject executables via engine constructors

### DIFF
--- a/glacium/engines/base_engine.py
+++ b/glacium/engines/base_engine.py
@@ -45,12 +45,16 @@ class BaseEngine:
 class XfoilEngine(BaseEngine):
     """Engine wrapper used by :class:`XfoilScriptJob`."""
 
-    def run_script(self, exe: str, script: Path, work: Path) -> None:
-        """Execute ``exe`` using ``script`` inside ``work`` directory."""
+    def __init__(self, exe: str, timeout: int | None = None) -> None:
+        super().__init__(timeout)
+        self.exe = exe
 
-        log.info(f"RUN: {exe} < {script.name}")
+    def run_script(self, script: Path, work: Path) -> None:
+        """Execute ``self.exe`` using ``script`` inside ``work`` directory."""
+
+        log.info(f"RUN: {self.exe} < {script.name}")
         with script.open("r") as stdin:
-            self.run([exe], cwd=work, stdin=stdin)
+            self.run([self.exe], cwd=work, stdin=stdin)
 
 
 @EngineFactory.register

--- a/glacium/engines/fensap.py
+++ b/glacium/engines/fensap.py
@@ -19,11 +19,15 @@ from .engine_factory import EngineFactory
 class FensapEngine(BaseEngine):
     """Execute ``.solvercmd`` files via ``nti_sh.exe``."""
 
-    def run_script(self, exe: str, script: Path, work: Path) -> None:
-        """Run ``script`` using ``exe`` inside ``work`` directory."""
+    def __init__(self, exe: str, timeout: int | None = None) -> None:
+        super().__init__(timeout)
+        self.exe = exe
 
-        log.info(f"RUN: {exe} {script.name}")
-        self.run([exe, str(script)], cwd=work)
+    def run_script(self, script: Path, work: Path) -> None:
+        """Run ``script`` using ``self.exe`` inside ``work`` directory."""
+
+        log.info(f"RUN: {self.exe} {script.name}")
+        self.run([self.exe, str(script)], cwd=work)
 
 
 __all__: Iterable[str] = [
@@ -89,8 +93,8 @@ class FensapScriptJob(Job):
         self.prepare()
 
         exe = cfg.get("FENSAP_EXE", self._DEFAULT_EXE)
-        engine = EngineFactory.create("FensapEngine")
-        engine.run_script(exe, work / ".solvercmd", work)
+        engine = EngineFactory.create("FensapEngine", exe)
+        engine.run_script(work / ".solvercmd", work)
 
 
 

--- a/glacium/engines/fluent2fensap.py
+++ b/glacium/engines/fluent2fensap.py
@@ -9,7 +9,19 @@ from glacium.models.job import Job
 from glacium.engines.base_engine import BaseEngine
 from glacium.utils.logging import log, log_call
 from .engine_factory import EngineFactory
-__all__ = ["Fluent2FensapJob"]
+__all__ = ["Fluent2FensapEngine", "Fluent2FensapJob"]
+
+
+@EngineFactory.register
+class Fluent2FensapEngine(BaseEngine):
+    """Run the ``fluent2fensap`` converter."""
+
+    def __init__(self, exe: str, timeout: int | None = None) -> None:
+        super().__init__(timeout)
+        self.exe = exe
+
+    def convert(self, cas_name: str, cas_stem: str, work: Path) -> None:
+        self.run([self.exe, cas_name, cas_stem], cwd=work)
 
 
 class Fluent2FensapJob(Job):
@@ -42,8 +54,8 @@ class Fluent2FensapJob(Job):
         if not cas_file.exists():
             raise FileNotFoundError(f"case file not found: {cas_file}")
 
-        engine = EngineFactory.create("BaseEngine")
-        engine.run([exe, cas_name, cas_stem], cwd=work)
+        engine = EngineFactory.create("Fluent2FensapEngine", exe)
+        engine.convert(cas_name, cas_stem, work)
 
         produced = work / f"{cas_stem}.grid"
         dest = paths.mesh_dir() / produced.name

--- a/glacium/engines/pointwise.py
+++ b/glacium/engines/pointwise.py
@@ -21,11 +21,15 @@ __all__: Iterable[str] = [
 class PointwiseEngine(BaseEngine):
     """Execute Pointwise TCL scripts."""
 
-    def run_script(self, exe: str, script: Path, work: Path) -> None:
-        """Execute ``exe`` with ``script`` inside ``work`` directory."""
+    def __init__(self, exe: str, timeout: int | None = None) -> None:
+        super().__init__(timeout)
+        self.exe = exe
 
-        log.info(f"RUN: {exe} {script.name}")
-        self.run([exe, str(script)], cwd=work)
+    def run_script(self, script: Path, work: Path) -> None:
+        """Execute ``self.exe`` with ``script`` inside ``work`` directory."""
+
+        log.info(f"RUN: {self.exe} {script.name}")
+        self.run([self.exe, str(script)], cwd=work)
 
 
 class PointwiseScriptJob(Job):
@@ -73,9 +77,9 @@ class PointwiseScriptJob(Job):
         dest_script = self.prepare()
 
         exe = cfg.get("POINTWISE_BIN", "pointwise")
-        engine = EngineFactory.create("PointwiseEngine")
+        engine = EngineFactory.create("PointwiseEngine", exe)
         # Run inside the solver directory so relative paths resolve correctly
-        engine.run_script(exe, dest_script, work)
+        engine.run_script(dest_script, work)
 
         if self.cfg_key_out:
             out_name = cfg.get(self.cfg_key_out)

--- a/glacium/engines/xfoil_base.py
+++ b/glacium/engines/xfoil_base.py
@@ -82,8 +82,8 @@ class XfoilScriptJob(Job):
 
         # ----------------------------- 2) run XFOIL ---------------
         exe = cfg.get("XFOIL_BIN", "xfoil.exe")
-        engine = EngineFactory.create("XfoilEngine")
-        engine.run_script(exe, dest_script, work)
+        engine = EngineFactory.create("XfoilEngine", exe)
+        engine.run_script(dest_script, work)
 
         # ----------------------------- 3) reference result --------
         if self.cfg_key_out:

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -38,8 +38,8 @@ def test_base_engine_run(tmp_path):
 def test_xfoil_engine_run_script(tmp_path):
     script = tmp_path / "script.in"
     script.write_text("hi")
-    engine = XfoilEngine()
-    engine.run_script("cat", script, tmp_path)
+    engine = XfoilEngine("cat")
+    engine.run_script(script, tmp_path)
 
 
 def test_dummy_engine_timer(monkeypatch):
@@ -79,7 +79,7 @@ def test_pointwise_engine_run_script(monkeypatch, tmp_path):
 
     script = tmp_path / "script.glf"
     script.write_text("puts hi")
-    engine = PointwiseEngine()
+    engine = PointwiseEngine("cat")
 
     called = {}
 
@@ -90,7 +90,7 @@ def test_pointwise_engine_run_script(monkeypatch, tmp_path):
 
     monkeypatch.setattr(BaseEngine, "run", fake_run)
 
-    engine.run_script("cat", script, tmp_path)
+    engine.run_script(script, tmp_path)
 
     assert called["cmd"] == ["cat", str(script)]
     assert called["cwd"] == tmp_path
@@ -163,8 +163,8 @@ def test_pointwise_script_job_runs_in_project_root(monkeypatch, tmp_path):
 def test_fensap_engine_run_script(tmp_path):
     script = tmp_path / "run.sh"
     script.write_text("exit 0")
-    engine = FensapEngine()
-    engine.run_script("sh", script, tmp_path)
+    engine = FensapEngine("sh")
+    engine.run_script(script, tmp_path)
 
 
 def test_fensap_run_job(tmp_path):
@@ -775,8 +775,7 @@ def test_fluent2fensap_job_keeps_log_level(monkeypatch, tmp_path):
 
 def test_engine_factory_create():
     """Ensure registered engines can be created by name."""
-
-    engine = EngineFactory.create("XfoilEngine")
+    engine = EngineFactory.create("XfoilEngine", "echo")
     assert isinstance(engine, XfoilEngine)
 
 
@@ -801,9 +800,9 @@ def test_xfoil_script_job_uses_engine_factory(monkeypatch, tmp_path):
 
     called = {}
 
-    def fake_create(name: str):
+    def fake_create(name: str, exe: str):
         called["name"] = name
-        return XfoilEngine()
+        return XfoilEngine(exe)
 
     monkeypatch.setattr(EngineFactory, "create", staticmethod(fake_create))
 
@@ -835,9 +834,9 @@ def test_fensap_script_job_uses_engine_factory(monkeypatch, tmp_path):
 
     called = {}
 
-    def fake_create(name: str):
+    def fake_create(name: str, exe: str):
         called["name"] = name
-        return FensapEngine()
+        return FensapEngine(exe)
 
     monkeypatch.setattr(EngineFactory, "create", staticmethod(fake_create))
 


### PR DESCRIPTION
## Summary
- refactor engine classes to take executable paths via constructor
- adjust job classes to supply executables when creating engines
- update engine tests for new constructor signature

## Testing
- `pytest tests/test_convergence_stats.py tests/test_single_convergence_stats.py tests/test_solver_convergence_stats_jobs.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68811b086c648327b5d8c13d33a913fc