### PR TITLE
Update run-all behavior to retry failed jobs

### DIFF
--- a/glacium/cli/run.py
+++ b/glacium/cli/run.py
@@ -24,7 +24,7 @@ def cli_run(jobs: tuple[str], run_all: bool):
         for uid in pm.list_uids():
             click.echo(f"[{uid}]")
             try:
-                pm.load(uid).job_manager.run(jobs or None)
+                pm.load(uid).job_manager.run(jobs or None, include_failed=True)
             except FileNotFoundError:
                 click.echo(f"[red]Projekt '{uid}' nicht gefunden.[/red]")
             except Exception as err:  # noqa: BLE001

--- a/glacium/jobs/analysis_jobs.py
+++ b/glacium/jobs/analysis_jobs.py
@@ -176,7 +176,7 @@ class FensapAnalysisJob(Job):
 
     def execute(self) -> None:  # noqa: D401
         project_root = self.project.root
-        dat_file = project_root / "run_FENSAP" / "soln.dat"
+        dat_file = project_root / "run_FENSAP" / "soln.fensap.dat"
         out_dir = project_root / "analysis" / "FENSAP"
 
         engine = PyEngine(fensap_analysis)

--- a/tests/test_run_all.py
+++ b/tests/test_run_all.py
@@ -53,7 +53,7 @@ def test_run_all_continues_on_error(tmp_path, monkeypatch):
 
         called = {}
 
-        def patched_run(self, jobs=None):
+        def patched_run(self, jobs=None, include_failed=False):
             if self.project.uid == p1.uid:
                 raise RuntimeError("boom")
             if self.project.uid == p2.uid:


### PR DESCRIPTION
## Summary
- rerun failed jobs when invoking `glacium run --all`
- fix fensap analysis dat filename
- update `test_run_all` monkeypatch for new `include_failed` param

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688372bac5548327ba851cf8fb776887