### PR TITLE
Update docs for core package

### DIFF
--- a/docs/adding_engines.rst
+++ b/docs/adding_engines.rst
@@ -8,17 +8,16 @@ via :class:`~glacium.engines.engine_factory.EngineFactory`.
 Implement a subclass
 --------------------
 
-Create a new class derived from
-:class:`~glacium.engines.base_engine.BaseEngine` and add methods that
-run your solver or other tools.  Use :meth:`~glacium.engines.base_engine.BaseEngine.run`
-to execute commands.
+Create a new class derived from :class:`glacium.core.EngineBase` and add
+methods that run your solver or other tools.  Use
+:meth:`~glacium.core.EngineBase.run` to execute commands.
 
 .. code-block:: python
 
    from pathlib import Path
-   from glacium.engines.base_engine import BaseEngine
+   from glacium.core import EngineBase
 
-   class MyEngine(BaseEngine):
+   class MyEngine(EngineBase):
        def run_my_solver(self, exe: str, work: Path) -> None:
            # call the executable inside ``work``
            self.run([exe, "--foo"], cwd=work)
@@ -36,7 +35,7 @@ by name.
    from glacium.engines.engine_factory import EngineFactory
 
    @EngineFactory.register
-   class MyEngine(BaseEngine):
+   class MyEngine(EngineBase):
        ...
 
 Later you can create an instance dynamically:

--- a/docs/adding_jobs.rst
+++ b/docs/adding_jobs.rst
@@ -1,22 +1,22 @@
 Adding Jobs
 ===========
 
-This guide explains how to implement new :class:`glacium.models.job.Job` classes
-and integrate them with the rest of the framework.
+This guide explains how to implement new :class:`glacium.core.JobBase`
+classes and integrate them with the rest of the framework.
 
 Extending ``Job``
 -----------------
 
-Create a subclass of :class:`glacium.models.job.Job` and override
-:meth:`~glacium.models.job.Job.execute`.  Each job must define a unique
-``name`` used for discovery and an optional ``deps`` sequence listing the names
-of jobs that need to finish before it may run.
+Create a subclass of :class:`glacium.core.JobBase` and override
+:meth:`~glacium.core.JobBase.execute`.  Each job must define a unique ``name``
+and an optional ``deps`` sequence listing the names of jobs that need to finish
+before it may run.
 
 .. code-block:: python
 
-   from glacium.models.job import Job
+   from glacium.core import JobBase
 
-   class HelloJob(Job):
+   class HelloJob(JobBase):
        name = "HELLO"
        deps = ()
 
@@ -37,18 +37,17 @@ abstract helpers :class:`~glacium.jobs.base.ScriptJob` and
 Registering with ``JobFactory``
 -------------------------------
 
-``JobFactory`` keeps a registry of available jobs.  Subclasses of
-:class:`~glacium.models.job.Job` are automatically registered via the
-``__init_subclass__`` hook when their module is imported.  If you create a job
-class dynamically or outside the standard packages you can register it
-manually:
+``JobFactory`` keeps a registry of available jobs.  ``Job`` subclasses from
+:mod:`glacium.models.job` register automatically when imported.  If you derive
+directly from :class:`glacium.core.JobBase` or create the class dynamically you
+can register it manually:
 
 .. code-block:: python
 
    from glacium.utils.JobIndex import JobFactory
 
    @JobFactory.register
-   class CustomJob(Job):
+   class CustomJob(JobBase):
        name = "CUSTOM"
        def execute(self):
            ...

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -13,6 +13,7 @@ The project is organised into a set of top level packages:
 * ``glacium/cli`` – ``click`` based command line interface
 * ``glacium/engines`` – wrappers around external programs
 * ``glacium/jobs`` – concrete job implementations
+* ``glacium/core`` – minimal base classes shared by jobs and engines
 * ``glacium/managers`` – high level helpers coordinating projects
 * ``glacium/recipes`` – collections of jobs bundled under a name
 * ``glacium/models`` – dataclasses used across the code base
@@ -44,3 +45,12 @@ Factories
 ``EngineFactory`` and ``JobFactory`` implement simple registries.  Engines and
 jobs register themselves via class decorators.  Recipes or job classes can then
 instantiate them by name without direct imports.
+
+Core layer
+----------
+
+``glacium.core`` sits at the bottom of the layered model.  It defines
+:class:`~glacium.core.JobBase` and :class:`~glacium.core.EngineBase` which
+provide the minimal interfaces used throughout the domain layer.  Higher levels
+build on these abstractions while remaining independent from concrete
+implementations.


### PR DESCRIPTION
## Summary
- clarify package layout for `glacium.core`
- mention the core layer in the architecture overview
- show `JobBase` usage in the adding jobs guide
- show `EngineBase` usage in the adding engines guide

## Testing
- `pytest -q` *(fails: 39 errors during collection)*
- `make -C docs html`

------
https://chatgpt.com/codex/tasks/task_e_68835a0672d08327ac3bf2fc5110cddd