### PR TITLE
Refactor selection tokens

### DIFF
--- a/glacium/cli/info.py
+++ b/glacium/cli/info.py
@@ -11,7 +11,7 @@ from rich.table import Table
 from rich import box
 
 from glacium.managers.project_manager import ProjectManager
-from glacium.utils.current import load as load_current
+from glacium.utils.current import PROJECT_TOKEN
 
 ROOT = Path("runs")
 console = Console()
@@ -25,7 +25,7 @@ def cli_info(uid: str | None) -> None:
     pm = ProjectManager(ROOT)
 
     if uid is None:
-        uid = load_current()
+        uid = PROJECT_TOKEN.load()
         if uid is None:
             raise click.ClickException(
                 "Kein Projekt ausgewaehlt. Erst 'glacium select <Nr>' nutzen."

--- a/glacium/cli/job/add.py
+++ b/glacium/cli/job/add.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import click
 from glacium.utils.logging import log_call
 
-from glacium.utils.current import load
+from glacium.utils.current import PROJECT_TOKEN
 from glacium.managers.project_manager import ProjectManager
 from glacium.managers.config_manager import ConfigManager
 
@@ -17,7 +17,7 @@ from . import cli_job, ROOT
 @log_call
 def cli_job_add(job_name: str) -> None:
     """Fügt einen Job aus dem aktuellen Rezept hinzu."""
-    uid = load()
+    uid = PROJECT_TOKEN.load()
     if uid is None:
         raise click.ClickException(
             "Kein Projekt gewählt. Erst 'glacium select' nutzen."

--- a/glacium/cli/job/list.py
+++ b/glacium/cli/job/list.py
@@ -8,7 +8,7 @@ from glacium.utils.logging import log_call
 from rich.table import Table
 from rich import box
 
-from glacium.utils.current import load
+from glacium.utils.current import PROJECT_TOKEN
 from glacium.managers.project_manager import ProjectManager
 
 from . import cli_job, ROOT, console
@@ -19,7 +19,7 @@ from . import cli_job, ROOT, console
 @log_call
 def cli_job_list(available: bool) -> None:
     """Zeigt alle Jobs + Status des aktuellen Projekts."""
-    uid = load()
+    uid = PROJECT_TOKEN.load()
     if uid is None:
         raise click.ClickException("Kein Projekt gewählt. Erst 'glacium select' nutzen.")
 

--- a/glacium/cli/job/remove.py
+++ b/glacium/cli/job/remove.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import click
 from glacium.utils.logging import log_call
 
-from glacium.utils.current import load
+from glacium.utils.current import PROJECT_TOKEN
 from glacium.managers.project_manager import ProjectManager
 from glacium.managers.config_manager import ConfigManager
 
@@ -17,7 +17,7 @@ from . import cli_job, ROOT
 @log_call
 def cli_job_remove(job_name: str) -> None:
     """Entfernt einen Job aus dem aktuellen Projekt."""
-    uid = load()
+    uid = PROJECT_TOKEN.load()
     if uid is None:
         raise click.ClickException(
             "Kein Projekt gewählt. Erst 'glacium select' nutzen."

--- a/glacium/cli/job/reset.py
+++ b/glacium/cli/job/reset.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import click
 from glacium.utils.logging import log_call
 
-from glacium.utils.current import load
+from glacium.utils.current import PROJECT_TOKEN
 from glacium.managers.project_manager import ProjectManager
 from glacium.core.base import JobStatus
 
@@ -17,7 +17,7 @@ from . import cli_job, ROOT
 @log_call
 def cli_job_reset(job_name: str) -> None:
     """Setzt JOB auf PENDING (falls nicht RUNNING)."""
-    uid = load()
+    uid = PROJECT_TOKEN.load()
     if uid is None:
         raise click.ClickException("Kein Projekt gewählt. Erst 'glacium select' nutzen.")
 

--- a/glacium/cli/job/run.py
+++ b/glacium/cli/job/run.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import click
 from glacium.utils.logging import log_call
 
-from glacium.utils.current import load
+from glacium.utils.current import PROJECT_TOKEN
 from glacium.managers.project_manager import ProjectManager
 from glacium.core.base import JobStatus
 
@@ -17,7 +17,7 @@ from . import cli_job, ROOT
 @log_call
 def cli_job_run(job_name: str) -> None:
     """Führe JOB aus dem aktuellen Projekt aus."""
-    uid = load()
+    uid = PROJECT_TOKEN.load()
     if uid is None:
         raise click.ClickException("Kein Projekt gewählt. Erst 'glacium select' nutzen.")
 

--- a/glacium/cli/job/select.py
+++ b/glacium/cli/job/select.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import click
 from glacium.utils.logging import log_call
 
-from glacium.utils.current import load
+from glacium.utils.current import PROJECT_TOKEN
 from glacium.managers.project_manager import ProjectManager
 
 from . import cli_job, ROOT
@@ -16,7 +16,7 @@ from . import cli_job, ROOT
 @log_call
 def cli_job_select(job: str) -> None:
     """Wähle JOB innerhalb des aktuellen Projekts aus."""
-    uid = load()
+    uid = PROJECT_TOKEN.load()
     if uid is None:
         raise click.ClickException("Kein Projekt gewählt. Erst 'glacium select' nutzen.")
 
@@ -36,7 +36,7 @@ def cli_job_select(job: str) -> None:
         if jname not in proj.job_manager._jobs:
             raise click.ClickException(f"Job '{job}' existiert nicht.")
 
-    from glacium.utils.current_job import save as save_job
+    from glacium.utils.current_job import JOB_TOKEN
 
-    save_job(jname)
+    JOB_TOKEN.save(jname)
     click.echo(jname)

--- a/glacium/cli/list.py
+++ b/glacium/cli/list.py
@@ -9,7 +9,7 @@ from rich.table import Table
 from rich import box
 
 from glacium.managers.project_manager import ProjectManager
-from glacium.utils.current import load as load_current
+from glacium.utils.current import PROJECT_TOKEN
 from glacium.models.job import UnavailableJob
 
 console = Console()
@@ -25,7 +25,7 @@ def cli_list(uid: str | None):
     pm = ProjectManager(Path("runs"))
 
     if uid is None:
-        uid = load_current()
+        uid = PROJECT_TOKEN.load()
         if uid is None:
             raise click.ClickException(
                 "No project selected. Use 'glacium select <nr>' first."

--- a/glacium/cli/remove.py
+++ b/glacium/cli/remove.py
@@ -8,7 +8,7 @@ from glacium.utils.logging import log_call
 from rich.console import Console
 
 from glacium.utils.ProjectIndex import list_projects
-from glacium.utils.current import load as load_current
+from glacium.utils.current import PROJECT_TOKEN
 
 ROOT = Path("runs")
 console = Console()
@@ -30,7 +30,7 @@ def cli_remove(project: str | None, remove_all: bool):
         uids = [p.name for p in ROOT.iterdir() if p.is_dir()]
     else:
         if project is None:
-            uid = load_current()
+            uid = PROJECT_TOKEN.load()
             if uid is None:
                 raise click.ClickException(
                     "Kein Projekt angegeben und kein Projekt ausgewählt.\n"

--- a/glacium/cli/select.py
+++ b/glacium/cli/select.py
@@ -5,7 +5,7 @@ from glacium.utils.logging import log_call
 from pathlib import Path
 from rich.console import Console
 from glacium.utils.ProjectIndex import list_projects
-from glacium.utils.current import save
+from glacium.utils.current import PROJECT_TOKEN
 
 console = Console()
 
@@ -29,6 +29,6 @@ def cli_select(project: str):
     if not (root / uid).exists():
         raise click.ClickException(f"Projekt '{uid}' nicht gefunden.")
 
-    save(uid)
+    PROJECT_TOKEN.save(uid)
     console.print(f"[green]Projekt ausgewählt:[/] {uid}")
 

--- a/glacium/cli/sync.py
+++ b/glacium/cli/sync.py
@@ -4,7 +4,7 @@ import click, yaml
 from glacium.utils.logging import log_call
 from pathlib import Path
 from glacium.managers.project_manager import ProjectManager
-from glacium.utils.current import load as load_current
+from glacium.utils.current import PROJECT_TOKEN
 from glacium.utils.ProjectIndex import list_projects
 
 ROOT = Path("runs")
@@ -29,7 +29,7 @@ def cli_sync(uid: str | None, sync_all: bool):
     elif uid:
         uids = [uid]
     else:
-        current = load_current()
+        current = PROJECT_TOKEN.load()
         if current is None:
             raise click.ClickException(
                 "Keine UID angegeben und kein Projekt ausgewählt.\n"

--- a/glacium/cli/update.py
+++ b/glacium/cli/update.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import click
 
 from glacium.utils.logging import log_call
-from glacium.utils.current import load as load_current
+from glacium.utils.current import PROJECT_TOKEN
 from glacium.managers.project_manager import ProjectManager
 from glacium.services import ProjectService
 
@@ -32,7 +32,7 @@ def cli_update(uid: str | None, case_file: Path | None) -> None:
     pm = ProjectManager(ROOT)
 
     if uid is None:
-        uid = load_current()
+        uid = PROJECT_TOKEN.load()
         if uid is None:
             raise click.ClickException(
                 "Keine UID angegeben und kein Projekt ausgewählt.\n"

--- a/glacium/services/run_service.py
+++ b/glacium/services/run_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from glacium.utils.current import load as load_current
+from glacium.utils.current import PROJECT_TOKEN
 from glacium.managers.project_manager import ProjectManager
 from glacium.utils.logging import log
 
@@ -28,7 +28,7 @@ class RunService:
                     log.error(f"{uid}: {err}")
             return executed
 
-        uid = load_current()
+        uid = PROJECT_TOKEN.load()
         if uid is None:
             raise RuntimeError("Kein Projekt ausgewaehlt")
 

--- a/glacium/utils/__init__.py
+++ b/glacium/utils/__init__.py
@@ -4,7 +4,11 @@ from importlib import import_module
 import sys
 
 from .JobIndex import list_jobs
-from .current_job import save as save_current_job, load as load_current_job
+from .current_job import JOB_TOKEN
+from .current import PROJECT_TOKEN
+
+save_current_job = JOB_TOKEN.save
+load_current_job = JOB_TOKEN.load
 from .default_paths import global_default_config, default_case_file
 from .case_to_global import generate_global_defaults
 from .first_cellheight import from_case as first_cellheight

--- a/glacium/utils/current.py
+++ b/glacium/utils/current.py
@@ -1,19 +1,9 @@
-"""Utility to persist the currently selected project UID."""
+from __future__ import annotations
+
+"""Current project selection token."""
 
 from pathlib import Path
 
-_TOKEN = Path.home() / ".glacium_current"
+from .selection_store import SelectionStore
 
-
-def save(uid: str) -> None:
-    """Write ``uid`` to the token file."""
-
-    _TOKEN.write_text(uid, encoding="utf-8")
-
-
-def load() -> str | None:
-    """Return the stored UID or ``None`` if no project is selected."""
-
-    return _TOKEN.read_text().strip() if _TOKEN.exists() else None
-
-
+PROJECT_TOKEN = SelectionStore(Path.home() / ".glacium_current")

--- a/glacium/utils/current_job.py
+++ b/glacium/utils/current_job.py
@@ -1,11 +1,9 @@
+from __future__ import annotations
+
+"""Current job selection token."""
+
 from pathlib import Path
 
-_TOKEN = Path.home() / ".glacium_current_job"
+from .selection_store import SelectionStore
 
-
-def save(name: str) -> None:
-    _TOKEN.write_text(name, encoding="utf-8")
-
-
-def load() -> str | None:
-    return _TOKEN.read_text().strip() if _TOKEN.exists() else None
+JOB_TOKEN = SelectionStore(Path.home() / ".glacium_current_job")

--- a/glacium/utils/selection_store.py
+++ b/glacium/utils/selection_store.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class SelectionStore:
+    """Simple wrapper to persist and load a selection token."""
+
+    path: Path
+
+    def save(self, value: str) -> None:
+        """Write ``value`` to :attr:`path`."""
+        self.path.write_text(value, encoding="utf-8")
+
+    def load(self) -> str | None:
+        """Return the stored value or ``None`` if :attr:`path` does not exist."""
+        return self.path.read_text().strip() if self.path.exists() else None

--- a/tests/test_job_cli_numbers.py
+++ b/tests/test_job_cli_numbers.py
@@ -27,9 +27,9 @@ def test_job_select_and_remove_by_index(tmp_path):
     res = runner.invoke(cli, ["job", "select", "1"], env=env)
     assert res.exit_code == 0
     first = res.output.strip()
-    from glacium.utils.current_job import load as load_job
+    from glacium.utils.current_job import JOB_TOKEN
 
-    assert load_job() == first
+    assert JOB_TOKEN.load() == first
 
     res = runner.invoke(cli, ["job", "remove", "1"], env=env)
     assert res.exit_code == 0


### PR DESCRIPTION
## Summary
- introduce `SelectionStore` to persist simple selection tokens
- replace current selection util functions with `SelectionStore` instances
- update CLI commands and tests to use `PROJECT_TOKEN` and `JOB_TOKEN`

## Testing
- `pytest -k job_cli_numbers -q` *(fails: ModuleNotFoundError: No module named 'verboselogs')*

------
https://chatgpt.com/codex/tasks/task_e_688372add2548327b1ca64fe442bf3f3