### PR TITLE
Refactor job and engine inheritance

### DIFF
--- a/glacium/engines/base_engine.py
+++ b/glacium/engines/base_engine.py
@@ -8,12 +8,12 @@ from glacium.utils.logging import log
 
 
 class BaseEngine(EngineBase):
-    """Small helper class wrapping subprocess execution."""
+    """Compatibility alias for :class:`EngineBase`."""
 
     pass
 
 
-class XfoilEngine(BaseEngine):
+class XfoilEngine(EngineBase):
     """Engine wrapper used by :class:`XfoilScriptJob`."""
 
     def __init__(self, exe: str, timeout: int | None = None) -> None:
@@ -28,7 +28,7 @@ class XfoilEngine(BaseEngine):
             self.run([self.exe], cwd=work, stdin=stdin)
 
 
-class DummyEngine(BaseEngine):
+class DummyEngine(EngineBase):
     """Engine used for tests; simulates a long running task."""
 
     def timer(self, seconds: int = 30) -> None:

--- a/glacium/engines/fensap.py
+++ b/glacium/engines/fensap.py
@@ -9,14 +9,13 @@ import sys
 import yaml
 
 from glacium.utils.logging import log, log_call
-from glacium.jobs.base import ScriptJob
+from glacium.core.base import EngineBase, ScriptJobBase
 from glacium.managers.template_manager import TemplateManager
-from .base_engine import BaseEngine
 from .engine_factory import EngineFactory
 
 
 @EngineFactory.register
-class FensapEngine(BaseEngine):
+class FensapEngine(EngineBase):
     """Execute ``.solvercmd`` files via ``nti_sh.exe``."""
 
     def __init__(self, exe: str, timeout: int | None = None) -> None:
@@ -36,7 +35,7 @@ __all__: Iterable[str] = [
 ]
 
 
-class FensapScriptJob(ScriptJob):
+class FensapScriptJob(ScriptJobBase):
     """Render FENSAP input files and execute the solver."""
 
     # Mapping of template -> output filename relative to the solver dir
@@ -86,7 +85,7 @@ class FensapScriptJob(ScriptJob):
         cfg = self.project.config
         return {**defaults, **cfg.extras}
 
-    # execution handled by :class:`ScriptJob`
+    # execution handled by :class:`ScriptJobBase`
 
 
 

--- a/glacium/engines/fluent2fensap.py
+++ b/glacium/engines/fluent2fensap.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from glacium.engines.base_engine import BaseEngine
+from glacium.core.base import EngineBase
 from glacium.utils.logging import log
 from .engine_factory import EngineFactory
 
@@ -12,7 +12,7 @@ __all__ = ["Fluent2FensapEngine"]
 
 
 @EngineFactory.register
-class Fluent2FensapEngine(BaseEngine):
+class Fluent2FensapEngine(EngineBase):
     """Run the ``fluent2fensap`` converter."""
 
     def __init__(self, exe: str, timeout: int | None = None) -> None:

--- a/glacium/engines/pointwise.py
+++ b/glacium/engines/pointwise.py
@@ -5,11 +5,9 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Iterable
 
-from glacium.jobs.base import ScriptJob
-from glacium.core.base import JobStatus
+from glacium.core.base import JobStatus, EngineBase, ScriptJobBase
 from glacium.managers.template_manager import TemplateManager
 from glacium.utils.logging import log
-from .base_engine import BaseEngine
 from .engine_factory import EngineFactory
 
 __all__: Iterable[str] = [
@@ -19,7 +17,7 @@ __all__: Iterable[str] = [
 
 
 @EngineFactory.register
-class PointwiseEngine(BaseEngine):
+class PointwiseEngine(EngineBase):
     """Execute Pointwise TCL scripts."""
 
     def __init__(self, exe: str, timeout: int | None = None) -> None:
@@ -33,7 +31,7 @@ class PointwiseEngine(BaseEngine):
         self.run([self.exe, str(script)], cwd=work)
 
 
-class PointwiseScriptJob(ScriptJob):
+class PointwiseScriptJob(ScriptJobBase):
     """Render a Pointwise .glf script and execute it."""
 
     engine_name = "PointwiseEngine"

--- a/glacium/engines/py_engine.py
+++ b/glacium/engines/py_engine.py
@@ -2,10 +2,19 @@
 from pathlib import Path
 from typing import Sequence, Callable
 
-class PyEngine:
-    """Ausführtbare Python-Callback als Job-Engine."""
-    def __init__(self, fn: Callable[[Path, Sequence[str]], None]):
+from glacium.core.base import EngineBase
+
+class PyEngine(EngineBase):
+    """Execute a Python callable as job engine."""
+
+    def __init__(self, fn: Callable[[Path, Sequence[str]], None], timeout: int | None = None) -> None:
+        super().__init__(timeout)
         self.fn = fn
 
-    def run(self, cmd: Sequence[str], cwd: Path, **_) -> None:
-        self.fn(cwd, cmd)                 # kein Sub-Prozess
+    def run(self, cmd: Sequence[str], *, cwd: Path, stdin=None) -> None:  # type: ignore[override]
+        self.fn(cwd, list(cmd))  # no subprocess
+
+    def run_script(self, script: Path, work: Path) -> None:  # pragma: no cover - not used
+        with script.open("r") as fh:
+            args = [line.strip() for line in fh if line.strip()]
+        self.run(args, cwd=work)

--- a/glacium/engines/xfoil_base.py
+++ b/glacium/engines/xfoil_base.py
@@ -13,8 +13,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Iterable
 
-from glacium.jobs.base import ScriptJob
-from glacium.core.base import JobStatus
+from glacium.core.base import JobStatus, ScriptJobBase
 from glacium.managers.template_manager import TemplateManager
 from glacium.utils.logging import log
 from .base_engine import XfoilEngine
@@ -25,7 +24,7 @@ __all__: Iterable[str] = [
 ]
 
 
-class XfoilScriptJob(ScriptJob):
+class XfoilScriptJob(ScriptJobBase):
     """Abstract base class for an XFOIL script job."""
 
     engine_name = "XfoilEngine"

--- a/glacium/jobs/analysis/analyze_multishot.py
+++ b/glacium/jobs/analysis/analyze_multishot.py
@@ -5,12 +5,12 @@ from pathlib import Path
 from typing import Sequence
 import pandas as pd
 
-from glacium.jobs.base import PythonJob
+from glacium.core.base import PythonJobBase
 from glacium.engines.py_engine import PyEngine
 from glacium.post import analysis as post_analysis
 
 
-class AnalyzeMultishotJob(PythonJob):
+class AnalyzeMultishotJob(PythonJobBase):
     """Analyse MULTISHOT solver exports."""
 
     name = "ANALYZE_MULTISHOT"

--- a/glacium/jobs/analysis/convergence_stats.py
+++ b/glacium/jobs/analysis/convergence_stats.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Sequence
 
-from glacium.jobs.base import PythonJob
+from glacium.core.base import PythonJobBase
 from glacium.engines.py_engine import PyEngine
 from glacium.utils.convergence import analysis, analysis_file
 from glacium.utils.report_converg_fensap import build_report
 
 
-class ConvergenceStatsJob(PythonJob):
+class ConvergenceStatsJob(PythonJobBase):
     """Aggregate convergence statistics of a MULTISHOT run."""
 
     name = "CONVERGENCE_STATS"

--- a/glacium/jobs/analysis/drop3d_convergence_stats.py
+++ b/glacium/jobs/analysis/drop3d_convergence_stats.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Sequence
 
-from glacium.jobs.base import PythonJob
+from glacium.core.base import PythonJobBase
 from glacium.utils.convergence import analysis_file
 from glacium.utils.report_converg_fensap import build_report
 
 
-class Drop3dConvergenceStatsJob(PythonJob):
+class Drop3dConvergenceStatsJob(PythonJobBase):
     """Generate convergence plots for a DROP3D run."""
 
     name = "DROP3D_CONVERGENCE_STATS"

--- a/glacium/jobs/analysis/fensap_analysis.py
+++ b/glacium/jobs/analysis/fensap_analysis.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Sequence
 
-from glacium.jobs.base import PythonJob
+from glacium.core.base import PythonJobBase
 from glacium.engines.py_engine import PyEngine
 from glacium.utils.postprocess_fensap import fensap_analysis
 
 
-class FensapAnalysisJob(PythonJob):
+class FensapAnalysisJob(PythonJobBase):
     """Generate slice plots from FENSAP results."""
 
     name = "FENSAP_ANALYSIS"

--- a/glacium/jobs/analysis/fensap_convergence_stats.py
+++ b/glacium/jobs/analysis/fensap_convergence_stats.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Sequence
 
-from glacium.jobs.base import PythonJob
+from glacium.core.base import PythonJobBase
 from glacium.utils.convergence import analysis_file
 from glacium.utils.report_converg_fensap import build_report
 
 
-class FensapConvergenceStatsJob(PythonJob):
+class FensapConvergenceStatsJob(PythonJobBase):
     """Generate convergence plots for a FENSAP run."""
 
     name = "FENSAP_CONVERGENCE_STATS"

--- a/glacium/jobs/analysis/ice3d_convergence_stats.py
+++ b/glacium/jobs/analysis/ice3d_convergence_stats.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Sequence
 
-from glacium.jobs.base import PythonJob
+from glacium.core.base import PythonJobBase
 from glacium.utils.convergence import analysis_file
 from glacium.utils.report_converg_fensap import build_report
 
 
-class Ice3dConvergenceStatsJob(PythonJob):
+class Ice3dConvergenceStatsJob(PythonJobBase):
     """Generate convergence plots for an ICE3D run."""
 
     name = "ICE3D_CONVERGENCE_STATS"

--- a/glacium/jobs/analysis/mesh_analysis.py
+++ b/glacium/jobs/analysis/mesh_analysis.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Sequence
 
-from glacium.jobs.base import PythonJob
+from glacium.core.base import PythonJobBase
 from glacium.engines.py_engine import PyEngine
 from glacium.utils.mesh_analysis import mesh_analysis
 
 
-class MeshAnalysisJob(PythonJob):
+class MeshAnalysisJob(PythonJobBase):
     """Generate mesh screenshots and HTML report."""
 
     name = "MESH_ANALYSIS"

--- a/glacium/jobs/base.py
+++ b/glacium/jobs/base.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-from abc import ABC
+"""Compatibility aliases for job base classes."""
 
-from glacium.core.base import JobBase, ScriptJobBase, PythonJobBase
-
-
-class ScriptJob(ScriptJobBase, ABC):
-    """Compatibility wrapper for :class:`~glacium.core.base.ScriptJobBase`."""
+from glacium.core.base import ScriptJobBase, PythonJobBase
 
 
-class PythonJob(PythonJobBase, ABC):
-    """Compatibility wrapper for :class:`~glacium.core.base.PythonJobBase`."""
+ScriptJob = ScriptJobBase
+PythonJob = PythonJobBase
+
+__all__ = ["ScriptJob", "PythonJob", "ScriptJobBase", "PythonJobBase"]

--- a/glacium/jobs/fensap/fluent2fensap.py
+++ b/glacium/jobs/fensap/fluent2fensap.py
@@ -3,14 +3,13 @@ from __future__ import annotations
 import shutil
 from pathlib import Path
 
-from glacium.models.job import Job
-from glacium.engines.base_engine import BaseEngine
+from glacium.core.base import PythonJobBase
 from glacium.engines.engine_factory import EngineFactory
 from glacium.engines.fluent2fensap import Fluent2FensapEngine
 from glacium.utils.logging import log, log_call
 
 
-class Fluent2FensapJob(Job):
+class Fluent2FensapJob(PythonJobBase):
     """Run ``fluent2fensap.exe`` to produce a ``.grid`` file."""
 
     name = "FLUENT2FENSAP"
@@ -19,6 +18,9 @@ class Fluent2FensapJob(Job):
     _DEFAULT_EXE = (
         r"C:/Program Files/ANSYS Inc/v251/fensapice/bin/fluent2fensap.exe"
     )
+
+    def args(self) -> list[str]:
+        return []
 
     @log_call
     def execute(self) -> None:  # noqa: D401

--- a/glacium/jobs/postprocess/multishot.py
+++ b/glacium/jobs/postprocess/multishot.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
-from glacium.models.job import Job
+from glacium.core.base import PythonJobBase
 from glacium.post.convert.multishot import MultiShotConverter
 from glacium.post import write_manifest
 
 
-class PostprocessMultishotJob(Job):
+class PostprocessMultishotJob(PythonJobBase):
     """Convert MULTISHOT results and write manifest."""
 
     name = "POSTPROCESS_MULTISHOT"
+
+    def args(self) -> list[str]:
+        return []
 
     def execute(self) -> None:  # noqa: D401
         root = self.project.root

--- a/glacium/jobs/postprocess/single_fensap.py
+++ b/glacium/jobs/postprocess/single_fensap.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
-from glacium.models.job import Job
+from glacium.core.base import PythonJobBase
 from glacium.post.convert.single import SingleShotConverter
 from glacium.post import PostProcessor, write_manifest
 
 
-class PostprocessSingleFensapJob(Job):
+class PostprocessSingleFensapJob(PythonJobBase):
     """Convert FENSAP single-shot results and write manifest."""
 
     name = "POSTPROCESS_SINGLE_FENSAP"
+
+    def args(self) -> list[str]:
+        return []
 
     def execute(self) -> None:  # noqa: D401
         root = self.project.root


### PR DESCRIPTION
## Summary
- remove thin job wrappers and expose core job base classes
- update engines to inherit directly from `EngineBase`
- adapt all job definitions to subclass the new bases
- migrate PyEngine to a real `EngineBase`

## Testing
- `pytest -q` *(fails: PermissionError, missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68834b0e58948327a2cbdf5442ca3a5c