### PR TITLE
Add global project directory option

### DIFF
--- a/glacium/cli/__init__.py
+++ b/glacium/cli/__init__.py
@@ -1,5 +1,7 @@
 """Command line interface entry point for Glacium."""
 
+from pathlib import Path
+
 import click
 
 # Einzel-Commands importieren
@@ -18,9 +20,19 @@ from .info import cli_info
 from .case_sweep import cli_case_sweep
 
 @click.group()
-def cli():
+@click.option(
+    "--dir",
+    "runs_dir",
+    default="runs",
+    show_default=True,
+    type=click.Path(file_okay=False, dir_okay=True, path_type=Path),
+    help="Directory containing projects",
+)
+@click.pass_context
+def cli(ctx: click.Context, runs_dir: Path) -> None:
     """Glacium – project & job control."""
-    pass
+
+    ctx.obj = runs_dir
 
 # Befehle registrieren
 cli.add_command(cli_new)

--- a/glacium/cli/info.py
+++ b/glacium/cli/info.py
@@ -13,7 +13,7 @@ from rich import box
 from glacium.managers.project_manager import ProjectManager
 from glacium.utils.current import load as load_current
 
-ROOT = Path("runs")
+from .utils import runs_root
 console = Console()
 
 
@@ -22,7 +22,7 @@ console = Console()
 @log_call
 def cli_info(uid: str | None) -> None:
     """Print case parameters and selected global config values."""
-    pm = ProjectManager(ROOT)
+    pm = ProjectManager(runs_root())
 
     if uid is None:
         uid = load_current()

--- a/glacium/cli/job/__init__.py
+++ b/glacium/cli/job/__init__.py
@@ -8,7 +8,7 @@ import click
 from glacium.utils.logging import log_call
 from rich.console import Console
 
-ROOT = Path("runs")
+from ..utils import runs_root
 console = Console()
 
 

--- a/glacium/cli/job/add.py
+++ b/glacium/cli/job/add.py
@@ -9,7 +9,8 @@ from glacium.utils.current import load
 from glacium.managers.project_manager import ProjectManager
 from glacium.managers.config_manager import ConfigManager
 
-from . import cli_job, ROOT
+from . import cli_job
+from ..utils import runs_root
 
 
 @cli_job.command("add")
@@ -23,7 +24,7 @@ def cli_job_add(job_name: str) -> None:
             "Kein Projekt gewählt. Erst 'glacium select' nutzen."
         )
 
-    pm = ProjectManager(ROOT)
+    pm = ProjectManager(runs_root())
     try:
         proj = pm.load(uid)
     except FileNotFoundError:

--- a/glacium/cli/job/list.py
+++ b/glacium/cli/job/list.py
@@ -11,7 +11,8 @@ from rich import box
 from glacium.utils.current import load
 from glacium.managers.project_manager import ProjectManager
 
-from . import cli_job, ROOT, console
+from . import cli_job, console
+from ..utils import runs_root
 
 
 @cli_job.command("list")
@@ -23,7 +24,7 @@ def cli_job_list(available: bool) -> None:
     if uid is None:
         raise click.ClickException("Kein Projekt gewählt. Erst 'glacium select' nutzen.")
 
-    pm = ProjectManager(ROOT)
+    pm = ProjectManager(runs_root())
     try:
         proj = pm.load(uid)
     except FileNotFoundError:

--- a/glacium/cli/job/remove.py
+++ b/glacium/cli/job/remove.py
@@ -9,7 +9,8 @@ from glacium.utils.current import load
 from glacium.managers.project_manager import ProjectManager
 from glacium.managers.config_manager import ConfigManager
 
-from . import cli_job, ROOT
+from . import cli_job
+from ..utils import runs_root
 
 
 @cli_job.command("remove")
@@ -23,7 +24,7 @@ def cli_job_remove(job_name: str) -> None:
             "Kein Projekt gewählt. Erst 'glacium select' nutzen."
         )
 
-    pm = ProjectManager(ROOT)
+    pm = ProjectManager(runs_root())
     try:
         proj = pm.load(uid)
     except FileNotFoundError:

--- a/glacium/cli/job/reset.py
+++ b/glacium/cli/job/reset.py
@@ -9,7 +9,8 @@ from glacium.utils.current import load
 from glacium.managers.project_manager import ProjectManager
 from glacium.models.job import JobStatus
 
-from . import cli_job, ROOT
+from . import cli_job
+from ..utils import runs_root
 
 
 @cli_job.command("reset")
@@ -21,7 +22,7 @@ def cli_job_reset(job_name: str) -> None:
     if uid is None:
         raise click.ClickException("Kein Projekt gewählt. Erst 'glacium select' nutzen.")
 
-    pm = ProjectManager(ROOT)
+    pm = ProjectManager(runs_root())
     try:
         proj = pm.load(uid)
     except FileNotFoundError:

--- a/glacium/cli/job/run.py
+++ b/glacium/cli/job/run.py
@@ -9,7 +9,8 @@ from glacium.utils.current import load
 from glacium.managers.project_manager import ProjectManager
 from glacium.models.job import JobStatus
 
-from . import cli_job, ROOT
+from . import cli_job
+from ..utils import runs_root
 
 
 @cli_job.command("run")
@@ -21,7 +22,7 @@ def cli_job_run(job_name: str) -> None:
     if uid is None:
         raise click.ClickException("Kein Projekt gewählt. Erst 'glacium select' nutzen.")
 
-    pm = ProjectManager(ROOT)
+    pm = ProjectManager(runs_root())
     try:
         proj = pm.load(uid)
     except FileNotFoundError:

--- a/glacium/cli/job/select.py
+++ b/glacium/cli/job/select.py
@@ -8,7 +8,8 @@ from glacium.utils.logging import log_call
 from glacium.utils.current import load
 from glacium.managers.project_manager import ProjectManager
 
-from . import cli_job, ROOT
+from . import cli_job
+from ..utils import runs_root
 
 
 @cli_job.command("select")
@@ -20,7 +21,7 @@ def cli_job_select(job: str) -> None:
     if uid is None:
         raise click.ClickException("Kein Projekt gewählt. Erst 'glacium select' nutzen.")
 
-    pm = ProjectManager(ROOT)
+    pm = ProjectManager(runs_root())
     try:
         proj = pm.load(uid)
     except FileNotFoundError:

--- a/glacium/cli/list.py
+++ b/glacium/cli/list.py
@@ -1,6 +1,5 @@
 """Display jobs of a project in a table."""
 
-from pathlib import Path
 import yaml
 import click
 from glacium.utils.logging import log_call
@@ -8,9 +7,12 @@ from rich.console import Console
 from rich.table import Table
 from rich import box
 
+from pathlib import Path
 from glacium.managers.project_manager import ProjectManager
 from glacium.utils.current import load as load_current
 from glacium.models.job import UnavailableJob
+
+from .utils import runs_root
 
 console = Console()
 
@@ -22,7 +24,7 @@ def cli_list(uid: str | None):
 
     Ohne UID wird das aktuell ausgewaehlte Projekt verwendet.
     """
-    pm = ProjectManager(Path("runs"))
+    pm = ProjectManager(runs_root())
 
     if uid is None:
         uid = load_current()

--- a/glacium/cli/projects.py
+++ b/glacium/cli/projects.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from glacium.utils.ProjectIndex import list_projects
 from glacium.utils.convergence import execution_time, cl_cd_summary
 
+from .utils import runs_root
+
 
 def _format_time(seconds: float) -> str:
     """Return ``HH:MM:SS`` string for ``seconds``."""
@@ -23,7 +25,7 @@ def _format_time(seconds: float) -> str:
 def cli_projects(results: bool):
     """Listet alle Projekte mit Job-Fortschritt."""
     console = Console()
-    root = Path("runs")
+    root = runs_root()
     items = list_projects(root)
 
     # Sammle alle Keys aus case.yaml

--- a/glacium/cli/remove.py
+++ b/glacium/cli/remove.py
@@ -10,7 +10,7 @@ from rich.console import Console
 from glacium.utils.ProjectIndex import list_projects
 from glacium.utils.current import load as load_current
 
-ROOT = Path("runs")
+from .utils import runs_root
 console = Console()
 
 
@@ -26,8 +26,9 @@ def cli_remove(project: str | None, remove_all: bool):
     Die Nummer entspricht der Ausgabe von ``glacium projects``.
     """
 
+    root = runs_root()
     if remove_all:
-        uids = [p.name for p in ROOT.iterdir() if p.is_dir()]
+        uids = [p.name for p in root.iterdir() if p.is_dir()]
     else:
         if project is None:
             uid = load_current()
@@ -38,7 +39,7 @@ def cli_remove(project: str | None, remove_all: bool):
                 )
         else:
             if project.isdigit():
-                items = list_projects(ROOT)
+                items = list_projects(root)
                 idx = int(project) - 1
                 if idx < 0 or idx >= len(items):
                     raise click.ClickException("Ungültige Nummer.")
@@ -48,7 +49,7 @@ def cli_remove(project: str | None, remove_all: bool):
         uids = [uid]
 
     for uid in uids:
-        path = ROOT / uid
+        path = root / uid
         if path.exists():
             shutil.rmtree(path)
             console.print(f"[green]{uid} entfernt.[/]")

--- a/glacium/cli/run.py
+++ b/glacium/cli/run.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from glacium.utils.current import load as load_current
 from glacium.managers.project_manager import ProjectManager
 
-ROOT = Path("runs")
+from .utils import runs_root
 
 @click.command("run")
 @click.argument("jobs", nargs=-1)
@@ -23,7 +23,7 @@ def cli_run(jobs: tuple[str], run_all: bool):
     Mit ``--all`` werden alle Projekte verarbeitet und Jobs im Status
     ``PENDING`` oder ``FAILED`` ausgeführt."""
 
-    pm = ProjectManager(ROOT)
+    pm = ProjectManager(runs_root())
 
     if run_all:
         for uid in pm.list_uids():

--- a/glacium/cli/select.py
+++ b/glacium/cli/select.py
@@ -7,6 +7,8 @@ from rich.console import Console
 from glacium.utils.ProjectIndex import list_projects
 from glacium.utils.current import save
 
+from .utils import runs_root
+
 console = Console()
 
 @click.command("select")
@@ -14,8 +16,8 @@ console = Console()
 @log_call
 def cli_select(project: str):
     """Projekt auswählen (Nr oder UID) und merken."""
-    root   = Path("runs")
-    items  = list_projects(root)
+    root = runs_root()
+    items = list_projects(root)
 
     # Nummer → UID umwandeln
     if project.isdigit():

--- a/glacium/cli/sync.py
+++ b/glacium/cli/sync.py
@@ -7,7 +7,8 @@ from glacium.managers.project_manager import ProjectManager
 from glacium.utils.current import load as load_current
 from glacium.utils.ProjectIndex import list_projects
 
-ROOT = Path("runs")
+from .utils import runs_root
+
 
 @click.command("sync")
 @click.argument("uid", required=False)
@@ -21,7 +22,8 @@ def cli_sync(uid: str | None, sync_all: bool):
     • Mit UID       → nur dieses Projekt
     • --all         → alle Projekte unter ./runs
     """
-    pm = ProjectManager(ROOT)
+    root = runs_root()
+    pm = ProjectManager(root)
 
     # -------------- Welche Projekte?
     if sync_all:

--- a/glacium/cli/update.py
+++ b/glacium/cli/update.py
@@ -19,7 +19,7 @@ from glacium.utils import (
     first_cellheight,
 )
 
-ROOT = Path("runs")
+from .utils import runs_root
 
 
 @click.command("update")
@@ -34,7 +34,7 @@ ROOT = Path("runs")
 @log_call
 def cli_update(uid: str | None, case_file: Path | None) -> None:
     """Regenerate ``global_config.yaml`` for a project."""
-    pm = ProjectManager(ROOT)
+    pm = ProjectManager(runs_root())
 
     if uid is None:
         uid = load_current()

--- a/glacium/cli/utils.py
+++ b/glacium/cli/utils.py
@@ -1,0 +1,16 @@
+"""Helpers for CLI commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+
+def runs_root() -> Path:
+    """Return the project directory from the current Click context."""
+
+    ctx = click.get_current_context(silent=True)
+    root = getattr(ctx, "obj", None)
+    return Path(root) if root is not None else Path("runs")
+

--- a/tests/test_cli_dir_override.py
+++ b/tests/test_cli_dir_override.py
@@ -1,0 +1,49 @@
+import yaml
+from pathlib import Path
+from click.testing import CliRunner
+
+from glacium.cli import cli
+from glacium.managers.project_manager import ProjectManager
+
+
+def test_cli_projects_custom_dir(tmp_path):
+    runner = CliRunner()
+    env = {"HOME": str(tmp_path), "COLUMNS": "200"}
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        root = Path("other_runs")
+        airfoil = (
+            Path(__file__).resolve().parents[1]
+            / "glacium"
+            / "data"
+            / "AH63K127.dat"
+        )
+        pm = ProjectManager(root)
+        proj = pm.create("demo", "hello", airfoil)
+
+        result = runner.invoke(cli, ["--dir", str(root), "projects"], env=env)
+        assert result.exit_code == 0
+        assert proj.uid in result.output
+
+
+def test_cli_run_all_custom_dir(tmp_path):
+    runner = CliRunner()
+    env = {"HOME": str(tmp_path)}
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        root = Path("overridepath")
+        airfoil = (
+            Path(__file__).resolve().parents[1]
+            / "glacium"
+            / "data"
+            / "AH63K127.dat"
+        )
+        pm = ProjectManager(root)
+        p1 = pm.create("proj1", "hello", airfoil)
+        p2 = pm.create("proj2", "hello", airfoil)
+
+        result = runner.invoke(cli, ["--dir", str(root), "run", "--all"], env=env)
+        assert result.exit_code == 0
+
+        jobs1 = yaml.safe_load((root / p1.uid / "_cfg" / "jobs.yaml").read_text())
+        jobs2 = yaml.safe_load((root / p2.uid / "_cfg" / "jobs.yaml").read_text())
+        assert jobs1.get("HelloJob") == "DONE"
+        assert jobs2.get("HelloJob") == "DONE"


### PR DESCRIPTION
## Summary
- allow overriding the projects directory via `--dir`
- add helper util `runs_root` to retrieve the directory
- update CLI commands to respect the override
- test listing and running projects in a custom directory

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6885fa11c6448327a9cb3d3f68bc0e7d