### PR TITLE
Add Cp CSV output for AnalyzeMultishotJob

### DIFF
--- a/docs/high_level_api/postprocessing.rst
+++ b/docs/high_level_api/postprocessing.rst
@@ -53,8 +53,8 @@ results and write a ``manifest.json`` under the project root.
 to create slice screenshots for ``run_FENSAP/soln.fensap.dat``.
 ``MESH_ANALYSIS`` executes :func:`glacium.utils.mesh_analysis.mesh_analysis`
 and produces a mesh quality report under ``analysis/MESH``.
-``ANALYZE_MULTISHOT`` runs the analysis helpers afterwards and stores figures in
-``analysis/MULTISHOT``.
+``ANALYZE_MULTISHOT`` runs the analysis helpers afterwards and stores figures
+and Cp CSV files in ``analysis/MULTISHOT``.
 When a manifest is present ``PostProcessor`` loads the saved ``ArtifactIndex`` instantly::
 
    from glacium.post import PostProcessor

--- a/glacium/jobs/analysis_jobs.py
+++ b/glacium/jobs/analysis_jobs.py
@@ -106,7 +106,11 @@ class Ice3dConvergenceStatsJob(Job):
 
 
 class AnalyzeMultishotJob(Job):
-    """Analyse MULTISHOT solver exports."""
+    """Analyse MULTISHOT solver exports.
+
+    Writes pressure coefficient curves for each time step under
+    ``analysis/MULTISHOT``.
+    """
 
     name = "ANALYZE_MULTISHOT"
     deps = ("POSTPROCESS_MULTISHOT",)
@@ -139,6 +143,7 @@ class AnalyzeMultishotJob(Job):
                 wall_tol,
                 rel_pct,
             )
+            (out_dir / f"{dat.stem}_cp.csv").write_text(cp.to_csv(index=False))
             cp_results.append((dat.stem, cp))
             img = out_dir / f"{dat.stem}_cp.png"
             post_analysis.plot_cp_directional(


### PR DESCRIPTION
## Summary
- save pressure coefficient data for each MULTISHOT step
- document new CSV output location
- unit test for CSV creation

## Testing
- `pytest tests/test_analyze_multishot_job.py tests/test_fensap_analysis_job.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68866e06cc7c8327b04cdb883820374c