### PR TITLE
Update multishot docs

### DIFF
--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -44,9 +44,9 @@ and ``glacium init`` the ``case.yaml`` file is parsed and the resulting
 ``global_config.yaml`` is written automatically.  If you change
 ``case.yaml`` later you can run ``glacium update`` to rebuild the
 configuration. When multishot jobs run, template files for each shot index are
-created automatically before launching the solver.  Use ``CASE_MULTISHOT`` in
-``case.yaml`` to specify the icing time of each cycle.  ``ICE_GUI_TOTAL_TIME``
-sets the total icing time for multishot cycles.
+created automatically before launching the solver. ``ICE_GUI_TOTAL_TIME``
+defines the icing duration for cycles after the fixed ``10``‑second first shot.
+Individual timings are no longer needed unless overriding that initial shot.
 
 Case sweep
 ~~~~~~~~~~


### PR DESCRIPTION
## Summary
- clarify the role of `ICE_GUI_TOTAL_TIME`
- note that explicit cycle timings are only needed to override the first shot

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ruamel')*

------
https://chatgpt.com/codex/tasks/task_e_688738fed4008327a220566d5e29d8e9