### PR TITLE
Introduce ConvergenceAnalyzer class

### DIFF
--- a/glacium/analysis/__init__.py
+++ b/glacium/analysis/__init__.py
@@ -1,0 +1,3 @@
+from .convergence import ConvergenceAnalyzer
+
+__all__ = ["ConvergenceAnalyzer"]

--- a/glacium/analysis/convergence.py
+++ b/glacium/analysis/convergence.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Sequence
+import csv
+
+import numpy as np
+import matplotlib.pyplot as plt
+import scienceplots
+
+from glacium.utils.solver_time import parse_execution_time, parse_time
+
+
+class ConvergenceAnalyzer:
+    """Helper class for analysing solver convergence history files."""
+
+    # IO helpers -----------------------------------------------------
+    def parse_headers(self, path: Path) -> list[str]:
+        """Return column labels from the header section of ``path``."""
+        labels: list[str] = []
+        for line in path.read_text().splitlines():
+            if not line.lstrip().startswith("#"):
+                break
+            if line.lstrip().startswith("#"):
+                parts = line.split(maxsplit=2)
+                if len(parts) >= 2:
+                    labels.append(parts[-1].strip())
+        return labels
+
+    def read_history(self, file: str | Path, nrows: int | None = None) -> np.ndarray:
+        """Return the last ``nrows`` rows from ``file``."""
+        path = Path(file)
+        data = [
+            [float(val.replace("D", "E")) for val in line.split()]
+            for line in path.read_text().splitlines()
+            if not line.lstrip().startswith("#") and line.strip()
+        ]
+        arr = np.array(data, dtype=float)
+        if nrows is not None:
+            arr = arr[-nrows:]
+        return arr
+
+    def read_history_with_labels(
+        self, file: str | Path, nrows: int | None = None
+    ) -> tuple[list[str], np.ndarray]:
+        """Return labels and data from ``file``."""
+        path = Path(file)
+        labels = self.parse_headers(path)
+        data = [
+            [float(val.replace("D", "E")) for val in line.split()]
+            for line in path.read_text().splitlines()
+            if not line.lstrip().startswith("#") and line.strip()
+        ]
+        arr = np.array(data, dtype=float)
+        if nrows is not None:
+            arr = arr[-nrows:]
+        return labels, arr
+
+    # Statistics -----------------------------------------------------
+    def stats_last_n(self, data: np.ndarray, n: int = 15) -> tuple[np.ndarray, np.ndarray]:
+        """Return column-wise mean and std of the last ``n`` rows in ``data``."""
+        tail = data[-n:] if n else data
+        return np.mean(tail, axis=0), np.std(tail, axis=0)
+
+    def cl_cd_stats(self, directory: Path, n: int = 15) -> np.ndarray:
+        """Return mean lift and drag coefficients from ``directory``."""
+        results: list[tuple[int, float, float]] = []
+        for file in sorted(Path(directory).glob("converg.fensap.*")):
+            labels = self.parse_headers(file)
+            try:
+                cl_idx = labels.index("lift coefficient")
+                cd_idx = labels.index("drag coefficient")
+            except ValueError:
+                continue
+            data = self.read_history(file, n)
+            tail = data[-n:] if n else data
+            cl_mean = float(np.mean(tail[:, cl_idx]))
+            cd_mean = float(np.mean(tail[:, cd_idx]))
+            try:
+                idx = int(file.name.split(".")[-1])
+            except ValueError:
+                idx = len(results)
+            results.append((idx, cl_mean, cd_mean))
+        return np.array(results, dtype=float)
+
+    def execution_time(self, file: Path) -> float:
+        """Return solver run time in seconds for ``file``."""
+        value = parse_execution_time(file)
+        if value is None:
+            return 0.0
+        return parse_time(value)
+
+    def cl_cd_summary(self, directory: Path, n: int = 15) -> tuple[float, float, float, float]:
+        """Return mean and std dev for lift and drag coefficients."""
+        data = self.cl_cd_stats(directory, n)
+        if data.size:
+            cl_mean = float(data[:, 1].mean())
+            cl_std = float(data[:, 1].std())
+            cd_mean = float(data[:, 2].mean())
+            cd_std = float(data[:, 2].std())
+            return cl_mean, cl_std, cd_mean, cd_std
+        return float("nan"), float("nan"), float("nan"), float("nan")
+
+    def aggregate_report(
+        self, directory: str | Path, n: int = 15
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Aggregate stats for all ``converg.fensap.*`` files in ``directory``."""
+        root = Path(directory)
+        means = []
+        stds = []
+        indices = []
+        for file in sorted(root.glob("converg.fensap.*")):
+            data = self.read_history(file, n)
+            mean, std = self.stats_last_n(data, n)
+            means.append(mean)
+            stds.append(std)
+            try:
+                indices.append(int(file.name.split(".")[-1]))
+            except ValueError:
+                indices.append(len(indices))
+        return (
+            np.array(indices, dtype=int),
+            np.vstack(means) if means else np.empty((0, 0)),
+            np.vstack(stds) if stds else np.empty((0, 0)),
+        )
+
+    def project_cl_cd_stats(self, report_dir: Path, n: int = 15) -> tuple[float, float, float, float]:
+        """Return overall mean and std deviation of lift/drag coefficients."""
+        first = next(iter(sorted(Path(report_dir).glob("converg.fensap.*"))), None)
+        if first is None:
+            return float("nan"), float("nan"), float("nan"), float("nan")
+        labels = self.parse_headers(first)
+        try:
+            cl_idx = labels.index("lift coefficient")
+            cd_idx = labels.index("drag coefficient")
+        except ValueError:
+            return float("nan"), float("nan"), float("nan"), float("nan")
+        _, means, stds = self.aggregate_report(report_dir, n)
+        if not means.size:
+            return float("nan"), float("nan"), float("nan"), float("nan")
+        cl_mean = float(np.mean(means[:, cl_idx]))
+        cl_std = float(np.mean(stds[:, cl_idx]))
+        cd_mean = float(np.mean(means[:, cd_idx]))
+        cd_std = float(np.mean(stds[:, cd_idx]))
+        return cl_mean, cl_std, cd_mean, cd_std
+
+    # Plotting -------------------------------------------------------
+    def plot_stats(
+        self,
+        indices: Iterable[int],
+        means: np.ndarray,
+        stds: np.ndarray,
+        out_dir: str | Path,
+        labels: Iterable[str] | None = None,
+    ) -> None:
+        """Write plots visualising ``means`` and ``stds``."""
+        plt.style.use(["science", "ieee"])
+        plt.rcParams["text.usetex"] = False
+        out = Path(out_dir)
+        fig_dir = out / "figures"
+        fig_dir.mkdir(parents=True, exist_ok=True)
+        ind = np.array(list(indices))
+        lbls = list(labels or [])
+        for col in range(means.shape[1]):
+            ylabel = lbls[col] if col < len(lbls) else f"column {col}"
+            plt.figure()
+            plt.errorbar(ind, means[:, col], yerr=stds[:, col], fmt="o-", capsize=3)
+            plt.xlabel("multishot index")
+            plt.ylabel(ylabel)
+            plt.grid(True)
+            plt.tight_layout()
+            plt.savefig(fig_dir / f"column_{col:02d}.png")
+            plt.close()
+
+    # High level helpers --------------------------------------------
+    def analysis(self, cwd: Path, args: Sequence[str | Path]) -> None:
+        """Aggregate convergence data and create plots."""
+        if len(args) < 2:
+            raise ValueError("analysis requires input and output directory")
+        report_dir = Path(args[0])
+        out_dir = Path(args[1])
+        idx, means, stds = self.aggregate_report(report_dir)
+        first = next(iter(sorted(report_dir.glob("converg.fensap.*"))), None)
+        labels = self.parse_headers(first) if first else []
+        if means.size:
+            self.plot_stats(idx, means, stds, out_dir, labels)
+        clcd = self.cl_cd_stats(report_dir)
+        if clcd.size:
+            out_dir.mkdir(parents=True, exist_ok=True)
+            fig_dir = out_dir / "figures"
+            fig_dir.mkdir(parents=True, exist_ok=True)
+            np.savetxt(
+                out_dir / "cl_cd_stats.csv",
+                clcd,
+                delimiter=",",
+                header="index,CL,CD",
+                comments="",
+            )
+            plt.figure()
+            plt.plot(clcd[:, 0], clcd[:, 1], marker=None)
+            plt.xlabel("multishot index")
+            plt.ylabel("CL")
+            plt.grid(True)
+            plt.tight_layout()
+            plt.savefig(fig_dir / "cl.png")
+            plt.close()
+            plt.figure()
+            plt.plot(clcd[:, 0], clcd[:, 2], marker=None)
+            plt.xlabel("multishot index")
+            plt.ylabel("CD")
+            plt.grid(True)
+            plt.tight_layout()
+            plt.savefig(fig_dir / "cd.png")
+            plt.close()
+            plt.figure()
+            plt.plot(clcd[:, 0], clcd[:, 1], label="CL", marker=None)
+            plt.plot(clcd[:, 0], clcd[:, 2], label="CD", marker=None)
+            plt.xlabel("multishot index")
+            plt.ylabel("coefficient")
+            plt.grid(True)
+            plt.legend()
+            plt.tight_layout()
+            plt.savefig(fig_dir / "cl_cd.png")
+            plt.close()
+
+    def analysis_file(self, cwd: Path, args: Sequence[str | Path]) -> None:
+        """Analyse a single convergence file and generate plots."""
+        if len(args) < 2:
+            raise ValueError("analysis_file requires input file and output directory")
+        file = Path(args[0])
+        out_dir = Path(args[1])
+        labels, data = self.read_history_with_labels(file)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        fig_dir = out_dir / "figures"
+        fig_dir.mkdir(parents=True, exist_ok=True)
+        iterations = np.arange(1, data.shape[0] + 1)
+        for col in range(data.shape[1]):
+            plt.figure()
+            plt.plot(iterations, data[:, col], marker=None)
+            plt.xlabel("iteration")
+            ylabel = labels[col] if col < len(labels) else f"column {col}"
+            plt.ylabel(ylabel)
+            plt.grid(True)
+            plt.tight_layout()
+            plt.savefig(fig_dir / f"column_{col:02d}.png")
+            plt.close()
+        mean, _ = self.stats_last_n(data, 15)
+        variance = np.var(data[-15:], axis=0)
+        with (out_dir / "stats.csv").open("w", newline="") as fh:
+            writer = csv.writer(fh)
+            writer.writerow(["label", "mean", "variance"])
+            for col in range(data.shape[1]):
+                label = labels[col] if col < len(labels) else f"column {col}"
+                writer.writerow([label, mean[col], variance[col]])
+        try:
+            cl_idx = labels.index("lift coefficient")
+            cd_idx = labels.index("drag coefficient")
+        except ValueError:
+            return
+        clcd = np.column_stack((iterations, data[:, cl_idx], data[:, cd_idx]))
+        np.savetxt(
+            out_dir / "cl_cd_stats.csv",
+            clcd,
+            delimiter=",",
+            header="index,CL,CD",
+            comments="",
+        )
+        plt.figure()
+        plt.plot(iterations, data[:, cl_idx], marker=None)
+        plt.xlabel("iteration")
+        plt.ylabel("CL")
+        plt.grid(True)
+        plt.tight_layout()
+        plt.savefig(fig_dir / "cl.png")
+        plt.close()
+        plt.figure()
+        plt.plot(iterations, data[:, cd_idx], marker=None)
+        plt.xlabel("iteration")
+        plt.ylabel("CD")
+        plt.grid(True)
+        plt.tight_layout()
+        plt.savefig(fig_dir / "cd.png")
+        plt.close()
+        plt.figure()
+        plt.plot(iterations, data[:, cl_idx], label="CL", marker=None)
+        plt.plot(iterations, data[:, cd_idx], label="CD", marker=None)
+        plt.xlabel("iteration")
+        plt.ylabel("coefficient")
+        plt.grid(True)
+        plt.legend()
+        plt.tight_layout()
+        plt.savefig(fig_dir / "cl_cd.png")
+        plt.close()

--- a/glacium/jobs/analysis/convergence_stats.py
+++ b/glacium/jobs/analysis/convergence_stats.py
@@ -5,8 +5,10 @@ from typing import Sequence
 
 from glacium.core.base import PythonJobBase
 from glacium.engines.py_engine import PyEngine
-from glacium.utils.convergence import analysis, analysis_file
+from glacium.analysis import ConvergenceAnalyzer
 from glacium.utils.report_converg_fensap import build_report
+
+_analyzer = ConvergenceAnalyzer()
 
 
 class ConvergenceStatsJob(PythonJobBase):
@@ -15,7 +17,7 @@ class ConvergenceStatsJob(PythonJobBase):
     name = "CONVERGENCE_STATS"
     deps = ("MULTISHOT_RUN",)
 
-    fn = staticmethod(analysis)
+    fn = staticmethod(_analyzer.analysis)
 
     def args(self) -> Sequence[str | Path]:
         project_root = self.project.root
@@ -31,5 +33,5 @@ class ConvergenceStatsJob(PythonJobBase):
         if self.project.config.get("CONVERGENCE_PDF"):
             files = sorted(report_dir.glob("converg.fensap.*"))
             if files:
-                PyEngine(analysis_file).run([files[-1], out_dir], cwd=self.project.root)
+                PyEngine(_analyzer.analysis_file).run([files[-1], out_dir], cwd=self.project.root)
             build_report(out_dir)

--- a/glacium/jobs/analysis/drop3d_convergence_stats.py
+++ b/glacium/jobs/analysis/drop3d_convergence_stats.py
@@ -4,8 +4,10 @@ from pathlib import Path
 from typing import Sequence
 
 from glacium.core.base import PythonJobBase
-from glacium.utils.convergence import analysis_file
+from glacium.analysis import ConvergenceAnalyzer
 from glacium.utils.report_converg_fensap import build_report
+
+_analyzer = ConvergenceAnalyzer()
 
 
 class Drop3dConvergenceStatsJob(PythonJobBase):
@@ -14,7 +16,7 @@ class Drop3dConvergenceStatsJob(PythonJobBase):
     name = "DROP3D_CONVERGENCE_STATS"
     deps = ("DROP3D_RUN",)
 
-    fn = staticmethod(analysis_file)
+    fn = staticmethod(_analyzer.analysis_file)
 
     def args(self) -> Sequence[str | Path]:
         project_root = self.project.root

--- a/glacium/jobs/analysis/fensap_convergence_stats.py
+++ b/glacium/jobs/analysis/fensap_convergence_stats.py
@@ -4,8 +4,10 @@ from pathlib import Path
 from typing import Sequence
 
 from glacium.core.base import PythonJobBase
-from glacium.utils.convergence import analysis_file
+from glacium.analysis import ConvergenceAnalyzer
 from glacium.utils.report_converg_fensap import build_report
+
+_analyzer = ConvergenceAnalyzer()
 
 
 class FensapConvergenceStatsJob(PythonJobBase):
@@ -14,7 +16,7 @@ class FensapConvergenceStatsJob(PythonJobBase):
     name = "FENSAP_CONVERGENCE_STATS"
     deps = ("FENSAP_RUN",)
 
-    fn = staticmethod(analysis_file)
+    fn = staticmethod(_analyzer.analysis_file)
 
     def args(self) -> Sequence[str | Path]:
         project_root = self.project.root

--- a/glacium/jobs/analysis/ice3d_convergence_stats.py
+++ b/glacium/jobs/analysis/ice3d_convergence_stats.py
@@ -4,8 +4,10 @@ from pathlib import Path
 from typing import Sequence
 
 from glacium.core.base import PythonJobBase
-from glacium.utils.convergence import analysis_file
+from glacium.analysis import ConvergenceAnalyzer
 from glacium.utils.report_converg_fensap import build_report
+
+_analyzer = ConvergenceAnalyzer()
 
 
 class Ice3dConvergenceStatsJob(PythonJobBase):
@@ -14,7 +16,7 @@ class Ice3dConvergenceStatsJob(PythonJobBase):
     name = "ICE3D_CONVERGENCE_STATS"
     deps = ("ICE3D_RUN",)
 
-    fn = staticmethod(analysis_file)
+    fn = staticmethod(_analyzer.analysis_file)
 
     def args(self) -> Sequence[str | Path]:
         project_root = self.project.root

--- a/glacium/utils/convergence/__init__.py
+++ b/glacium/utils/convergence/__init__.py
@@ -5,16 +5,20 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Sequence
 
-from .io import parse_headers, read_history, read_history_with_labels
-from .stats import (
-    stats_last_n,
-    cl_cd_stats,
-    execution_time,
-    cl_cd_summary,
-    project_cl_cd_stats,
-    aggregate_report,
-)
-from .plot import plot_stats
+from glacium.analysis import ConvergenceAnalyzer
+
+_analyzer = ConvergenceAnalyzer()
+
+parse_headers = _analyzer.parse_headers
+read_history = _analyzer.read_history
+read_history_with_labels = _analyzer.read_history_with_labels
+stats_last_n = _analyzer.stats_last_n
+cl_cd_stats = _analyzer.cl_cd_stats
+execution_time = _analyzer.execution_time
+cl_cd_summary = _analyzer.cl_cd_summary
+project_cl_cd_stats = _analyzer.project_cl_cd_stats
+aggregate_report = _analyzer.aggregate_report
+plot_stats = _analyzer.plot_stats
 
 __all__ = [
     "parse_headers",
@@ -29,154 +33,15 @@ __all__ = [
     "plot_stats",
     "analysis",
     "analysis_file",
+    "ConvergenceAnalyzer",
 ]
 
 
 def analysis(cwd: Path, args: Sequence[str | Path]) -> None:
     """Aggregate convergence data and create plots."""
-
-    if len(args) < 2:
-        raise ValueError("analysis requires input and output directory")
-
-    report_dir = Path(args[0])
-    out_dir = Path(args[1])
-    fig_dir = out_dir / "figures"
-
-    idx, means, stds = aggregate_report(report_dir)
-
-    first = next(iter(sorted(report_dir.glob("converg.fensap.*"))), None)
-    labels = parse_headers(first) if first else []
-
-    if means.size:
-        plot_stats(idx, means, stds, out_dir, labels)
-
-    clcd = cl_cd_stats(report_dir)
-    if clcd.size:
-        import numpy as np
-        import matplotlib.pyplot as plt
-
-        out_dir.mkdir(parents=True, exist_ok=True)
-        fig_dir.mkdir(parents=True, exist_ok=True)
-
-        np.savetxt(
-            out_dir / "cl_cd_stats.csv",
-            clcd,
-            delimiter=",",
-            header="index,CL,CD",
-            comments="",
-        )
-
-        plt.figure()
-        plt.plot(clcd[:, 0], clcd[:, 1], marker=None)
-        plt.xlabel("multishot index")
-        plt.ylabel("CL")
-        plt.grid(True)
-        plt.tight_layout()
-        plt.savefig(fig_dir / "cl.png")
-        plt.close()
-
-        plt.figure()
-        plt.plot(clcd[:, 0], clcd[:, 2], marker=None)
-        plt.xlabel("multishot index")
-        plt.ylabel("CD")
-        plt.grid(True)
-        plt.tight_layout()
-        plt.savefig(fig_dir / "cd.png")
-        plt.close()
-
-        plt.figure()
-        plt.plot(clcd[:, 0], clcd[:, 1], label="CL", marker=None)
-        plt.plot(clcd[:, 0], clcd[:, 2], label="CD", marker=None)
-        plt.xlabel("multishot index")
-        plt.ylabel("coefficient")
-        plt.grid(True)
-        plt.legend()
-        plt.tight_layout()
-        plt.savefig(fig_dir / "cl_cd.png")
-        plt.close()
+    _analyzer.analysis(cwd, args)
 
 
 def analysis_file(cwd: Path, args: Sequence[str | Path]) -> None:
-    """Analyse a single FENSAP convergence file and generate plots."""
-
-    if len(args) < 2:
-        raise ValueError("analysis_file requires input file and output directory")
-
-    file = Path(args[0])
-    out_dir = Path(args[1])
-    fig_dir = out_dir / "figures"
-
-    import numpy as np
-    import matplotlib.pyplot as plt
-    import csv
-
-    labels, data = read_history_with_labels(file)
-
-    out_dir.mkdir(parents=True, exist_ok=True)
-    fig_dir.mkdir(parents=True, exist_ok=True)
-
-    iterations = np.arange(1, data.shape[0] + 1)
-    for col in range(data.shape[1]):
-        plt.figure()
-        plt.plot(iterations, data[:, col], marker=None)
-        plt.xlabel("iteration")
-        ylabel = labels[col] if col < len(labels) else f"column {col}"
-        plt.ylabel(ylabel)
-        plt.grid(True)
-        plt.tight_layout()
-        plt.savefig(fig_dir / f"column_{col:02d}.png")
-        plt.close()
-
-    mean, _ = stats_last_n(data, 15)
-    variance = np.var(data[-15:], axis=0)
-
-    with (out_dir / "stats.csv").open("w", newline="") as fh:
-        writer = csv.writer(fh)
-        writer.writerow(["label", "mean", "variance"])
-        for col in range(data.shape[1]):
-            label = labels[col] if col < len(labels) else f"column {col}"
-            writer.writerow([label, mean[col], variance[col]])
-
-    try:
-        cl_idx = labels.index("lift coefficient")
-        cd_idx = labels.index("drag coefficient")
-    except ValueError:
-        return
-
-    clcd = np.column_stack((iterations, data[:, cl_idx], data[:, cd_idx]))
-    np.savetxt(
-        out_dir / "cl_cd_stats.csv",
-        clcd,
-        delimiter=",",
-        header="index,CL,CD",
-        comments="",
-    )
-
-    plt.figure()
-    plt.plot(iterations, data[:, cl_idx], marker=None)
-    plt.xlabel("iteration")
-    plt.ylabel("CL")
-    plt.grid(True)
-    plt.tight_layout()
-    plt.savefig(fig_dir / "cl.png")
-    plt.close()
-
-    plt.figure()
-    plt.plot(iterations, data[:, cd_idx], marker=None)
-    plt.xlabel("iteration")
-    plt.ylabel("CD")
-    plt.grid(True)
-    plt.tight_layout()
-    plt.savefig(fig_dir / "cd.png")
-    plt.close()
-
-    plt.figure()
-    plt.plot(iterations, data[:, cl_idx], label="CL", marker=None)
-    plt.plot(iterations, data[:, cd_idx], label="CD", marker=None)
-    plt.xlabel("iteration")
-    plt.ylabel("coefficient")
-    plt.grid(True)
-    plt.legend()
-    plt.tight_layout()
-    plt.savefig(fig_dir / "cl_cd.png")
-    plt.close()
+    """Analyse a single convergence file and generate plots."""
+    _analyzer.analysis_file(cwd, args)

--- a/tests/test_convergence_headers.py
+++ b/tests/test_convergence_headers.py
@@ -3,7 +3,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import numpy as np
-from glacium.utils.convergence.io import parse_headers, read_history_with_labels
+from glacium.analysis import ConvergenceAnalyzer
 
 
 def test_parse_headers_and_read_history(tmp_path):
@@ -16,13 +16,14 @@ def test_parse_headers_and_read_history(tmp_path):
     file = tmp_path / "converg"
     file.write_text(content)
 
-    labels = parse_headers(file)
+    analyzer = ConvergenceAnalyzer()
+    labels = analyzer.parse_headers(file)
     assert labels == ["residual", "lift"]
 
-    labels2, data = read_history_with_labels(file)
+    labels2, data = analyzer.read_history_with_labels(file)
     assert labels2 == labels
     assert np.allclose(data, np.array([[1.0, 2.0], [3.0, 4.0]]))
 
-    _, data_tail = read_history_with_labels(file, nrows=1)
+    _, data_tail = analyzer.read_history_with_labels(file, nrows=1)
     assert data_tail.shape == (1, 2)
     assert np.allclose(data_tail, np.array([[3.0, 4.0]]))

--- a/tests/test_convergence_stats.py
+++ b/tests/test_convergence_stats.py
@@ -9,6 +9,7 @@ import pytest
 from PyPDF2 import PdfReader
 
 from glacium.utils import convergence
+from glacium.analysis import ConvergenceAnalyzer
 from glacium.jobs.analysis import ConvergenceStatsJob
 from glacium.models.config import GlobalConfig
 from glacium.managers.path_manager import PathBuilder
@@ -36,6 +37,8 @@ def report_dirs(tmp_path):
 def test_analysis_returns_expected_stats(report_dirs, tmp_path, monkeypatch):
     report, out_dir, exp_means, exp_stds = report_dirs
 
+    analyzer = ConvergenceAnalyzer()
+
     captured = {}
 
     def fake_plot(idx, means, stds, out, labels=None):
@@ -44,9 +47,9 @@ def test_analysis_returns_expected_stats(report_dirs, tmp_path, monkeypatch):
         captured["stds"] = stds
         captured["labels"] = labels
 
-    monkeypatch.setattr(convergence, "plot_stats", fake_plot)
+    monkeypatch.setattr(analyzer, "plot_stats", fake_plot)
 
-    convergence.analysis(tmp_path, [report, out_dir])
+    analyzer.analysis(tmp_path, [report, out_dir])
 
     assert captured["idx"] == [1, 2]
     assert np.allclose(captured["means"], exp_means)

--- a/tests/test_single_convergence_stats.py
+++ b/tests/test_single_convergence_stats.py
@@ -13,7 +13,7 @@ import os
 import pytest
 from PyPDF2 import PdfReader
 
-from glacium.utils.convergence import analysis_file
+from glacium.analysis import ConvergenceAnalyzer
 from glacium.utils.reporting.report_converg_fensap import build_report
 
 
@@ -39,7 +39,8 @@ def test_single_convergence_stats(tmp_path):
     lines += [" ".join(map(str, row)) for row in data]
     conv_file.write_text("\n".join(lines))
 
-    analysis_file(tmp_path, [conv_file, out_dir])
+    analyzer = ConvergenceAnalyzer()
+    analyzer.analysis_file(tmp_path, [conv_file, out_dir])
     build_report(out_dir)
 
     fig_dir = out_dir / "figures"


### PR DESCRIPTION
## Summary
- add `ConvergenceAnalyzer` with helpers for reading and plotting convergence history
- use the new analyzer in convergence jobs and convenience wrappers
- update convergence tests to exercise the class API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_68838fe46f7883279455408d8807bcb3