### PR TITLE
Improve GCI best-triplet selection

### DIFF
--- a/docs/grid_dependency_study.rst
+++ b/docs/grid_dependency_study.rst
@@ -58,6 +58,7 @@ statistics via :func:`glacium.utils.convergence.project_cl_cd_stats`.
 Each three-grid window yields observed orders ``p`` and GCIs for lift and drag.
 Negative ``p`` or negative GCI mark the affected coefficient as invalid for that
 triplet.  Valid coefficients still contribute to the efficiency index
-``E = \mathrm{GCI} \times t``.  The grid with the lowest ``E`` across all valid
-coefficients is recommended.
+``E = \mathrm{GCI} \times t``.  The recommended grid is selected based on the
+lowest ``E`` for lift (``CL``) while the drag results are reported for
+reference only.
 


### PR DESCRIPTION
## Summary
- choose the recommended grid based only on E(CL)
- highlight best CL and CD triplets in all GCI plots
- document new behaviour
- regression test for CL-based selection

## Testing
- `python -m py_compile scripts/full_power_gci.py`
- `python -m py_compile tests/test_full_power_gci.py`
- `pytest tests/test_full_power_gci.py -k test_best_triplet_selected_from_cl -q` *(fails: ModuleNotFoundError: No module named 'trimesh')*


------
https://chatgpt.com/codex/tasks/task_e_6889c847a6f08327973ed6dc1ba4e357