### PR TITLE
Add momentum coefficient helper

### DIFF
--- a/glacium/post/analysis/__init__.py
+++ b/glacium/post/analysis/__init__.py
@@ -1,4 +1,10 @@
-from .cp import read_tec_ascii, compute_cp, plot_cp as _plot_cp, plot_cp_overlay
+from .cp import (
+    read_tec_ascii,
+    compute_cp,
+    momentum_coefficient,
+    plot_cp as _plot_cp,
+    plot_cp_overlay,
+)
 from .ice_thickness import read_wall_zone, process_wall_zone, plot_ice_thickness
 from .ice_contours import load_contours, plot_overlay, animate_growth
 from .cp2 import load_stl_contour, resample_contour, map_cp_to_contour
@@ -9,6 +15,7 @@ plot_cp = _plot_cp
 __all__ = [
     "read_tec_ascii",
     "compute_cp",
+    "momentum_coefficient",
     "plot_cp",
     "plot_cp_overlay",
     "plot_cp_directional",

--- a/glacium/post/analysis/cp.py
+++ b/glacium/post/analysis/cp.py
@@ -17,6 +17,7 @@ except Exception:  # pragma: no cover - optional dependency
 __all__ = [
     "read_tec_ascii",
     "compute_cp",
+    "momentum_coefficient",
     "plot_cp",
     "plot_cp_overlay",
 ]
@@ -136,6 +137,11 @@ def compute_cp(
     surf = sort_surface_contour(surf)
 
     return surf
+
+
+def momentum_coefficient(cp_df: pd.DataFrame) -> float:
+    """Return C_mu obtained by integrating the Cp curve."""
+    return float(np.trapz(-cp_df["Cp"], cp_df["x_c"]))
 
 
 def plot_cp(df: pd.DataFrame, outfile: str | Path) -> Path:

--- a/tests/test_analysis_tools.py
+++ b/tests/test_analysis_tools.py
@@ -6,6 +6,7 @@ import os
 import numpy as np
 import pandas as pd
 import trimesh
+import pytest
 
 from glacium.post.analysis.cp import compute_cp
 from glacium.post.analysis.ice_thickness import process_wall_zone
@@ -14,6 +15,7 @@ from glacium.post.analysis import (
     load_stl_contour,
     resample_contour,
     map_cp_to_contour,
+    momentum_coefficient,
 )
 
 
@@ -94,4 +96,15 @@ def test_map_cp_to_contour():
     surf_df = pd.DataFrame({"X": [0.0, 2.0], "Y": [0.0, 0.0], "Cp": [1.0, 2.0]})
     mapped = map_cp_to_contour(contour, surf_df)
     assert list(mapped["Cp"]) == [1.0, 1.0, 2.0]
+
+
+def test_momentum_coefficient():
+    cp_df = pd.DataFrame(
+        {
+            "x_c": [0.0, 0.25, 0.5, 0.75, 1.0],
+            "Cp": [-1.0, -0.5, 0.0, 0.5, 0.0],
+        }
+    )
+    cmu = momentum_coefficient(cp_df)
+    assert cmu == pytest.approx(0.125)
 


### PR DESCRIPTION
## Summary
- add `momentum_coefficient` helper for integrating Cp
- export helper from `glacium.post.analysis`
- unit test for momentum coefficient

## Testing
- `pytest tests/test_analysis_tools.py::test_momentum_coefficient -q`

------
https://chatgpt.com/codex/tasks/task_e_68866f9c02408327b63bca4aa6b1a8e7