### PR TITLE
Document run --all behaviour

### DIFF
--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -104,7 +104,8 @@ all pending jobs in the correct dependency order with:
 
    glacium run
 
-To run pending jobs for every project under ``runs`` in the current working directory use ``--all``:
+Pass ``--all`` to process every project below ``runs``.  Jobs with the
+status ``PENDING`` or ``FAILED`` are executed in dependency order:
 
 .. code-block:: bash
 

--- a/glacium/cli/run.py
+++ b/glacium/cli/run.py
@@ -10,13 +10,18 @@ ROOT = Path("runs")
 
 @click.command("run")
 @click.argument("jobs", nargs=-1)
-@click.option("--all", "run_all", is_flag=True,
-              help="Alle Projekte nacheinander ausführen")
+@click.option(
+    "--all",
+    "run_all",
+    is_flag=True,
+    help="Alle Projekte nacheinander ausführen; wiederholt fehlgeschlagene Jobs",
+)
 @log_call
 def cli_run(jobs: tuple[str], run_all: bool):
     """Führt die Jobs des aktuellen Projekts aus.
     JOBS sind optionale Jobnamen, die ausgeführt werden sollen.
-    Mit ``--all`` werden alle Projekte verarbeitet."""
+    Mit ``--all`` werden alle Projekte verarbeitet und Jobs im Status
+    ``PENDING`` oder ``FAILED`` ausgeführt."""
 
     pm = ProjectManager(ROOT)
 


### PR DESCRIPTION
## Summary
- explain that `glacium run --all` will run `PENDING` and `FAILED` jobs
- mention retry behaviour in CLI help text

## Testing
- `pytest tests/test_run_all.py::test_run_all_retries_failed_jobs -q`


------
https://chatgpt.com/codex/tasks/task_e_68837bdf14188327994e7c4c18370a2f