### PR TITLE
Move physics helpers to new module

### DIFF
--- a/glacium/physics/__init__.py
+++ b/glacium/physics/__init__.py
@@ -1,0 +1,37 @@
+"""Physics helper functions."""
+
+from __future__ import annotations
+
+
+def ambient_pressure(altitude: float) -> float:
+    """Return ambient pressure at ``altitude`` in metres (Pa)."""
+
+    return 101325.0 * (1.0 - 2.25577e-5 * altitude) ** 5.2559
+
+
+def interpolate_kinematic_viscosity(T_K: float) -> float:
+    """Interpolate air kinematic viscosity [m²/s] for temperature ``T_K`` in K."""
+
+    table = [
+        (175, 0.586e-5),
+        (200, 0.753e-5),
+        (225, 0.935e-5),
+        (250, 1.132e-5),
+        (275, 1.343e-5),
+        (300, 1.568e-5),
+        (325, 1.807e-5),
+        (350, 2.056e-5),
+        (375, 2.317e-5),
+        (400, 2.591e-5),
+        (450, 3.168e-5),
+        (500, 3.782e-5),
+        (550, 4.439e-5),
+        (600, 5.128e-5),
+    ]
+    for (T1, nu1), (T2, nu2) in zip(table, table[1:]):
+        if T1 < T_K < T2:
+            return nu1 + (nu2 - nu1) * (T_K - T1) / (T2 - T1)
+    raise ValueError("Temperature out of supported range 175–600 K")
+
+
+__all__ = ["ambient_pressure", "interpolate_kinematic_viscosity"]

--- a/glacium/utils/case_to_global.py
+++ b/glacium/utils/case_to_global.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Dict, Any
-
 import math
+from pathlib import Path
+from typing import Any, Dict
+
 import yaml
 
-from .first_cellheight import from_case as first_cellheight, interpolate_kinematic_viscosity
+from glacium.physics import ambient_pressure, interpolate_kinematic_viscosity
+
+from .first_cellheight import from_case as first_cellheight
 
 """Helper converting ``case.yaml`` files to global configuration data."""
 
@@ -15,13 +17,6 @@ __all__ = ["generate_global_defaults"]
 
 def _load_yaml(file: Path) -> dict:
     return yaml.safe_load(file.read_text()) if file.exists() else {}
-
-
-def _ambient_pressure(altitude: float) -> float:
-    """Return ambient pressure at ``altitude`` in metres (Pa)."""
-    return 101325.0 * (1.0 - 2.25577e-5 * altitude) ** 5.2559
-
-
 
 
 def generate_global_defaults(case_path: Path, template_path: Path) -> Dict[str, Any]:
@@ -53,7 +48,7 @@ def generate_global_defaults(case_path: Path, template_path: Path) -> Dict[str, 
     refinement = float(case.get("PWS_REFINEMENT", cfg.get("PWS_REFINEMENT", 1)))
     multishot = case.get("CASE_MULTISHOT")
     # Ambient conditions ------------------------------------------------------
-    pressure = _ambient_pressure(altitude)
+    pressure = ambient_pressure(altitude)
     density = pressure / (287.05 * temperature)
     nu = interpolate_kinematic_viscosity(temperature)
     mu = density * nu
@@ -61,7 +56,7 @@ def generate_global_defaults(case_path: Path, template_path: Path) -> Dict[str, 
     a = math.sqrt(1.4 * 287.05 * temperature)
     mach = velocity / a if a else 0.0
     reynolds = density * velocity * chord / mu if mu else 0.0
-    ad_temperture = temperature*(1+(kappa-1)*0.5*(mach**2))+10
+    ad_temperture = temperature * (1 + (kappa - 1) * 0.5 * (mach**2)) + 10
 
     # First cell height -------------------------------------------------------
     first_height = first_cellheight(case)
@@ -71,74 +66,72 @@ def generate_global_defaults(case_path: Path, template_path: Path) -> Dict[str, 
     vx = velocity * math.cos(alpha)
     vy = velocity * math.sin(alpha)
     vz = 0.0
-    spacing1 = cfg.get("PWS_SPACING_1")
-    spacing2 = cfg.get("PWS_SPACING_2")
     # Populate configuration --------------------------------------------------
-    cfg.update({
-        "PWS_CHORD_LENGTH": chord,
-        "PWS_TE_GAP": 0.001/chord,
-        "PWS_TREX_FIRST_HEIGHT": first_height,
-        "PWS_POL_REYNOLDS": reynolds,
-        "PWS_PSI_REYNOLDS": reynolds,
-        "PWS_POL_MACH": mach,
-        "PWS_PSI_MACH": mach,
-        "PWS_EXTRUSION_Z_DISTANCE": chord * 0.1,
-        "MSH_GLOBMIN": 0.1*(3e-4),
-        "MSH_PROXMIN": 1e-4,
-        "MSH_CURVMIN": 3e-4,
-        "MSH_CURVMAX": 1e-3,
-        "MSH_GLOBMAX": 0.12,
-
-        "MSH_Z_SPAN": chord * 0.1,
-        "MSH_MPX": chord * 1.01,
-        "MSH_MPY": 0.0,
-        "MSH_MPZ": chord * 0.1 * 0.5,
-        "MSH_FIRSTCELLHEIGHT": 0.0000045,
-        "FSP_CHARAC_LENGTH": chord,
-        "FSP_REF_AREA": 0.1*chord**2,
-        "FSP_FREESTREAM_PRESSURE": pressure,
-        "FSP_FREESTREAM_TEMPERATURE": temperature,
-        "FSP_FREESTREAM_VELOCITY": velocity,
-        "FSP_FREESTREAM_DIAMETER": mvd,
-        "FSP_FREESTREAM_LWC": lwc,
-        "FSP_MACH_NUMBER": mach,
-        "FSP_REYNOLDS_NUMBER": reynolds,
-        "FSP_VELOCITY_X": vx,
-        "FSP_VELOCITY_Y": vy,
-        "FSP_VELOCITY_Z": vz,
-        "FSP_VX": f"4 {vx} 0 0 0",
-        "FSP_VY": f"4 {vy} 0 0 0",
-        "FSP_VZ": f"4 {vz} 0 0 0",
-        "FSP_VX_EQUATION": f'4 "{vx}" "0" "0" "0"',
-        "FSP_VY_EQUATION": f'4 "{vy}" "0" "0" "0"',
-        "FSP_VZ_EQUATION": f'4 "{vz}" "0" "0" "0"',
-        "FSP_TS": f"4 {temperature} {ad_temperture} {ad_temperture} 0",
-        "FSP_TS_EQUATION": f'4 "{temperature}" "{ad_temperture}" "{ad_temperture}" "0"',
-        "FSP_PS": f"4 {pressure} 0 0 0",
-        "FSP_PS_EQUATION": f'4 "{pressure}" "0" "0" "0"',
-        "FSP_MOMENTS_REFERENCE_POINT_COMPONENT_X": chord/4,
-        "FSP_MOMENTS_REFERENCE_POINT_COMPONENT_Z": chord*0.1*0.5,
-        "ICE_MACH_NUMBER": mach,
-        "ICE_REYNOLDS_NUMBER": reynolds,
-        "ICE_REF_AIR_PRESSURE": pressure / 1000.0,
-        "ICE_REF_TEMPERATURE": temperature - 273.15,
-        "ICE_REF_VELOCITY": velocity,
-        "ICE_CHARAC_LENGTH": chord,
-        "ICE_TEMPERATURE": temperature - 273.15,
-        "DRP_GUI_BC_DIAM": f'4 "{mvd}" "" "" ""',
-        "DRP_GUI_BC_LWC": f'4 "{lwc}" "" "" ""',
-        "DRP_GUI_BC_TEMP": f'4 "{temperature}" "" "" ""',
-        "DRP_GUI_BC_VX": f'4 "{vx}" "" "" ""',
-        "DRP_GUI_BC_VY": f'4 "{vy}" "" "" ""',
-        "FSP_DROPLET_INITIAL_VEL": f'4 {vx} {vy} 0 0',
-        "DRP_GUI_ANGLE_OF_ATTACK_ALPHA": aoa,
-        "FSP_ANGLE_OF_ATTACK_ALPHA": aoa,
-        "FSP_GUI_DROPLET_INITIAL_VEL_COMP_X": vx,
-        "FSP_GUI_DROPLET_INITIAL_VEL_COMP_Y": vy,
-        "PWS_REFINEMENT": refinement,
-        "FSP_DIMENSIONAL_WALL_ROUGHNESS": roughness,
-
-    })
+    cfg.update(
+        {
+            "PWS_CHORD_LENGTH": chord,
+            "PWS_TE_GAP": 0.001 / chord,
+            "PWS_TREX_FIRST_HEIGHT": first_height,
+            "PWS_POL_REYNOLDS": reynolds,
+            "PWS_PSI_REYNOLDS": reynolds,
+            "PWS_POL_MACH": mach,
+            "PWS_PSI_MACH": mach,
+            "PWS_EXTRUSION_Z_DISTANCE": chord * 0.1,
+            "MSH_GLOBMIN": 0.1 * (3e-4),
+            "MSH_PROXMIN": 1e-4,
+            "MSH_CURVMIN": 3e-4,
+            "MSH_CURVMAX": 1e-3,
+            "MSH_GLOBMAX": 0.12,
+            "MSH_Z_SPAN": chord * 0.1,
+            "MSH_MPX": chord * 1.01,
+            "MSH_MPY": 0.0,
+            "MSH_MPZ": chord * 0.1 * 0.5,
+            "MSH_FIRSTCELLHEIGHT": 0.0000045,
+            "FSP_CHARAC_LENGTH": chord,
+            "FSP_REF_AREA": 0.1 * chord**2,
+            "FSP_FREESTREAM_PRESSURE": pressure,
+            "FSP_FREESTREAM_TEMPERATURE": temperature,
+            "FSP_FREESTREAM_VELOCITY": velocity,
+            "FSP_FREESTREAM_DIAMETER": mvd,
+            "FSP_FREESTREAM_LWC": lwc,
+            "FSP_MACH_NUMBER": mach,
+            "FSP_REYNOLDS_NUMBER": reynolds,
+            "FSP_VELOCITY_X": vx,
+            "FSP_VELOCITY_Y": vy,
+            "FSP_VELOCITY_Z": vz,
+            "FSP_VX": f"4 {vx} 0 0 0",
+            "FSP_VY": f"4 {vy} 0 0 0",
+            "FSP_VZ": f"4 {vz} 0 0 0",
+            "FSP_VX_EQUATION": f'4 "{vx}" "0" "0" "0"',
+            "FSP_VY_EQUATION": f'4 "{vy}" "0" "0" "0"',
+            "FSP_VZ_EQUATION": f'4 "{vz}" "0" "0" "0"',
+            "FSP_TS": f"4 {temperature} {ad_temperture} {ad_temperture} 0",
+            "FSP_TS_EQUATION": f'4 "{temperature}" "{ad_temperture}" "{ad_temperture}" "0"',
+            "FSP_PS": f"4 {pressure} 0 0 0",
+            "FSP_PS_EQUATION": f'4 "{pressure}" "0" "0" "0"',
+            "FSP_MOMENTS_REFERENCE_POINT_COMPONENT_X": chord / 4,
+            "FSP_MOMENTS_REFERENCE_POINT_COMPONENT_Z": chord * 0.1 * 0.5,
+            "ICE_MACH_NUMBER": mach,
+            "ICE_REYNOLDS_NUMBER": reynolds,
+            "ICE_REF_AIR_PRESSURE": pressure / 1000.0,
+            "ICE_REF_TEMPERATURE": temperature - 273.15,
+            "ICE_REF_VELOCITY": velocity,
+            "ICE_CHARAC_LENGTH": chord,
+            "ICE_TEMPERATURE": temperature - 273.15,
+            "DRP_GUI_BC_DIAM": f'4 "{mvd}" "" "" ""',
+            "DRP_GUI_BC_LWC": f'4 "{lwc}" "" "" ""',
+            "DRP_GUI_BC_TEMP": f'4 "{temperature}" "" "" ""',
+            "DRP_GUI_BC_VX": f'4 "{vx}" "" "" ""',
+            "DRP_GUI_BC_VY": f'4 "{vy}" "" "" ""',
+            "FSP_DROPLET_INITIAL_VEL": f"4 {vx} {vy} 0 0",
+            "DRP_GUI_ANGLE_OF_ATTACK_ALPHA": aoa,
+            "FSP_ANGLE_OF_ATTACK_ALPHA": aoa,
+            "FSP_GUI_DROPLET_INITIAL_VEL_COMP_X": vx,
+            "FSP_GUI_DROPLET_INITIAL_VEL_COMP_Y": vy,
+            "PWS_REFINEMENT": refinement,
+            "FSP_DIMENSIONAL_WALL_ROUGHNESS": roughness,
+        }
+    )
 
     cfg["CASE_ROUGHNESS"] = roughness
     cfg["CASE_CHARACTERISTIC_LENGTH"] = chord

--- a/tests/test_first_cellheight.py
+++ b/tests/test_first_cellheight.py
@@ -1,13 +1,29 @@
 import sys
 from pathlib import Path
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import pytest
 
-from glacium.utils import first_cellheight, generate_global_defaults, global_default_config
+from glacium.physics import ambient_pressure, interpolate_kinematic_viscosity
+from glacium.utils import (first_cellheight, generate_global_defaults,
+                           global_default_config)
 
 
 def test_first_cellheight_from_case():
-    case = Path(__file__).resolve().parents[1] / "glacium" / "config" / "defaults" / "case.yaml"
-    expected = generate_global_defaults(case, global_default_config())["PWS_TREX_FIRST_HEIGHT"]
+    case = (
+        Path(__file__).resolve().parents[1]
+        / "glacium"
+        / "config"
+        / "defaults"
+        / "case.yaml"
+    )
+    expected = generate_global_defaults(case, global_default_config())[
+        "PWS_TREX_FIRST_HEIGHT"
+    ]
     assert first_cellheight(case) == pytest.approx(expected)
+
+
+def test_physics_helpers():
+    assert ambient_pressure(0.0) == pytest.approx(101325.0)
+    assert interpolate_kinematic_viscosity(300.0) == pytest.approx(1.568e-5)


### PR DESCRIPTION
## Summary
- expose `ambient_pressure` and `interpolate_kinematic_viscosity` in new package `glacium.physics`
- reuse these helpers in `first_cellheight` and `case_to_global`
- adjust tests

## Testing
- `ruff check glacium/physics/__init__.py glacium/utils/first_cellheight.py glacium/utils/case_to_global.py tests/test_first_cellheight.py`
- `mypy glacium/physics/__init__.py glacium/utils/first_cellheight.py glacium/utils/case_to_global.py tests/test_first_cellheight.py` *(fails: Library stubs not installed for "yaml" ...)*
- `pytest tests/test_first_cellheight.py -q` *(fails: ModuleNotFoundError: No module named 'pyvista')*

------
https://chatgpt.com/codex/tasks/task_e_68836f4608408327acb06c4bef139802