### PR TITLE
Introduce parameter converters

### DIFF
--- a/glacium/utils/par2j2.py
+++ b/glacium/utils/par2j2.py
@@ -10,36 +10,17 @@ Usage:
 import sys
 from pathlib import Path
 
-def convert_line(line: str) -> str:
-    stripped = line.lstrip()
+from .par_converter import JinjaParConverter
 
-    # Pass through blank lines and pure comments
-    if not stripped or stripped.startswith("#"):
-        return line
-
-    # Keep leading whitespace
-    prefix_len = len(line) - len(stripped)
-    prefix = line[:prefix_len]
-
-    # Separate inline comment (if any)
-    parts_before_comment = stripped.split("#", 1)
-    main_part = parts_before_comment[0].rstrip()
-    inline_comment = (" #" + parts_before_comment[1]) if len(parts_before_comment) == 2 else ""
-
-    # KEY is first token
-    key = main_part.split(None, 1)[0]
-
-    # Emit Jinja2 placeholder with tight braces: {{ KEY }}
-    return f"{prefix}{key} {{{{ {key} }}}}{inline_comment}\n"
+converter = JinjaParConverter()
 
 def main():
     if len(sys.argv) < 2:
         print("Usage: python param2j2.py <input-file>", file=sys.stderr)
         sys.exit(1)
 
-    text = Path(sys.argv[1]).read_text(encoding="utf-8", errors="ignore")
-    for line in text.splitlines(keepends=True):
-        sys.stdout.write(convert_line(line))
+    path = Path(sys.argv[1])
+    sys.stdout.write(converter.convert_file(path))
 
 if __name__ == "__main__":
     main()

--- a/glacium/utils/par2yaml.py
+++ b/glacium/utils/par2yaml.py
@@ -9,25 +9,10 @@ Usage:
 import sys
 from pathlib import Path
 
+from .par_converter import YamlParConverter
 
-def convert_line(line: str) -> str:
-    stripped = line.lstrip()
 
-    # Pass through blank lines and pure comment lines unchanged
-    if not stripped or stripped.startswith("#"):
-        return line
-
-    # -------- parameter line --------------------------------------------------
-    # KEY is everything up to the first whitespace; the rest is the value
-    key_end = stripped.find(" ")
-    if key_end == -1:                         # defensive fallback
-        return stripped + "\n"
-
-    key = stripped[:key_end]
-    value = stripped[key_end + 1 :].lstrip()  # keep any inline comment
-
-    # Emit key flush‑left (no leading prefix) ⇒ valid top‑level YAML
-    return f"{key}: {value}\n"
+converter = YamlParConverter()
 
 
 def main():
@@ -35,9 +20,8 @@ def main():
         print("Usage: python param2yaml.py <input-file>", file=sys.stderr)
         sys.exit(1)
 
-    text = Path(sys.argv[1]).read_text(encoding="utf-8", errors="ignore")
-    for line in text.splitlines(keepends=True):
-        sys.stdout.write(convert_line(line))
+    path = Path(sys.argv[1])
+    sys.stdout.write(converter.convert_file(path))
 
 
 if __name__ == "__main__":

--- a/glacium/utils/par_converter.py
+++ b/glacium/utils/par_converter.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+"""Utilities for converting FENSAP ``.par`` files."""
+
+from pathlib import Path
+
+__all__ = ["ParConverter", "YamlParConverter", "JinjaParConverter"]
+
+
+class ParConverter:
+    """Base class for ``.par`` file converters."""
+
+    def convert_line(self, line: str) -> str:  # pragma: no cover - overridden
+        """Convert a single line of text.
+
+        Subclasses override :meth:`format_line` to control the output format.
+        """
+        newline = "\n" if line.endswith("\n") else ""
+        raw = line[:-1] if newline else line
+
+        stripped = raw.lstrip()
+        if not stripped or stripped.startswith("#"):
+            return raw + newline
+
+        prefix_len = len(raw) - len(stripped)
+        prefix = raw[:prefix_len]
+
+        parts = stripped.split(None, 1)
+        key = parts[0]
+        rest = parts[1] if len(parts) == 2 else ""
+
+        if rest == "":
+            return self.on_missing_value(prefix, key) + newline
+
+        return self.format_line(prefix, key, rest) + newline
+
+    def on_missing_value(self, prefix: str, key: str) -> str:
+        """Handle lines that contain only a key without a value."""
+        return self.format_line(prefix, key, "")
+
+    def format_line(self, prefix: str, key: str, rest: str) -> str:
+        """Return the formatted output for ``key`` and ``rest``."""
+        raise NotImplementedError
+
+    def convert_file(self, file: Path | str) -> str:
+        """Return the converted content of *file*."""
+        path = Path(file)
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        return "".join(self.convert_line(l) for l in text.splitlines(keepends=True))
+
+
+class YamlParConverter(ParConverter):
+    """Converter emitting YAML key/value pairs."""
+
+    def format_line(self, prefix: str, key: str, rest: str) -> str:  # noqa: ARG002
+        value = rest.lstrip()
+        return f"{key}: {value}"
+
+    def on_missing_value(self, prefix: str, key: str) -> str:  # noqa: ARG002
+        return key
+
+
+class JinjaParConverter(ParConverter):
+    """Converter emitting Jinja2 placeholders."""
+
+    def format_line(self, prefix: str, key: str, rest: str) -> str:
+        part = rest.lstrip()
+        inline_comment = ""
+        if "#" in part:
+            inline_comment = " #" + part.split("#", 1)[1]
+        return f"{prefix}{key} {{{{ {key} }}}}{inline_comment}"

--- a/tests/test_par_converter.py
+++ b/tests/test_par_converter.py
@@ -1,0 +1,37 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location(
+    "par_converter", ROOT / "glacium" / "utils" / "par_converter.py"
+)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+YamlParConverter = module.YamlParConverter
+JinjaParConverter = module.JinjaParConverter
+
+
+def test_yaml_converter_lines():
+    conv = YamlParConverter()
+    assert conv.convert_line("KEY 1\n") == "KEY: 1\n"
+    assert conv.convert_line("  KEY    VAL  # c\n") == "KEY: VAL  # c\n"
+    assert conv.convert_line("# comment\n") == "# comment\n"
+    assert conv.convert_line("\n") == "\n"
+    assert conv.convert_line("KEY_ONLY\n") == "KEY_ONLY\n"
+
+
+def test_jinja_converter_lines():
+    conv = JinjaParConverter()
+    assert conv.convert_line("  KEY    VAL  # c\n") == "  KEY {{ KEY }} # c\n"
+    assert conv.convert_line("KEY\n") == "KEY {{ KEY }}\n"
+
+
+def test_convert_file(tmp_path):
+    src = tmp_path / "in.par"
+    src.write_text("A 1\nB 2\n")
+    conv = YamlParConverter()
+    text = conv.convert_file(src)
+    assert text == "A: 1\nB: 2\n"


### PR DESCRIPTION
## Summary
- factor out `.par` file conversion logic into `ParConverter`
- add YAML and Jinja2 converter implementations
- use the converters in `par2yaml.py` and `par2j2.py`
- test converters

## Testing
- `pytest tests/test_par_converter.py -q`
- `pytest -q` *(fails: 55 failed, 90 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68837bf1bd988327999001f75bbe6e59