### PR TITLE
Add base_dir option in full_power_gci main

### DIFF
--- a/scripts/full_power_gci.py
+++ b/scripts/full_power_gci.py
@@ -441,10 +441,11 @@ def generate_gci_pdf_report(
     print(f"✅ PDF report created: {out_pdf}")
 
 
-def main() -> None:
-    root = Path("GridDependencyStudy")
+def main(base_dir: Path | str = Path("")) -> None:
+    base = Path(base_dir)
+    root = base / "GridDependencyStudy"
     runs = load_runs(root)
-    gci_analysis2(runs, Path("grid_dependency_results"))
+    gci_analysis2(runs, base / "grid_dependency_results")
 
 
 


### PR DESCRIPTION
## Summary
- add an optional `base_dir` argument for `main()` in `scripts/full_power_gci.py`
- results and input directories are now derived from the supplied path

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'veusz' and others)*

------
https://chatgpt.com/codex/tasks/task_e_688742a188408327abf051c9707ab27f