### PR TITLE
Update AGENTS for services refactor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,40 @@
 
 > Dependencies always point *downwards*; Domain remains framework-agnostic.
 
+### Services Layer
+- CLI commands delegate to service classes for orchestration.
+- Services combine multiple managers and remain stateless.
+```python
+from pathlib import Path
+from glacium.services import ProjectService
+service = ProjectService(Path("runs"))
+project = service.create_project("demo", "prep", Path("foil.dat"))
+```
+
+### ProjectBuilder
+- Build `Project` objects programmatically.
+- Methods return `self` for chaining.
+```python
+from glacium.api import ProjectBuilder
+project = (
+    ProjectBuilder("runs")
+    .name("demo")
+    .select_airfoil("foil.dat")
+    .add_job("POINTWISE_MESH2")
+    .create()
+)
+```
+
+### Package Map
+- `glacium/api` – high level API helpers like `ProjectBuilder`.
+- `glacium/cli` – command line interface.
+- `glacium/services` – orchestration layer used by the CLI.
+- `glacium/managers` – coordinate projects, configs and jobs.
+- `glacium/jobs` – concrete job implementations.
+- `glacium/engines` – wrappers for external programs.
+- `glacium/recipes` – job collections.
+- `glacium/models` – dataclasses for persistence.
+- `glacium/utils` – miscellaneous helpers.
 ---
 
 ## 3  Configuration & Variable Management
@@ -110,6 +144,7 @@
 - **Functional parameters** come first, **Optionals** last.
 - No abbreviations except commonly known (`cfg`, `id`).
 
+- Service classes end with `Service`; builder classes end with `Builder`.
 ---
 
 ## 9  API Interface


### PR DESCRIPTION
## Summary
- document new `services` layer
- add `ProjectBuilder` subsection with example
- list updated package map
- note naming convention for service/builder classes

## Testing
- `pytest -k project_builder -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6881fa77f0048327a7ed20c2cdb2ab15