### PR TITLE
Add FENSAP run helper script

### DIFF
--- a/scripts/test_02_fensap.py
+++ b/scripts/test_02_fensap.py
@@ -1,0 +1,39 @@
+"""Run a FENSAP case using a pre-generated mesh."""
+
+from __future__ import annotations
+
+import argparse
+
+from glacium.api import Project
+
+
+def main() -> None:
+    """Execute a FENSAP run with a copied mesh and limited steps."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mesh-root", default="MeshRuns")
+    parser.add_argument("--mesh-uid", required=True)
+    parser.add_argument("--max-steps", type=int, default=700)
+    parser.add_argument("--out-root", default="FensapRuns")
+    args = parser.parse_args()
+
+    mesh_proj = Project.load(args.mesh_root, args.mesh_uid)
+    mesh_path = Project.get_mesh(mesh_proj)
+
+    proj = Project(args.out_root).create()
+    Project.set_mesh(mesh_path, proj)
+
+    proj.set("FSP_MAX_TIME_STEPS_PER_CYCLE", args.max_steps)
+    try:
+        proj.set("FSP_GUI_FENSAP_MAX_TIME_STEPS_PER_CYCLE", args.max_steps)
+    except KeyError:
+        pass
+
+    proj.add_job("FENSAP_RUN")
+    proj.run()
+    print(proj.uid)
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    main()
+


### PR DESCRIPTION
## Summary
- add script to run FENSAP with mesh copy and step-limit

## Testing
- `pytest tests/test_analysis_tools.py::test_dummy -q` *(fails: ModuleNotFoundError: No module named 'trimesh')*
- `pytest tests/test_single_convergence_stats.py::test_dummy -q` *(fails: ModuleNotFoundError: No module named 'PyPDF2')*


------
https://chatgpt.com/codex/tasks/task_e_688df1b451a88327b52e5ed242afb635