### PR TITLE
Implement run --all job reset

### DIFF
--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -111,8 +111,10 @@ status ``PENDING`` or ``FAILED`` are executed in dependency order:
 
    glacium run --all
 
-You may restrict execution to specific jobs by name or index.  The
-``list`` command shows the current status and index of each job:
+You may restrict execution to specific jobs by name or index.  When
+using ``--all`` with job names those jobs are first reset to ``PENDING``
+on every project.  The ``list`` command shows the current status and
+index of each job:
 
 .. code-block:: bash
 

--- a/glacium/managers/job_manager.py
+++ b/glacium/managers/job_manager.py
@@ -127,6 +127,18 @@ class JobManager:
         self._save_status()
 
     # ------------------------------------------------------------------
+    def reset_jobs(self, names: Iterable[str]) -> None:
+        """Set listed jobs to ``PENDING`` if they are not currently running."""
+
+        for name in names:
+            job = self._jobs.get(name)
+            if job is None:
+                continue
+            if job.status is not JobStatus.RUNNING:
+                job.status = JobStatus.PENDING
+        self._save_status()
+
+    # ------------------------------------------------------------------
     def _execute(self, job: Job):
         """Run a single job and update its status."""
 


### PR DESCRIPTION
## Summary
- add `reset_jobs` method to reset jobs to PENDING
- reset jobs before running them with `glacium run --all`
- document how to rerun named jobs across projects
- test resetting job status when using `--all`

## Testing
- `pytest tests/test_run_all.py::test_run_all_resets_named_jobs -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68867da260a4832780b2584391c523d4