### PR TITLE
Update polar_compare for flexible base directory

### DIFF
--- a/scripts/polar_compare.py
+++ b/scripts/polar_compare.py
@@ -71,12 +71,20 @@ def plot_combined(
     plt.close(fig)
 
 
-def main() -> None:
-    clean_csv = Path("aoa_sweep_results") / "polar.csv"
-    iced_csv = Path("aoa_sweep_results_iced") / "polar.csv"
+def main(base_dir: Path | str = Path("")) -> None:
+    """Compare polar curves located under ``base_dir``."""
+
+    base = Path(base_dir)
+    result_dirs = sorted(base.glob("aoa_sweep_results*"))
+    if len(result_dirs) < 2:
+        raise FileNotFoundError("not enough result directories found")
+
+    clean_csv = result_dirs[0] / "polar.csv"
+    iced_csv = result_dirs[1] / "polar.csv"
+
     clean = load_csv(clean_csv)
     iced = load_csv(iced_csv)
-    plot_combined(clean, iced, Path("polar_combined_results"))
+    plot_combined(clean, iced, base / "polar_combined_results")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- make `polar_compare` accept a base directory
- load sweep results with a glob to locate `polar.csv`
- write plots next to the sweeps in `polar_combined_results`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'veusz', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68874cd257648327a84195bdb14b2f14