### PR TITLE
Fix test imports for new module paths

### DIFF
--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -1,29 +1,21 @@
+import sys
 import time
 from pathlib import Path
 
-import sys
-from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-import time
 import pytest
 
-from glacium.engines.base_engine import BaseEngine, XfoilEngine, DummyEngine
-from glacium.engines.xfoil_base import XfoilScriptJob
-from glacium.engines.pointwise import PointwiseEngine, PointwiseScriptJob
-from glacium.engines.fensap import FensapEngine, FensapScriptJob
+from glacium.engines.base_engine import BaseEngine, DummyEngine, XfoilEngine
 from glacium.engines.engine_factory import EngineFactory
-from glacium.jobs.fensap import (
-    FensapRunJob,
-    Drop3dRunJob,
-    Ice3dRunJob,
-    MultiShotRunJob,
-    Fluent2FensapJob,
-)
-import glacium.jobs.fensap as fensap_jobs
-from glacium.models.config import GlobalConfig
+from glacium.engines.fensap import FensapEngine, FensapScriptJob
+from glacium.engines.pointwise import PointwiseEngine, PointwiseScriptJob
+from glacium.engines.xfoil_base import XfoilScriptJob
+from glacium.jobs.fensap import (Drop3dRunJob, FensapRunJob, Fluent2FensapJob,
+                                 Ice3dRunJob, MultiShotRunJob)
 from glacium.managers.path_manager import PathBuilder
 from glacium.managers.template_manager import TemplateManager
+from glacium.models.config import GlobalConfig
 from glacium.models.project import Project
 
 
@@ -232,7 +224,6 @@ def test_fensap_run_job_calls_base_engine(monkeypatch, tmp_path):
 def test_multishot_run_job(monkeypatch, tmp_path):
     template_root = tmp_path / "templates"
     template_root.mkdir()
-    monkeypatch.setattr(fensap_jobs, "__file__", str(tmp_path / "pkg" / "fensap/__init__.py"))
     (template_root / "MULTISHOT.meshingSizes.scm.j2").write_text("scm")
     (template_root / "MULTISHOT.custom_remeshing.sh.j2").write_text("custom")
     (template_root / "MULTISHOT.solvercmd.j2").write_text("exit 0")
@@ -250,7 +241,6 @@ def test_multishot_run_job(monkeypatch, tmp_path):
     (template_root / "config.ice.j2").write_text("ice")
     (template_root / "files.drop.j2").write_text("fdrop")
     (template_root / "files.fensap.j2").write_text("ffsp")
-
 
     cfg = GlobalConfig(project_uid="uid", base_dir=tmp_path)
     cfg["FENSAP_EXE"] = "sh"
@@ -270,7 +260,6 @@ def test_multishot_run_job_calls_base_engine(monkeypatch, tmp_path):
 
     template_root = tmp_path / "templates"
     template_root.mkdir()
-    monkeypatch.setattr(fensap_jobs, "__file__", str(tmp_path / "pkg" / "fensap/__init__.py"))
     (template_root / "MULTISHOT.meshingSizes.scm.j2").write_text("scm")
     (template_root / "MULTISHOT.custom_remeshing.sh.j2").write_text("custom")
     (template_root / "MULTISHOT.solvercmd.j2").write_text("exit 0")
@@ -325,7 +314,6 @@ def test_multishot_run_job_calls_base_engine(monkeypatch, tmp_path):
 def test_multishot_run_job_renders_batch(monkeypatch, tmp_path, count):
     template_root = tmp_path / "templates"
     template_root.mkdir()
-    monkeypatch.setattr(fensap_jobs, "__file__", str(tmp_path / "pkg" / "fensap/__init__.py"))
     # required templates
     (template_root / "MULTISHOT.meshingSizes.scm.j2").write_text("scm")
     (template_root / "MULTISHOT.custom_remeshing.sh.j2").write_text("custom")
@@ -369,7 +357,6 @@ def test_multishot_run_job_renders_batch(monkeypatch, tmp_path, count):
 def test_multishot_initial_type(monkeypatch, tmp_path):
     template_root = tmp_path / "templates"
     template_root.mkdir()
-    monkeypatch.setattr(fensap_jobs, "__file__", str(tmp_path / "pkg" / "fensap/__init__.py"))
 
     # minimal required templates
     names = [
@@ -421,8 +408,6 @@ def test_multishot_drop_initial_type_and_timebc(monkeypatch, tmp_path):
     """Check DRP_GUI_INITIAL_TYPE and FSP_GUI_NO_TIMEBC handling."""
     template_root = tmp_path / "templates"
     template_root.mkdir()
-    monkeypatch.setattr(fensap_jobs, "__file__", str(tmp_path / "pkg" / "fensap/__init__.py"))
-
     names = [
         "MULTISHOT.meshingSizes.scm.j2",
         "MULTISHOT.custom_remeshing.sh.j2",
@@ -472,7 +457,6 @@ def test_multishot_drop_initial_type_and_timebc(monkeypatch, tmp_path):
 def test_multishot_roughness_and_laplace(monkeypatch, tmp_path):
     template_root = tmp_path / "templates"
     template_root.mkdir()
-    monkeypatch.setattr(fensap_jobs, "__file__", str(tmp_path / "pkg" / "fensap/__init__.py"))
 
     names = [
         "MULTISHOT.meshingSizes.scm.j2",
@@ -524,7 +508,6 @@ def test_multishot_global_laplace_is_ignored_first_shot(monkeypatch, tmp_path):
     """A globally defined ``FSP_MAX_LAPLACE_ITERATIONS`` must not appear in the first shot."""
     template_root = tmp_path / "templates"
     template_root.mkdir()
-    monkeypatch.setattr(fensap_jobs, "__file__", str(tmp_path / "pkg" / "fensap/__init__.py"))
 
     names = [
         "MULTISHOT.meshingSizes.scm.j2",
@@ -845,4 +828,3 @@ def test_fensap_script_job_uses_engine_factory(monkeypatch, tmp_path):
     job.execute()
 
     assert called["name"] == "FensapEngine"
-

--- a/tests/test_multishot_timings.py
+++ b/tests/test_multishot_timings.py
@@ -1,19 +1,18 @@
 import sys
 from pathlib import Path
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from glacium.jobs import fensap as fensap_jobs
 from glacium.jobs.fensap import MultiShotRunJob
+from glacium.managers.path_manager import PathBuilder
 from glacium.managers.template_manager import TemplateManager
 from glacium.models.config import GlobalConfig
-from glacium.managers.path_manager import PathBuilder
 from glacium.models.project import Project
 
 
 def test_multishot_timings(monkeypatch, tmp_path):
     template_root = tmp_path / "templates"
     template_root.mkdir()
-    monkeypatch.setattr(fensap_jobs, "__file__", str(tmp_path / "pkg" / "fensap/__init__.py"))
 
     # minimal required templates
     names = [
@@ -38,7 +37,9 @@ def test_multishot_timings(monkeypatch, tmp_path):
         (template_root / n).write_text(content)
 
     # template under test prints timing values
-    (template_root / "config.ice.j2").write_text("{{ ICE_GUI_INITIAL_TIME }} {{ ICE_GUI_TOTAL_TIME }}")
+    (template_root / "config.ice.j2").write_text(
+        "{{ ICE_GUI_INITIAL_TIME }} {{ ICE_GUI_TOTAL_TIME }}"
+    )
 
     cfg = GlobalConfig(project_uid="uid", base_dir=tmp_path)
     cfg["FENSAP_EXE"] = "sh"
@@ -64,4 +65,3 @@ def test_multishot_timings(monkeypatch, tmp_path):
         text = (work / f"config.ice.{idx}").read_text().strip()
         nums = [float(x) for x in text.split()]
         assert nums == [float(pair[0]), float(pair[1])]
-

--- a/tests/test_single_convergence_stats.py
+++ b/tests/test_single_convergence_stats.py
@@ -1,17 +1,20 @@
 import sys
 from pathlib import Path
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-import numpy as np
 import matplotlib
-matplotlib.use('Agg')
-import pytest
+import numpy as np
+
+matplotlib.use("Agg")
 import csv
 import os
+
+import pytest
 from PyPDF2 import PdfReader
 
 from glacium.utils.convergence import analysis_file
-from glacium.utils.report_converg_fensap import build_report
+from glacium.utils.reporting.report_converg_fensap import build_report
 
 
 def test_single_convergence_stats(tmp_path):
@@ -19,15 +22,18 @@ def test_single_convergence_stats(tmp_path):
     out_dir = tmp_path / "out"
     os.environ["FPDF_FONT_DIR"] = "/usr/share/fonts/truetype/dejavu"
     from fpdf import fpdf
+
     setattr(fpdf, "FPDF_FONT_DIR", "/usr/share/fonts/truetype/dejavu")
 
-    data = np.array([
-        [1.0, 2.0],
-        [3.0, 4.0],
-        [5.0, 6.0],
-        [7.0, 8.0],
-        [9.0, 10.0],
-    ])
+    data = np.array(
+        [
+            [1.0, 2.0],
+            [3.0, 4.0],
+            [5.0, 6.0],
+            [7.0, 8.0],
+            [9.0, 10.0],
+        ]
+    )
     labels = ["mass inflow , kg/s", "mass outflow, kg/s"]
     lines = [f"# 1 {labels[0]}", f"# 2 {labels[1]}"]
     lines += [" ".join(map(str, row)) for row in data]


### PR DESCRIPTION
## Summary
- update old imports to new paths in reporting
- drop outdated __file__ monkeypatches
- format updated tests

## Testing
- `black tests/test_single_convergence_stats.py tests/test_multishot_timings.py tests/test_engines.py`
- `ruff check --fix tests/test_single_convergence_stats.py tests/test_multishot_timings.py tests/test_engines.py`
- `isort tests/test_single_convergence_stats.py tests/test_multishot_timings.py tests/test_engines.py`
- `mypy tests/test_single_convergence_stats.py tests/test_multishot_timings.py tests/test_engines.py` *(fails: No overload variant of "__getitem__" of "list" matches argument type)*
- `pytest -k JobFactory -q` *(fails: ModuleNotFoundError: No module named 'pyvista')*

------
https://chatgpt.com/codex/tasks/task_e_688244fb80ec83279168bbddc0787acc