### PR TITLE
Inject engines via DI

### DIFF
--- a/glacium/jobs/fensap/fluent2fensap.py
+++ b/glacium/jobs/fensap/fluent2fensap.py
@@ -5,8 +5,9 @@ from pathlib import Path
 
 from glacium.models.job import Job
 from glacium.engines.base_engine import BaseEngine
-from glacium.utils.logging import log, log_call
 from glacium.engines.engine_factory import EngineFactory
+from glacium.engines.fluent2fensap import Fluent2FensapEngine
+from glacium.utils.logging import log, log_call
 
 
 class Fluent2FensapJob(Job):

--- a/glacium/jobs/fensap/multishot_run.py
+++ b/glacium/jobs/fensap/multishot_run.py
@@ -33,8 +33,8 @@ class MultiShotRunJob(FensapScriptJob):
         "files.fensap.j2": "files.fensap.{idx}",
     }
 
-    def __init__(self, project):
-        super().__init__(project)
+    def __init__(self, project, engine=None):
+        super().__init__(project, engine)
 
     def prepare(self):
         paths = self.project.paths

--- a/glacium/recipes/default_aero.py
+++ b/glacium/recipes/default_aero.py
@@ -2,6 +2,7 @@
 
 from glacium.managers.recipe_manager import RecipeManager, BaseRecipe
 from glacium.utils.JobIndex import JobFactory
+from glacium.engines.pointwise import PointwiseEngine
 
 
 @RecipeManager.register
@@ -16,7 +17,7 @@ class DefaultAero(BaseRecipe):
             JobFactory.create("XFOIL_REFINE", project),
             JobFactory.create("XFOIL_THICKEN_TE", project),
             JobFactory.create("XFOIL_PW_CONVERT", project),
-            JobFactory.create("POINTWISE_GCI", project),
+            JobFactory.create("POINTWISE_GCI", project, engine=PointwiseEngine),
             JobFactory.create("FLUENT2FENSAP", project),
         ]
 

--- a/glacium/recipes/fensap.py
+++ b/glacium/recipes/fensap.py
@@ -2,6 +2,7 @@
 
 from glacium.managers.recipe_manager import RecipeManager, BaseRecipe
 from glacium.utils.JobIndex import JobFactory
+from glacium.engines.fensap import FensapEngine
 
 @RecipeManager.register
 class FensapRecipe(BaseRecipe):
@@ -10,6 +11,6 @@ class FensapRecipe(BaseRecipe):
     name = "fensap"
     description = "Run fensap scripts"
     def build(self, project):
-        return [JobFactory.create("FENSAP_RUN", project)]
+        return [JobFactory.create("FENSAP_RUN", project, engine=FensapEngine)]
 
 

--- a/glacium/recipes/grid_dependency.py
+++ b/glacium/recipes/grid_dependency.py
@@ -2,6 +2,8 @@
 
 from glacium.managers.recipe_manager import RecipeManager, BaseRecipe
 from glacium.utils.JobIndex import JobFactory
+from glacium.engines.pointwise import PointwiseEngine
+from glacium.engines.fensap import FensapEngine
 
 
 @RecipeManager.register
@@ -16,8 +18,8 @@ class GridDependencyRecipe(BaseRecipe):
             JobFactory.create("XFOIL_REFINE", project),
             JobFactory.create("XFOIL_THICKEN_TE", project),
             JobFactory.create("XFOIL_PW_CONVERT", project),
-            JobFactory.create("POINTWISE_GCI", project),
+            JobFactory.create("POINTWISE_GCI", project, engine=PointwiseEngine),
             JobFactory.create("FLUENT2FENSAP", project),
-            JobFactory.create("FENSAP_RUN", project),
+            JobFactory.create("FENSAP_RUN", project, engine=FensapEngine),
             JobFactory.create("FENSAP_CONVERGENCE_STATS", project),
         ]

--- a/glacium/recipes/multishot.py
+++ b/glacium/recipes/multishot.py
@@ -2,6 +2,8 @@
 
 from glacium.managers.recipe_manager import RecipeManager, BaseRecipe
 from glacium.utils.JobIndex import JobFactory
+from glacium.engines.pointwise import PointwiseEngine
+from glacium.engines.fensap import FensapEngine
 
 @RecipeManager.register
 class DefaultAero(BaseRecipe):
@@ -15,9 +17,9 @@ class DefaultAero(BaseRecipe):
             JobFactory.create("XFOIL_REFINE", project),
             JobFactory.create("XFOIL_THICKEN_TE", project),
             JobFactory.create("XFOIL_PW_CONVERT", project),
-            JobFactory.create("POINTWISE_GCI", project),
+            JobFactory.create("POINTWISE_GCI", project, engine=PointwiseEngine),
             JobFactory.create("FLUENT2FENSAP", project),
-            JobFactory.create("MULTISHOT_RUN", project),
+            JobFactory.create("MULTISHOT_RUN", project, engine=FensapEngine),
             JobFactory.create("CONVERGENCE_STATS", project),
         ]
 

--- a/glacium/recipes/pointwise.py
+++ b/glacium/recipes/pointwise.py
@@ -2,6 +2,7 @@
 
 from glacium.managers.recipe_manager import RecipeManager, BaseRecipe
 from glacium.utils.JobIndex import JobFactory
+from glacium.engines.pointwise import PointwiseEngine
 
 @RecipeManager.register
 class PointwiseRecipe(BaseRecipe):
@@ -12,8 +13,8 @@ class PointwiseRecipe(BaseRecipe):
 
     def build(self, project):
         return [
-            JobFactory.create("POINTWISE_GCI", project),
-            JobFactory.create("POINTWISE_MESH2", project),
+            JobFactory.create("POINTWISE_GCI", project, engine=PointwiseEngine),
+            JobFactory.create("POINTWISE_MESH2", project, engine=PointwiseEngine),
             JobFactory.create("FLUENT2FENSAP", project),
         ]
 

--- a/glacium/recipes/prep.py
+++ b/glacium/recipes/prep.py
@@ -2,6 +2,7 @@
 
 from glacium.managers.recipe_manager import RecipeManager, BaseRecipe
 from glacium.utils.JobIndex import JobFactory
+from glacium.engines.pointwise import PointwiseEngine
 
 
 @RecipeManager.register
@@ -16,6 +17,6 @@ class PrepRecipe(BaseRecipe):
             JobFactory.create("XFOIL_REFINE", project),
             JobFactory.create("XFOIL_THICKEN_TE", project),
             JobFactory.create("XFOIL_PW_CONVERT", project),
-            JobFactory.create("POINTWISE_GCI", project),
+            JobFactory.create("POINTWISE_GCI", project, engine=PointwiseEngine),
             JobFactory.create("FLUENT2FENSAP", project),
         ]

--- a/glacium/recipes/solver.py
+++ b/glacium/recipes/solver.py
@@ -2,6 +2,7 @@
 
 from glacium.managers.recipe_manager import RecipeManager, BaseRecipe
 from glacium.utils.JobIndex import JobFactory
+from glacium.engines.fensap import FensapEngine
 
 
 @RecipeManager.register
@@ -13,10 +14,10 @@ class SolverRecipe(BaseRecipe):
 
     def build(self, project):
         return [
-            JobFactory.create("FENSAP_RUN", project),
+            JobFactory.create("FENSAP_RUN", project, engine=FensapEngine),
             JobFactory.create("FENSAP_CONVERGENCE_STATS", project),
-            JobFactory.create("DROP3D_RUN", project),
+            JobFactory.create("DROP3D_RUN", project, engine=FensapEngine),
             JobFactory.create("DROP3D_CONVERGENCE_STATS", project),
-            JobFactory.create("ICE3D_RUN", project),
+            JobFactory.create("ICE3D_RUN", project, engine=FensapEngine),
             JobFactory.create("ICE3D_CONVERGENCE_STATS", project),
         ]

--- a/glacium/utils/JobIndex.py
+++ b/glacium/utils/JobIndex.py
@@ -42,8 +42,8 @@ class JobFactory:
 
     # ------------------------------------------------------------------
     @classmethod
-    def create(cls, name: str, project) -> Job:
-        """Instantiate the registered job ``name`` for ``project``."""
+    def create(cls, name: str, project, *args, **kwargs) -> Job:
+        """Instantiate the registered job ``name`` for ``project`` with optional parameters."""
 
         cls._load()
         if name not in cls._jobs:  # type: ignore[arg-type]
@@ -53,7 +53,7 @@ class JobFactory:
                     f"Job '{name}' nicht bekannt. Fehler beim Import folgender Module: {mods}"
                 )
             raise KeyError(f"Job '{name}' nicht bekannt.")
-        return cls._jobs[name](project)  # type: ignore[index]
+        return cls._jobs[name](project, *args, **kwargs)  # type: ignore[index]
 
     # ------------------------------------------------------------------
     @classmethod
@@ -118,8 +118,8 @@ def get_job_class(name: str) -> Optional[Type[Job]]:
     return JobFactory.get(name)
 
 
-def create_job(name: str, project) -> Job:
-    return JobFactory.create(name, project)
+def create_job(name: str, project, *args, **kwargs) -> Job:
+    return JobFactory.create(name, project, *args, **kwargs)
 
 
 def get_import_errors() -> Dict[str, Exception]:


### PR DESCRIPTION
## Summary
- allow `ScriptJob` to accept an engine instance or factory
- load `Fluent2FensapEngine` when converting meshes
- inject engines when creating jobs in recipes
- update engine tests for new injection style

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688248e7d0b48327bcd66e876f2a51c0