### PR TITLE
Parameterise full_power study root

### DIFF
--- a/scripts/clean_sweep_analysis.py
+++ b/scripts/clean_sweep_analysis.py
@@ -109,10 +109,11 @@ def aoa_sweep_analysis(runs: list[tuple[float, float, float, float, Project]], o
     plt.close(fig)
 
 
-def main() -> None:
-    root = Path("CleanSweep")
+def main(base_dir: str | Path = ".") -> None:
+    base_dir = Path(base_dir)
+    root = base_dir / "CleanSweep"
     runs = load_runs(root)
-    aoa_sweep_analysis(runs, Path("aoa_sweep_results"))
+    aoa_sweep_analysis(runs, base_dir / "aoa_sweep_results")
 
 
 if __name__ == "__main__":

--- a/scripts/clean_sweep_creation.py
+++ b/scripts/clean_sweep_creation.py
@@ -8,18 +8,20 @@ from glacium.utils.logging import log
 from full_power_gci import load_runs, gci_analysis2
 
 
-def main() -> None:
+def main(base_dir: str | Path = ".") -> None:
     """Create AOA sweep projects using the best grid from the GCI study."""
 
-    runs = load_runs(Path("GridDependencyStudy"))
-    result = gci_analysis2(runs, Path("grid_dependency_results"))
+    base_dir = Path(base_dir)
+
+    runs = load_runs(base_dir / "GridDependencyStudy")
+    result = gci_analysis2(runs, base_dir / "grid_dependency_results")
     if result is None:
         return
 
     _, _, best_proj = result
     mesh_path = Project.get_mesh(best_proj)
 
-    base = Project("CleanSweep").name("aoa_sweep")
+    base = Project(base_dir / "CleanSweep").name("aoa_sweep")
     base.set("RECIPE", "fensap")
     base.set("CASE_CHARACTERISTIC_LENGTH", best_proj.get("CASE_CHARACTERISTIC_LENGTH"))
     base.set("CASE_VELOCITY", best_proj.get("CASE_VELOCITY"))

--- a/scripts/full_power.py
+++ b/scripts/full_power.py
@@ -1,26 +1,39 @@
 from __future__ import annotations
 
-from full_power_creation import main as create_runs
-from full_power_gci import main as analyze_gci
-from clean_sweep_creation import main as run_clean_sweep
-from clean_sweep_analysis import main as analyze_clean_sweep
-from multishot_creation import main as create_multishot
-from multishot_analysis import main as analyze_multishot
-from iced_sweep_creation import main as run_iced_sweep
-from iced_sweep_analysis import main as analyze_iced_sweep
-from polar_compare import main as compare_polars
+from pathlib import Path
+
+import full_power_creation
+import full_power_gci
+import clean_sweep_creation
+import clean_sweep_analysis
+import multishot_creation
+import multishot_analysis
+import iced_sweep_creation
+import iced_sweep_analysis
+import polar_compare
 
 
-def main() -> None:
-    create_runs()
-    analyze_gci()
-    run_clean_sweep()
-    analyze_clean_sweep()
-    create_multishot()
-    analyze_multishot()
-    run_iced_sweep()
-    analyze_iced_sweep()
-    compare_polars()
+def main(base_dir: str = "Study1") -> None:
+    study_root = Path(base_dir)
+
+    case_vars = {
+        "CASE_CHARACTERISTIC_LENGTH": 0.431,
+        "CASE_VELOCITY": 20,
+        "CASE_ALTITUDE": 100,
+        "CASE_TEMPERATURE": 263.15,
+        "CASE_AOA": 0,
+        "CASE_YPLUS": 0.3,
+    }
+
+    full_power_creation.main(study_root, case_vars=case_vars)
+    full_power_gci.main(study_root)
+    clean_sweep_creation.main(study_root)
+    clean_sweep_analysis.main(study_root)
+    multishot_creation.main(study_root)
+    multishot_analysis.main(study_root)
+    iced_sweep_creation.main(study_root)
+    iced_sweep_analysis.main(study_root)
+    polar_compare.main(study_root)
 
 
 if __name__ == "__main__":

--- a/scripts/full_power_creation.py
+++ b/scripts/full_power_creation.py
@@ -1,16 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
 from glacium.api import Project
 from glacium.utils.logging import log
 
 
-def main() -> None:
+def main(
+    base_dir: str | Path = ".",
+    case_vars: Mapping[str, Any] | None = None,
+) -> None:
     """Create and run grid refinement projects."""
-    base = Project("GridDependencyStudy").name("grid")
-    base.set("CASE_CHARACTERISTIC_LENGTH", 0.431)
-    base.set("CASE_VELOCITY", 20)
-    base.set("CASE_ALTITUDE", 100)
-    base.set("CASE_TEMPERATURE", 263.15)
-    base.set("CASE_AOA", 0)
-    base.set("CASE_YPLUS", 0.3)
+
+    base_dir = Path(base_dir)
+
+    defaults: dict[str, Any] = {
+        "CASE_CHARACTERISTIC_LENGTH": 0.431,
+        "CASE_VELOCITY": 20,
+        "CASE_ALTITUDE": 100,
+        "CASE_TEMPERATURE": 263.15,
+        "CASE_AOA": 0,
+        "CASE_YPLUS": 0.3,
+    }
+    params = {**defaults, **(case_vars or {})}
+
+    base = Project(base_dir / "GridDependencyStudy").name("grid")
+    for key, value in params.items():
+        base.set(key, value)
 
     base_jobs = [
         "XFOIL_REFINE",

--- a/scripts/full_power_gci.py
+++ b/scripts/full_power_gci.py
@@ -441,10 +441,11 @@ def generate_gci_pdf_report(
     print(f"✅ PDF report created: {out_pdf}")
 
 
-def main() -> None:
-    root = Path("GridDependencyStudy")
+def main(base_dir: str | Path = ".") -> None:
+    base_dir = Path(base_dir)
+    root = base_dir / "GridDependencyStudy"
     runs = load_runs(root)
-    gci_analysis2(runs, Path("grid_dependency_results"))
+    gci_analysis2(runs, base_dir / "grid_dependency_results")
 
 
 

--- a/scripts/iced_sweep_analysis.py
+++ b/scripts/iced_sweep_analysis.py
@@ -109,10 +109,11 @@ def aoa_sweep_analysis(runs: list[tuple[float, float, float, float, Project]], o
     plt.close(fig)
 
 
-def main() -> None:
-    root = Path("IcedSweep")
+def main(base_dir: str | Path = ".") -> None:
+    base_dir = Path(base_dir)
+    root = base_dir / "IcedSweep"
     runs = load_runs(root)
-    aoa_sweep_analysis(runs, Path("aoa_sweep_results_iced"))
+    aoa_sweep_analysis(runs, base_dir / "aoa_sweep_results_iced")
 
 
 if __name__ == "__main__":

--- a/scripts/iced_sweep_creation.py
+++ b/scripts/iced_sweep_creation.py
@@ -25,12 +25,14 @@ def get_last_iced_grid(project: Project) -> Path:
     return best[1]
 
 
-def main() -> None:
+def main(base_dir: str | Path = ".") -> None:
     """Create AOA sweep using the last iced grid from the multishot project."""
-    ms_project = load_multishot_project(Path("Multishot"))
+    base_dir = Path(base_dir)
+
+    ms_project = load_multishot_project(base_dir / "Multishot")
     grid_path = get_last_iced_grid(ms_project)
 
-    base = Project("IcedSweep").name("aoa_sweep")
+    base = Project(base_dir / "IcedSweep").name("aoa_sweep")
     base.set("RECIPE", "fensap")
     base.set("CASE_CHARACTERISTIC_LENGTH", ms_project.get("CASE_CHARACTERISTIC_LENGTH"))
     base.set("CASE_VELOCITY", ms_project.get("CASE_VELOCITY"))

--- a/scripts/multishot_analysis.py
+++ b/scripts/multishot_analysis.py
@@ -44,11 +44,12 @@ def plot_cl_cd(csv_file: Path, out_dir: Path) -> None:
     plt.close()
 
 
-def main() -> None:
-    project_root = Path("Multishot")
+def main(base_dir: str | Path = ".") -> None:
+    base_dir = Path(base_dir)
+    project_root = base_dir / "Multishot"
     project = load_multishot_project(project_root)
     csv_path = project.root / "analysis" / "MULTISHOT" / "cl_cd_stats.csv"
-    plot_cl_cd(csv_path, Path("multishot_results"))
+    plot_cl_cd(csv_path, base_dir / "multishot_results")
 
 
 if __name__ == "__main__":

--- a/scripts/multishot_creation.py
+++ b/scripts/multishot_creation.py
@@ -30,18 +30,20 @@ def _run_project(base: Project, mesh: Path, count: int) -> None:
     log.info(f"Completed multishot project {proj.uid} ({count} shots)")
 
 
-def main() -> None:
+def main(base_dir: str | Path = ".") -> None:
     """Create and run several multishot projects using the best grid."""
 
-    runs = load_runs(Path("GridDependencyStudy"))
-    result = gci_analysis2(runs, Path("grid_dependency_results"))
+    base_dir = Path(base_dir)
+
+    runs = load_runs(base_dir / "GridDependencyStudy")
+    result = gci_analysis2(runs, base_dir / "grid_dependency_results")
     if result is None:
         return
 
     _, _, best_proj = result
     mesh_path = Project.get_mesh(best_proj)
 
-    base = Project("Multishot").name("multishot")
+    base = Project(base_dir / "Multishot").name("multishot")
     base.set("CASE_CHARACTERISTIC_LENGTH", best_proj.get("CASE_CHARACTERISTIC_LENGTH"))
     base.set("CASE_VELOCITY", best_proj.get("CASE_VELOCITY"))
     base.set("CASE_ALTITUDE", best_proj.get("CASE_ALTITUDE"))

--- a/scripts/polar_compare.py
+++ b/scripts/polar_compare.py
@@ -71,12 +71,13 @@ def plot_combined(
     plt.close(fig)
 
 
-def main() -> None:
-    clean_csv = Path("aoa_sweep_results") / "polar.csv"
-    iced_csv = Path("aoa_sweep_results_iced") / "polar.csv"
+def main(base_dir: str | Path = ".") -> None:
+    base_dir = Path(base_dir)
+    clean_csv = base_dir / "aoa_sweep_results" / "polar.csv"
+    iced_csv = base_dir / "aoa_sweep_results_iced" / "polar.csv"
     clean = load_csv(clean_csv)
     iced = load_csv(iced_csv)
-    plot_combined(clean, iced, Path("polar_combined_results"))
+    plot_combined(clean, iced, base_dir / "polar_combined_results")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow specifying a base directory for all full_power scripts
- propagate case configuration from `full_power.py`
- adjust all helper scripts to use the provided study directory

## Testing
- `pip install numpy pyyaml --quiet`
- `pytest tests/test_full_power_gci.py::test_load_runs_reads_results -q` *(fails: ModuleNotFoundError: No module named 'verboselogs')*

------
https://chatgpt.com/codex/tasks/task_e_68873dc134648327803a6d6a042126a4