### PR TITLE
Add Cp distribution output for FensapAnalysisJob

### DIFF
--- a/tests/test_fensap_analysis_job.py
+++ b/tests/test_fensap_analysis_job.py
@@ -8,6 +8,8 @@ from glacium.models.config import GlobalConfig
 from glacium.managers.path_manager import PathBuilder
 from glacium.models.project import Project
 from glacium.managers.job_manager import JobManager
+from glacium.post import analysis as post_analysis
+import pandas as pd
 
 
 def test_fensap_analysis_job(tmp_path, monkeypatch):
@@ -38,6 +40,23 @@ def test_fensap_analysis_job(tmp_path, monkeypatch):
     monkeypatch.setattr(analysis_jobs, "PyEngine", FakePyEngine)
     monkeypatch.setattr(analysis_jobs, "fensap_analysis", lambda *_: None)
 
+    def rec(name, ret=None):
+        def wrapper(*args, **kwargs):
+            called[name] = args
+            return ret
+        return wrapper
+
+    cp_df = pd.DataFrame({"x_c": [0.0], "Cp": [0.0]})
+
+    monkeypatch.setattr(post_analysis, "read_tec_ascii", rec("read_tec_ascii", "DF"))
+    monkeypatch.setattr(post_analysis, "compute_cp", rec("compute_cp", cp_df))
+
+    def fake_plot_cp_directional(*args):
+        called["plot_cp_directional"] = args
+        Path(args[5]).write_text("img")
+
+    monkeypatch.setattr(post_analysis, "plot_cp_directional", fake_plot_cp_directional)
+
     jm = JobManager(project)
     jm.run()
 
@@ -45,3 +64,5 @@ def test_fensap_analysis_job(tmp_path, monkeypatch):
     assert called["fn"] is analysis_jobs.fensap_analysis
     assert called["cwd"] == tmp_path
     assert called["args"] == [dat, out_dir]
+    assert (out_dir / "soln.fensap_cp.png").exists()
+    assert (out_dir / "cp_curve.csv").exists()


### PR DESCRIPTION
## Summary
- compute Cp distribution in `FensapAnalysisJob`
- save Cp curve CSV and Cp plot
- extend test to verify Cp artifacts

## Testing
- `pytest tests/test_fensap_analysis_job.py::test_fensap_analysis_job -q`

------
https://chatgpt.com/codex/tasks/task_e_68866c0dd65c8327a679d7163ec8dc80