### PR TITLE
Add ICE_GUI_TOTAL_TIME support

### DIFF
--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -45,7 +45,8 @@ and ``glacium init`` the ``case.yaml`` file is parsed and the resulting
 ``case.yaml`` later you can run ``glacium update`` to rebuild the
 configuration. When multishot jobs run, template files for each shot index are
 created automatically before launching the solver.  Use ``CASE_MULTISHOT`` in
-``case.yaml`` to specify the icing time of each cycle.
+``case.yaml`` to specify the icing time of each cycle.  ``ICE_GUI_TOTAL_TIME``
+sets the total icing time for multishot cycles.
 
 Case sweep
 ~~~~~~~~~~

--- a/glacium/config/defaults/case.yaml
+++ b/glacium/config/defaults/case.yaml
@@ -11,3 +11,4 @@ CASE_YPLUS: 0.3
 PWS_REFINEMENT: 8 # mesh refinement level
 # Optional icing time for each MULTISHOT iteration (seconds)
 # CASE_MULTISHOT: [10, 20, 30]
+ICE_GUI_TOTAL_TIME: 1200  # total icing time for multishot cycles

--- a/glacium/utils/case_to_global.py
+++ b/glacium/utils/case_to_global.py
@@ -52,6 +52,7 @@ def generate_global_defaults(case_path: Path, template_path: Path) -> Dict[str, 
     yplus = float(case.get("CASE_YPLUS", 1.0))
     refinement = float(case.get("PWS_REFINEMENT", cfg.get("PWS_REFINEMENT", 1)))
     multishot = case.get("CASE_MULTISHOT")
+    ice_total = float(case.get("ICE_GUI_TOTAL_TIME", cfg.get("ICE_GUI_TOTAL_TIME", 1200)))
     # Ambient conditions ------------------------------------------------------
     pressure = _ambient_pressure(altitude)
     density = pressure / (287.05 * temperature)
@@ -141,6 +142,9 @@ def generate_global_defaults(case_path: Path, template_path: Path) -> Dict[str, 
         "FSP_DRAG_VECTOR_COMPONENT_Y": math.sin(alpha),
         "FSP_DRAG_VECTOR_COMPONENT_Z": 0.0,
     })
+
+    cfg["ICE_GUI_TOTAL_TIME"] = ice_total
+    cfg["ICE_NUMBER_TIME_STEP"] = int(ice_total * 1000)
 
     cfg["CASE_ROUGHNESS"] = roughness
     cfg["CASE_CHARACTERISTIC_LENGTH"] = chord


### PR DESCRIPTION
## Summary
- default total icing time in `case.yaml`
- document `ICE_GUI_TOTAL_TIME`
- use `ICE_GUI_TOTAL_TIME` when generating config

## Testing
- `pytest tests/test_run_builder.py::test_run_builder_creates_files -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'veusz')*

------
https://chatgpt.com/codex/tasks/task_e_688731b734348327baddecc673857249