### PR TITLE
Add multishot project analysis utilities

### DIFF
--- a/scripts/multishot_analysis.py
+++ b/scripts/multishot_analysis.py
@@ -1,209 +1,106 @@
-#!/usr/bin/env python3
-"""
-stl_dat_surface_plot.py
------------------------
+from __future__ import annotations
 
-Generates *s*‑curves over an STL surface and plots variables from the first
-Tecplot‑*.dat* zone. Each curve is saved as a PNG.
+"""Simple helpers to analyse multishot projects.
 
-What’s new (2025‑07‑30)
-~~~~~~~~~~~~~~~~~~~~~~~
-* **Custom start point**   Choose the parametric direction explicitly.
-  * `--axis pca|x|y|z`   direction used for ordering (default *pca*).
-  * `--reverse`           start at the *other* end of the selected axis.
-
-Typical calls
-~~~~~~~~~~~~~
-    # All variables, start at min‑X end, save in plots/
-    python stl_dat_surface_plot.py ice.stl results.dat \
-           --all --axis x --save-dir plots
-
-    # Single variable, start at max along PCA direction
-    python stl_dat_surface_plot.py ice.stl results.dat \
-           --var-index 2 --reverse
-
-Key options (unchanged)
-~~~~~~~~~~~~~~~~~~~~~~~
-* `--all`          plot **every** extra variable beyond X,Y,Z.
-* `--var-index`    plot only the given variable (integer).
-* `--save-dir`     target folder for PNGs (auto‑created).
-* `--dpi`          image resolution (default 300).
-
-Dependencies
-~~~~~~~~~~~~
-    numpy ≥ 2.0, scipy, matplotlib, trimesh, scikit‑learn
-Install with
-`pip install numpy scipy matplotlib trimesh scikit-learn`.
+The module exposes :func:`load_multishot_project` to locate the multishot
+project with the highest ``MULTISHOT_COUNT`` and a small :func:`main` entry
+point mirroring the behaviour of :mod:`scripts.single_shot_analysis`.
 """
 
-import argparse
-import re
-import sys
 from pathlib import Path
+import shutil
 
-import numpy as np
+import pandas as pd
 import matplotlib.pyplot as plt
-import trimesh
-from scipy.spatial import cKDTree
-from sklearn.decomposition import PCA
+import scienceplots
 
-# --------------------------------------------------------------------------- #
-# Tecplot *.dat* utilities
-# --------------------------------------------------------------------------- #
-TEC_VARIABLE_RE = re.compile(r'VARIABLES\s*=\s*(.*)', re.IGNORECASE)
-TEC_ZONE_RE = re.compile(r'ZONE[^\n]*N\s*=\s*(\d+)[^\n]*', re.IGNORECASE)
-FORTRAN_BARE_EXP_RE = re.compile(r'^([+-]?\d*\.?\d*)([+-]\d+)$')
+from glacium.api import Project
+from glacium.managers.project_manager import ProjectManager
+from glacium.utils.logging import log
+from glacium.post import analysis as post_analysis
 
 
-def _split_quoted_list(s: str):
-    parts, current, in_quotes = [], [], False
-    for ch in s:
-        if ch == '"':
-            in_quotes = not in_quotes
-            continue
-        if ch == ',' and not in_quotes:
-            parts.append(''.join(current).strip())
-            current = []
-        else:
-            current.append(ch)
-    if current:
-        parts.append(''.join(current).strip())
-    return parts
+plt.style.use(["science", "ieee"])
 
 
-def _to_float(tok: str) -> float:
-    tok = tok.strip().replace('D', 'E').replace('d', 'E')
-    if 'E' in tok or 'e' in tok:
-        return float(tok)
-    m = FORTRAN_BARE_EXP_RE.match(tok)
-    if m:
-        mant, exp = m.groups()
-        return float(f"{mant}E{exp}")
-    return float(tok)
-
-
-def read_first_zone_dat(path: Path):
-    coords, variables = [], []
-    var_names = None
-    text = path.read_text(encoding='utf‑8', errors='ignore')
-    m = TEC_VARIABLE_RE.search(text)
-    if m:
-        var_names = _split_quoted_list(m.group(1))
-    zone_m = TEC_ZONE_RE.search(text)
-    if not zone_m:
-        raise ValueError('No ZONE header found.')
-    n_nodes = int(zone_m.group(1))
-    lines = text[zone_m.end():].lstrip().splitlines()[:n_nodes]
-    for ln in lines:
-        nums = [_to_float(t) for t in re.split(r'[\s,]+', ln.strip()) if t]
-        coords.append(nums[:3])
-        variables.append(nums[3:])
-    return np.array(coords), np.array(variables), var_names
-
-# --------------------------------------------------------------------------- #
-# STL path utilities
-# --------------------------------------------------------------------------- #
-
-def make_path_from_vertices(verts: np.ndarray, axis: str = 'pca', reverse: bool = False):
-    """Return cumulative arc‑length *s* for each vertex.
+def load_multishot_project(root: Path) -> Project:
+    """Return multishot project with the highest ``MULTISHOT_COUNT``.
 
     Parameters
     ----------
-    axis : 'pca' | 'x' | 'y' | 'z'
-        Direction used for ordering vertices.
-    reverse : bool
-        If *True*, start at the opposite end.
+    root:
+        Directory containing multishot projects.
+
+    Returns
+    -------
+    Project
+        Loaded :class:`~glacium.api.Project` instance.
     """
-    verts_u, inv = np.unique(verts, axis=0, return_inverse=True)
 
-    if axis == 'pca':
-        t = PCA(1).fit_transform(verts_u).ravel()
-    else:
-        idx = {'x': 0, 'y': 1, 'z': 2}[axis]
-        t = verts_u[:, idx]
+    pm = ProjectManager(root)
+    uids = pm.list_uids()
+    if not uids:
+        raise FileNotFoundError(f"No projects found in {root}")
 
-    order = np.argsort(t)
-    if reverse:
-        order = order[::-1]
+    best_uid = uids[0]
+    best_count = -1
+    for uid in uids:
+        try:
+            proj = Project.load(root, uid)
+            count = int(proj.get("MULTISHOT_COUNT"))
+        except Exception:
+            count = -1
+        if count > best_count:
+            best_uid = uid
+            best_count = count
 
-    ordered = verts_u[order]
-    seg_lens = np.linalg.norm(np.diff(ordered, axis=0), axis=1)
-    s = np.concatenate([[0.0], np.cumsum(seg_lens)])
-    if np.ptp(ordered) > 10.0:  # assume mm → m
-        s *= 1e-3
-    return s, order, inv
+    return Project.load(root, best_uid)
 
 
-def load_stl_vertices(path: Path):
-    mesh = trimesh.load_mesh(str(path))
-    if not isinstance(mesh, trimesh.Trimesh):
-        raise ValueError('STL contains multiple solids.')
-    return mesh.vertices
+def analyze_project(proj: Project, out_dir: Path) -> None:
+    """Collect basic analysis artefacts for a multishot project."""
 
-# --------------------------------------------------------------------------- #
-# Plot util
-# --------------------------------------------------------------------------- #
+    out_dir.mkdir(parents=True, exist_ok=True)
+    ms_dir = proj.root / "analysis" / "MULTISHOT"
 
-def _safe_name(name: str):
-    return re.sub(r'[^0-9A-Za-z._-]+', '_', name)
+    cp_results: list[tuple[str, pd.DataFrame]] = []
+    cmu_rows: list[tuple[str, float]] = []
 
-# --------------------------------------------------------------------------- #
-# Main
-# --------------------------------------------------------------------------- #
+    for csv_file in sorted(ms_dir.glob("soln.fensap.*_cp.csv")):
+        try:
+            df = pd.read_csv(csv_file)
+        except Exception:
+            continue
+        label = csv_file.stem.replace("_cp", "")
+        cp_results.append((label, df))
+        cmu_rows.append((label, float(post_analysis.momentum_coefficient(df))))
 
-def main(argv=None):
-    p = argparse.ArgumentParser(description='Plot Tecplot variables along STL‑surface s.')
-    p.add_argument('stl', type=Path)
-    p.add_argument('dat', type=Path)
-    p.add_argument('--var-index', type=int, default=0,
-                   help='Single variable index (0‑based, extras only)')
-    p.add_argument('--all', action='store_true', help='Plot all extra variables')
-    p.add_argument('--axis', choices=['pca', 'x', 'y', 'z'], default='pca',
-                   help='Axis/direction for parametrisation (default: pca)')
-    p.add_argument('--reverse', action='store_true',
-                   help='Start at the opposite end')
-    p.add_argument('--save-dir', type=Path, default=Path('.'),
-                   help='Directory to save PNGs (created if missing)')
-    p.add_argument('--dpi', type=int, default=300)
-    args = p.parse_args(argv)
+    if cp_results:
+        post_analysis.plot_cp_overlay(cp_results, out_dir / "cp_overlay.png")
+        pd.DataFrame(cmu_rows, columns=["step", "C_mu"]).to_csv(
+            out_dir / "momentum.csv", index=False
+        )
 
-    verts = load_stl_vertices(args.stl)
-    s_verts, order, inv = make_path_from_vertices(verts, args.axis, args.reverse)
+    gif = ms_dir / "ice_growth.gif"
+    if gif.exists():
+        shutil.copy2(gif, out_dir / gif.name)
 
-    coords, vars_, names = read_first_zone_dat(args.dat)
-    if vars_.size == 0:
-        sys.exit('No variables beyond X,Y,Z found.')
 
-    indices = range(vars_.shape[1]) if args.all else [args.var_index]
-    if max(indices) >= vars_.shape[1]:
-        sys.exit('var-index out of range.')
+def main(base_dir: Path | str = Path("")) -> None:
+    """Entry point used by other scripts and the command line."""
 
-    tree = cKDTree(verts)
-    _, nearest = tree.query(coords)
-    s_nodes = s_verts[inv[nearest]]
+    base = Path(base_dir)
+    root = base / "Multishot"
 
-    args.save_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        proj = load_multishot_project(root)
+    except FileNotFoundError as err:
+        log.error(str(err))
+        return
 
-    for idx in indices:
-        y = vars_[:, idx]
-        seq = np.argsort(s_nodes)
-        s_sorted, y_sorted = s_nodes[seq], y[seq]
+    analyze_project(proj, base / "multishot_results")
 
-        fig, ax = plt.subplots(figsize=(8, 4))
-        ax.plot(s_sorted, y_sorted)
-        ax.set_xlabel('s  [m]')
-        label = (names[3+idx] if names and len(names) > 3+idx else f'Var{idx}')
-        ax.set_ylabel(label)
-        ax.grid(True)
-        fig.tight_layout()
 
-        fname = args.save_dir / f"{args.dat.stem}_{_safe_name(label)}.png"
-        fig.savefig(fname, dpi=args.dpi)
-        print(f'Saved {fname}')
-        plt.close(fig)
-
-    if not args.all:
-        print('Finished single‑variable plot.')
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Summary
- replace previous multishot_analysis script with module for multishot project analysis
- add loader selecting project with highest MULTISHOT_COUNT
- provide cp overlay plotting and momentum coefficient export

## Testing
- `PYTHONPATH=. python scripts/multishot_analysis.py`
- `PYTHONPATH=. python scripts/iced_sweep_creation.py` *(fails: No projects found in Multishot)*
- `PYTHONPATH=. python scripts/full_power.py --help`
- `PYTHONPATH=. pytest tests` *(fails: TemplateNotFound: 'FENSAP.ICE3D.create-2.5D-mesh.bin.j2'; AssertionError: PosixPath('/tmp/pytest-of-root/pytest...)*

------
https://chatgpt.com/codex/tasks/task_e_688e6d9632e08327b719c84ba4147160