### PR TITLE
Add base_dir parameter to sweep scripts

### DIFF
--- a/scripts/clean_sweep_analysis.py
+++ b/scripts/clean_sweep_analysis.py
@@ -109,10 +109,13 @@ def aoa_sweep_analysis(runs: list[tuple[float, float, float, float, Project]], o
     plt.close(fig)
 
 
-def main() -> None:
-    root = Path("CleanSweep")
+def main(base_dir: Path | str = Path("")) -> None:
+    """Analyze a clean sweep located under ``base_dir``."""
+
+    base = Path(base_dir)
+    root = base / "CleanSweep"
     runs = load_runs(root)
-    aoa_sweep_analysis(runs, Path("aoa_sweep_results"))
+    aoa_sweep_analysis(runs, base / "aoa_sweep_results")
 
 
 if __name__ == "__main__":

--- a/scripts/iced_sweep_analysis.py
+++ b/scripts/iced_sweep_analysis.py
@@ -109,10 +109,13 @@ def aoa_sweep_analysis(runs: list[tuple[float, float, float, float, Project]], o
     plt.close(fig)
 
 
-def main() -> None:
-    root = Path("IcedSweep")
+def main(base_dir: Path | str = Path("")) -> None:
+    """Analyze an iced sweep located under ``base_dir``."""
+
+    base = Path(base_dir)
+    root = base / "IcedSweep"
     runs = load_runs(root)
-    aoa_sweep_analysis(runs, Path("aoa_sweep_results_iced"))
+    aoa_sweep_analysis(runs, base / "aoa_sweep_results_iced")
 
 
 if __name__ == "__main__":

--- a/scripts/multishot_analysis.py
+++ b/scripts/multishot_analysis.py
@@ -44,11 +44,14 @@ def plot_cl_cd(csv_file: Path, out_dir: Path) -> None:
     plt.close()
 
 
-def main() -> None:
-    project_root = Path("Multishot")
+def main(base_dir: Path | str = Path("")) -> None:
+    """Analyze a multishot project located under ``base_dir``."""
+
+    base = Path(base_dir)
+    project_root = base / "Multishot"
     project = load_multishot_project(project_root)
     csv_path = project.root / "analysis" / "MULTISHOT" / "cl_cd_stats.csv"
-    plot_cl_cd(csv_path, Path("multishot_results"))
+    plot_cl_cd(csv_path, base / "multishot_results")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `base_dir` and `case_vars` parameters to sweep creation scripts
- allow analysis scripts to run under a custom base directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688749725c448327ad89ed0b9102dcf4