### PR TITLE
Update GCI efficiency calculations

### DIFF
--- a/docs/grid_dependency_study.rst
+++ b/docs/grid_dependency_study.rst
@@ -55,3 +55,8 @@ entries.  If these values are missing, ``full_power_gci.py`` falls back to
 parsing the convergence history under ``analysis/FENSAP`` and computes the
 statistics via :func:`glacium.utils.convergence.project_cl_cd_stats`.
 
+Each three-grid window yields observed orders ``p`` and GCIs for lift and drag.
+Negative ``p`` or negative GCI mark a grid triplet as invalid.  For valid
+triplets the efficiency index ``E = \mathrm{GCI} \times t`` is computed for both
+coefficients.  The grid with the lowest ``E`` is recommended.
+


### PR DESCRIPTION
## Summary
- compute efficiency index for both lift and drag GCIs
- mark triplets invalid if order or GCI is negative
- select recommended grid based on lowest valid efficiency
- show E(CL) and E(CD) in PDF report table and README docs

## Testing
- `pytest tests/test_full_power_gci.py::test_load_runs_reads_results -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_6889c21bee988327855cc478dc571b2d