### PR TITLE
Add option to rerun failed jobs

### DIFF
--- a/tests/test_jobmanager_include_failed.py
+++ b/tests/test_jobmanager_include_failed.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from glacium.models.config import GlobalConfig
+from glacium.managers.path_manager import PathBuilder
+from glacium.models.project import Project
+from glacium.managers.job_manager import JobManager
+from glacium.models.job import Job, JobStatus
+
+
+def test_run_reruns_failed_jobs(tmp_path):
+    cfg = GlobalConfig(project_uid="uid", base_dir=tmp_path)
+    paths = PathBuilder(tmp_path).build()
+    paths.ensure()
+
+    project = Project("uid", tmp_path, cfg, paths, [])
+
+    executed = []
+
+    class DummyJob(Job):
+        name = "DUMMY"
+        deps = ()
+
+        def execute(self):
+            executed.append("x")
+
+    job = DummyJob(project)
+    job.status = JobStatus.FAILED
+    project.jobs = [job]
+
+    jm = JobManager(project)
+
+    jm.run()
+    assert executed == []
+    assert job.status is JobStatus.FAILED
+
+    jm.run(include_failed=True)
+    assert executed == ["x"]
+    assert job.status is JobStatus.DONE


### PR DESCRIPTION
## Summary
- allow `JobManager.run()` to optionally re-run FAILED jobs
- cover this behaviour with a new test

## Testing
- `pytest tests/test_jobmanager_include_failed.py::test_run_reruns_failed_jobs -q`
- `pytest tests/test_job_cli_numbers.py::test_job_run_by_index -q`

------
https://chatgpt.com/codex/tasks/task_e_6883702cebe883278afb618ac79edd0e