### PR TITLE
Introduce ScriptJob and PythonJob bases

### DIFF
--- a/glacium/__init__.py
+++ b/glacium/__init__.py
@@ -47,5 +47,6 @@ except PackageNotFoundError:  # package is not installed
 from .api import Run
 from .post import PostProcessor
 from .setup import update
+from . import managers  # expose subpackage for monkeypatching
 
 __all__ = ["Run", "PostProcessor", "update"]

--- a/glacium/engines/__init__.py
+++ b/glacium/engines/__init__.py
@@ -1,9 +1,7 @@
 """Engine implementations wrapping external solver calls."""
+from __future__ import annotations
 
-from .engine_factory import EngineFactory
-from .base_engine import BaseEngine, XfoilEngine, DummyEngine
-from .pointwise import PointwiseEngine, PointwiseScriptJob
-from .fensap import FensapEngine, FensapScriptJob
+from importlib import import_module
 
 __all__ = [
     "BaseEngine",
@@ -16,3 +14,20 @@ __all__ = [
     "EngineFactory",
 ]
 
+_module_map = {
+    "BaseEngine": "glacium.engines.base_engine",
+    "XfoilEngine": "glacium.engines.base_engine",
+    "DummyEngine": "glacium.engines.base_engine",
+    "PointwiseEngine": "glacium.engines.pointwise",
+    "PointwiseScriptJob": "glacium.engines.pointwise",
+    "FensapEngine": "glacium.engines.fensap",
+    "FensapScriptJob": "glacium.engines.fensap",
+    "EngineFactory": "glacium.engines.engine_factory",
+}
+
+
+def __getattr__(name: str):
+    if name in _module_map:
+        module = import_module(_module_map[name])
+        return getattr(module, name)
+    raise AttributeError(name)

--- a/glacium/engines/fensap.py
+++ b/glacium/engines/fensap.py
@@ -9,7 +9,7 @@ import sys
 import yaml
 
 from glacium.utils.logging import log, log_call
-from glacium.models.job import Job
+from glacium.jobs.base import ScriptJob
 from glacium.managers.template_manager import TemplateManager
 from .base_engine import BaseEngine
 from .engine_factory import EngineFactory
@@ -36,7 +36,7 @@ __all__: Iterable[str] = [
 ]
 
 
-class FensapScriptJob(Job):
+class FensapScriptJob(ScriptJob):
     """Render FENSAP input files and execute the solver."""
 
     # Mapping of template -> output filename relative to the solver dir
@@ -47,7 +47,9 @@ class FensapScriptJob(Job):
     batch_dir: Path | None = None
     deps: tuple[str, ...] = ()
 
-    _DEFAULT_EXE = (
+    engine_name = "FensapEngine"
+    exe_key = "FENSAP_EXE"
+    default_exe = (
         r"C:\\Program Files\\ANSYS Inc\\v251\\fensapice\\bin\\nti_sh.exe"
     )
 
@@ -84,17 +86,7 @@ class FensapScriptJob(Job):
         cfg = self.project.config
         return {**defaults, **cfg.extras}
 
-    @log_call
-    def execute(self) -> None:  # noqa: D401
-        cfg = self.project.config
-        paths = self.project.paths
-        work = paths.solver_dir(self.solver_dir)
-
-        self.prepare()
-
-        exe = cfg.get("FENSAP_EXE", self._DEFAULT_EXE)
-        engine = EngineFactory.create("FensapEngine", exe)
-        engine.run_script(work / ".solvercmd", work)
+    # execution handled by :class:`ScriptJob`
 
 
 

--- a/glacium/jobs/__init__.py
+++ b/glacium/jobs/__init__.py
@@ -1,32 +1,7 @@
 """Job implementations used by Glacium."""
+from __future__ import annotations
 
-from .analysis import (
-    ConvergenceStatsJob,
-    FensapConvergenceStatsJob,
-    Drop3dConvergenceStatsJob,
-    Ice3dConvergenceStatsJob,
-    AnalyzeMultishotJob,
-    FensapAnalysisJob,
-    MeshAnalysisJob,
-)
-from .fensap import (
-    FensapRunJob,
-    Drop3dRunJob,
-    Ice3dRunJob,
-    MultiShotRunJob,
-    Fluent2FensapJob,
-)
-from .xfoil import (
-    XfoilRefineJob,
-    XfoilThickenTEJob,
-    XfoilBoundaryLayerJob,
-    XfoilPolarsJob,
-    XfoilSuctionCurveJob,
-    XfoilConvertJob,
-)
-from .pointwise import PointwiseGCIJob, PointwiseMesh2Job
-from .postprocess import PostprocessSingleFensapJob, PostprocessMultishotJob
-from glacium.recipes.hello_world import HelloJob
+from importlib import import_module
 
 __all__ = [
     "FensapRunJob",
@@ -53,3 +28,36 @@ __all__ = [
     "PostprocessSingleFensapJob",
     "PostprocessMultishotJob",
 ]
+
+_module_map = {
+    "FensapRunJob": "glacium.jobs.fensap.fensap_run",
+    "Drop3dRunJob": "glacium.jobs.fensap.drop3d_run",
+    "Ice3dRunJob": "glacium.jobs.fensap.ice3d_run",
+    "MultiShotRunJob": "glacium.jobs.fensap.multishot_run",
+    "Fluent2FensapJob": "glacium.jobs.fensap.fluent2fensap",
+    "ConvergenceStatsJob": "glacium.jobs.analysis.convergence_stats",
+    "FensapConvergenceStatsJob": "glacium.jobs.analysis.fensap_convergence_stats",
+    "Drop3dConvergenceStatsJob": "glacium.jobs.analysis.drop3d_convergence_stats",
+    "Ice3dConvergenceStatsJob": "glacium.jobs.analysis.ice3d_convergence_stats",
+    "AnalyzeMultishotJob": "glacium.jobs.analysis.analyze_multishot",
+    "FensapAnalysisJob": "glacium.jobs.analysis.fensap_analysis",
+    "MeshAnalysisJob": "glacium.jobs.analysis.mesh_analysis",
+    "PointwiseGCIJob": "glacium.jobs.pointwise.gci",
+    "PointwiseMesh2Job": "glacium.jobs.pointwise.mesh2",
+    "XfoilRefineJob": "glacium.jobs.xfoil.refine",
+    "XfoilThickenTEJob": "glacium.jobs.xfoil.thicken_te",
+    "XfoilBoundaryLayerJob": "glacium.jobs.xfoil.boundary_layer",
+    "XfoilPolarsJob": "glacium.jobs.xfoil.polars",
+    "XfoilSuctionCurveJob": "glacium.jobs.xfoil.suction_curve",
+    "XfoilConvertJob": "glacium.jobs.xfoil.convert",
+    "HelloJob": "glacium.recipes.hello_world",
+    "PostprocessSingleFensapJob": "glacium.jobs.postprocess.single_fensap",
+    "PostprocessMultishotJob": "glacium.jobs.postprocess.multishot",
+}
+
+
+def __getattr__(name: str):
+    if name in _module_map:
+        module = import_module(_module_map[name])
+        return getattr(module, name)
+    raise AttributeError(name)

--- a/glacium/jobs/analysis/analyze_multishot.py
+++ b/glacium/jobs/analysis/analyze_multishot.py
@@ -1,18 +1,23 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
+from typing import Sequence
 import pandas as pd
 
-from glacium.models.job import Job
+from glacium.jobs.base import PythonJob
 from glacium.engines.py_engine import PyEngine
 from glacium.post import analysis as post_analysis
 
 
-class AnalyzeMultishotJob(Job):
+class AnalyzeMultishotJob(PythonJob):
     """Analyse MULTISHOT solver exports."""
 
     name = "ANALYZE_MULTISHOT"
     deps = ("POSTPROCESS_MULTISHOT",)
+
+    def args(self) -> Sequence[str | Path]:  # unused
+        return []
 
     def execute(self) -> None:  # noqa: D401
         project_root = self.project.root

--- a/glacium/jobs/analysis/fensap_analysis.py
+++ b/glacium/jobs/analysis/fensap_analysis.py
@@ -1,20 +1,25 @@
 from __future__ import annotations
 
-from glacium.models.job import Job
+from pathlib import Path
+from typing import Sequence
+
+from glacium.jobs.base import PythonJob
 from glacium.engines.py_engine import PyEngine
 from glacium.utils.postprocess_fensap import fensap_analysis
 
 
-class FensapAnalysisJob(Job):
+class FensapAnalysisJob(PythonJob):
     """Generate slice plots from FENSAP results."""
 
     name = "FENSAP_ANALYSIS"
     deps = ("POSTPROCESS_SINGLE_FENSAP",)
 
-    def execute(self) -> None:  # noqa: D401
+    def args(self) -> Sequence[str | Path]:
         project_root = self.project.root
         dat_file = project_root / "run_FENSAP" / "soln.fensap.dat"
         out_dir = project_root / "analysis" / "FENSAP"
+        return [dat_file, out_dir]
 
+    def execute(self) -> None:  # noqa: D401
         engine = PyEngine(fensap_analysis)
-        engine.run([dat_file, out_dir], cwd=project_root)
+        engine.run(self.args(), cwd=self.project.root)

--- a/glacium/jobs/analysis/ice3d_convergence_stats.py
+++ b/glacium/jobs/analysis/ice3d_convergence_stats.py
@@ -1,24 +1,28 @@
 from __future__ import annotations
 
-from glacium.models.job import Job
-from glacium.engines.py_engine import PyEngine
+from pathlib import Path
+from typing import Sequence
+
+from glacium.jobs.base import PythonJob
 from glacium.utils.convergence import analysis_file
 from glacium.utils.report_converg_fensap import build_report
 
 
-class Ice3dConvergenceStatsJob(Job):
+class Ice3dConvergenceStatsJob(PythonJob):
     """Generate convergence plots for an ICE3D run."""
 
     name = "ICE3D_CONVERGENCE_STATS"
     deps = ("ICE3D_RUN",)
 
-    def execute(self) -> None:  # noqa: D401
+    fn = staticmethod(analysis_file)
+
+    def args(self) -> Sequence[str | Path]:
         project_root = self.project.root
         converg_file = project_root / "run_ICE3D" / "iceconv.dat"
         out_dir = project_root / "analysis" / "ICE3D"
+        self._out_dir = out_dir
+        return [converg_file, out_dir]
 
-        engine = PyEngine(analysis_file)
-        engine.run([converg_file, out_dir], cwd=project_root)
-
+    def after_run(self) -> None:
         if self.project.config.get("CONVERGENCE_PDF"):
-            build_report(out_dir)
+            build_report(self._out_dir)

--- a/glacium/jobs/analysis/mesh_analysis.py
+++ b/glacium/jobs/analysis/mesh_analysis.py
@@ -1,20 +1,25 @@
 from __future__ import annotations
 
-from glacium.models.job import Job
+from pathlib import Path
+from typing import Sequence
+
+from glacium.jobs.base import PythonJob
 from glacium.engines.py_engine import PyEngine
 from glacium.utils.mesh_analysis import mesh_analysis
 
 
-class MeshAnalysisJob(Job):
+class MeshAnalysisJob(PythonJob):
     """Generate mesh screenshots and HTML report."""
 
     name = "MESH_ANALYSIS"
     deps: tuple[str, ...] = ()
 
-    def execute(self) -> None:  # noqa: D401
+    def args(self) -> Sequence[str | Path]:
         project_root = self.project.root
         meshfile = project_root / "run_MULTISHOT" / "lastwrap-remeshed.msh"
         out_dir = project_root / "analysis" / "MESH"
+        return [meshfile, out_dir, out_dir / "mesh_report.html"]
 
+    def execute(self) -> None:  # noqa: D401
         engine = PyEngine(mesh_analysis)
-        engine.run([meshfile, out_dir, out_dir / "mesh_report.html"], cwd=project_root)
+        engine.run(self.args(), cwd=self.project.root)

--- a/glacium/jobs/base.py
+++ b/glacium/jobs/base.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Sequence, Callable
+import sys
+
+from glacium.models.job import Job
+from glacium.engines.py_engine import PyEngine
+from glacium.engines.engine_factory import EngineFactory
+from glacium.utils.logging import log_call
+
+
+class ScriptJob(Job, ABC):
+    """Base class for jobs executing an external engine."""
+
+    engine_name: str
+    exe_key: str
+    default_exe: str = ""
+    solver_dir: str = ""
+
+    @abstractmethod
+    def prepare(self) -> Path:
+        """Return the script file to execute."""
+
+    def executable(self) -> str:
+        return self.project.config.get(self.exe_key, self.default_exe)
+
+    def workdir(self) -> Path:  # type: ignore[override]
+        return self.project.paths.solver_dir(self.solver_dir)
+
+    def after_run(self, work: Path) -> None:
+        return None
+
+    @log_call
+    def execute(self) -> None:  # noqa: D401
+        work = self.workdir()
+        script = self.prepare()
+        exe = self.executable()
+        engine = EngineFactory.create(self.engine_name, exe)
+        engine.run_script(script, work)
+        self.after_run(work)
+
+
+class PythonJob(Job, ABC):
+    """Base job executing a Python callable via :class:`PyEngine`."""
+
+    fn: Callable[..., None]
+
+    @abstractmethod
+    def args(self) -> Sequence[str | Path]:
+        """Return arguments passed to the callable."""
+
+    def after_run(self) -> None:
+        return None
+
+    def execute(self) -> None:  # noqa: D401
+        module = sys.modules[self.__module__]
+        engine_cls = getattr(module, "PyEngine", PyEngine)
+        engine = engine_cls(self.fn)
+        engine.run(self.args(), cwd=self.project.root)
+        self.after_run()
+

--- a/glacium/jobs/fensap/drop3d_run.py
+++ b/glacium/jobs/fensap/drop3d_run.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from glacium.engines import FensapScriptJob
+from glacium.engines.fensap import FensapScriptJob
 
 
 class Drop3dRunJob(FensapScriptJob):

--- a/glacium/jobs/fensap/fensap_run.py
+++ b/glacium/jobs/fensap/fensap_run.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from glacium.engines import FensapScriptJob
+from glacium.engines.fensap import FensapScriptJob
 
 
 class FensapRunJob(FensapScriptJob):

--- a/glacium/jobs/fensap/ice3d_run.py
+++ b/glacium/jobs/fensap/ice3d_run.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from glacium.engines import FensapScriptJob
+from glacium.engines.fensap import FensapScriptJob
 
 
 class Ice3dRunJob(FensapScriptJob):

--- a/glacium/jobs/fensap/multishot_run.py
+++ b/glacium/jobs/fensap/multishot_run.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from glacium.managers.template_manager import TemplateManager
-from glacium.engines import FensapScriptJob
+from glacium.engines.fensap import FensapScriptJob
 
 
 class MultiShotRunJob(FensapScriptJob):

--- a/glacium/models/job.py
+++ b/glacium/models/job.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from enum import Enum, auto
 from pathlib import Path
 from typing import Sequence
+from abc import ABC, abstractmethod
 
 
 class JobStatus(Enum):
@@ -14,7 +15,7 @@ class JobStatus(Enum):
     STALE   = auto()
 
 
-class Job:
+class Job(ABC):
     """Base class for concrete jobs following the Command pattern."""
 
     # unique identifier used as key in ``JobManager``
@@ -41,8 +42,9 @@ class Job:
     # ------------------------------------------------------------------
     # template method: concrete subclasses implement ``execute()``
     # ------------------------------------------------------------------
+    @abstractmethod
     def execute(self) -> None:                # noqa: D401
-        raise NotImplementedError
+        """Run the job."""
 
     # ------------------------------------------------------------------
     # Optional hook executed before a job is run


### PR DESCRIPTION
## Summary
- make `Job` an abstract base class
- create `ScriptJob` and `PythonJob` in `glacium/jobs/base.py`
- derive engine jobs from `ScriptJob`
- refactor analysis jobs to extend `PythonJob`
- provide lazy loading in `glacium.jobs` and `glacium.engines`
- expose managers package in `glacium.__init__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68820d5c6b7883278d97df6c0017f86d