### PR TITLE
Adjust job discovery packages

### DIFF
--- a/glacium/utils/JobIndex.py
+++ b/glacium/utils/JobIndex.py
@@ -23,7 +23,7 @@ class JobFactory:
 
     _jobs: Dict[str, Type[Job]] | None = None
     _loaded: bool = False
-    _PACKAGES: Iterable[str] = ["glacium.jobs", "glacium.engines", "glacium.recipes"]
+    _PACKAGES: Iterable[str] = ["glacium.jobs", "glacium.recipes"]
     _import_errors: Dict[str, Exception] | None = None
 
     # ------------------------------------------------------------------

--- a/tests/test_job_import_errors.py
+++ b/tests/test_job_import_errors.py
@@ -56,10 +56,11 @@ def test_cli_list_with_missing_job(tmp_path, monkeypatch):
         runner.invoke(cli, ["select", uid], env=env)
 
         monkeypatch.syspath_prepend(tmp_path)
-        monkeypatch.setattr(JobFactory, "_PACKAGES", [
-            "glacium.recipes",
-            "fake_pkg",
-        ])
+        monkeypatch.setattr(
+            JobFactory,
+            "_PACKAGES",
+            ["glacium.jobs", "glacium.recipes", "fake_pkg"],
+        )
         monkeypatch.setattr(JobFactory, "_loaded", False)
         monkeypatch.setattr(JobFactory, "_import_errors", None)
 


### PR DESCRIPTION
## Summary
- narrow the JobFactory search path to the jobs and recipes packages
- update tests to use the new job discovery default

## Testing
- `pytest tests/test_job_import_errors.py tests/test_job_factory_list.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688230356e00832791089b510cd9b02a