### PR TITLE
Add Multishot analysis script

### DIFF
--- a/scripts/multishot_analysis.py
+++ b/scripts/multishot_analysis.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+import numpy as np
+import matplotlib.pyplot as plt
+import scienceplots
+
+from glacium.api import Project
+from glacium.managers.project_manager import ProjectManager
+from glacium.utils.logging import log
+
+plt.style.use(["science", "ieee"])
+
+
+def load_multishot_project(root: Path) -> Project:
+    """Return the single multishot project located in ``root``."""
+    pm = ProjectManager(root)
+    uids = pm.list_uids()
+    if not uids:
+        raise FileNotFoundError(f"No projects found in {root}")
+    if len(uids) > 1:
+        log.warning("Multiple projects found, using the first one")
+    return Project.load(root, uids[0])
+
+
+def plot_cl_cd(csv_file: Path, out_dir: Path) -> None:
+    """Plot CL and CD values from ``csv_file`` and save into ``out_dir``."""
+    data = np.loadtxt(csv_file, delimiter=",", skiprows=1)
+    if data.ndim == 1:
+        data = data.reshape(1, -1)
+    idx, cl, cd = data[:, 0], data[:, 1], data[:, 2]
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    plt.figure()
+    plt.plot(idx, cl, marker="o", label="CL")
+    plt.plot(idx, cd, marker="o", label="CD")
+    plt.xlabel("shot index")
+    plt.ylabel("coefficient")
+    plt.grid(True)
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(out_dir / "cl_cd_vs_index.png")
+    plt.close()
+
+
+def main() -> None:
+    project_root = Path("Multishot")
+    project = load_multishot_project(project_root)
+    csv_path = project.root / "analysis" / "MULTISHOT" / "cl_cd_stats.csv"
+    plot_cl_cd(csv_path, Path("multishot_results"))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add new `multishot_analysis.py` helper script
- the script loads a multishot project, parses `analysis/MULTISHOT/cl_cd_stats.csv`
  and plots CL/CD over shot index into `multishot_results/`

## Testing
- `pytest tests/test_convergence_stats.py::test_convergence_stats_job_creates_plots -q`
- `pytest tests/test_fensap_analysis_job.py::test_fensap_analysis_job -q` *(fails: assertion on expected args)*


------
https://chatgpt.com/codex/tasks/task_e_6884ec5aa300832784a29c52bc10dacf