### PR TITLE
Refactor multishot timing handling

### DIFF
--- a/glacium/engines/fensap.py
+++ b/glacium/engines/fensap.py
@@ -78,7 +78,12 @@ class FensapScriptJob(Job):
         defaults_file = global_default_config()
         defaults = yaml.safe_load(defaults_file.read_text()) if defaults_file.exists() else {}
         cfg = self.project.config
-        return {**defaults, **cfg.extras}
+        ctx = {**defaults, **cfg.extras}
+        if "ICE_GUI_TOTAL_TIME" not in ctx:
+            timings = cfg.get("CASE_MULTISHOT")
+            if isinstance(timings, list) and timings:
+                ctx["ICE_GUI_TOTAL_TIME"] = timings[0]
+        return ctx
 
     @log_call
     def execute(self) -> None:  # noqa: D401

--- a/glacium/jobs/fensap_jobs.py
+++ b/glacium/jobs/fensap_jobs.py
@@ -101,16 +101,13 @@ class MultiShotRunJob(FensapScriptJob):
         for tpl, dest in self.templates.items():
             tm.render_to_file(tpl, ctx, work / dest)
 
-        count = self.project.config.get("MULTISHOT_COUNT", 10)
         timings = self.project.config.get("CASE_MULTISHOT")
+        if not isinstance(timings, list) or not timings:
+            timings = [ctx.get("ICE_GUI_TOTAL_TIME")]
+        count = len(timings)
         start = 0.0
-        default_total = ctx.get("ICE_GUI_TOTAL_TIME")
         for i in range(1, count + 1):
-            total = (
-                timings[i - 1]
-                if isinstance(timings, list) and i - 1 < len(timings)
-                else default_total
-            )
+            total = timings[i - 1]
             shot_ctx = {
                 **ctx,
                 "shot_index": f"{i:06d}",
@@ -118,9 +115,9 @@ class MultiShotRunJob(FensapScriptJob):
                 "next_shot_index": f"{i+1:06d}",
                 "ICE_GUI_INITIAL_TIME": start,
                 "ICE_GUI_TOTAL_TIME": total,
-                "ICE_NUMBER_TIME_STEP": int(total*1000),
+                "ICE_NUMBER_TIME_STEP": int(total * 1000),
                 "ICE_GUI_TIME_BETWEEN_OUTPUT": total,
-                "ICE_TIME_STEP_BETWEEN_OUTPUT": int(total*1000),
+                "ICE_TIME_STEP_BETWEEN_OUTPUT": int(total * 1000),
                 "FSP_GUI_INITIAL_TYPE": 1 if i == 1 else 2,
                 "DRP_GUI_INITIAL_TYPE": 1 if i == 1 else 2,
                 "FSP_GUI_ROUGHNESS_TYPE": 1 if i == 1 else 4,

--- a/glacium/templates/MULTISHOT.solvercmd.j2
+++ b/glacium/templates/MULTISHOT.solvercmd.j2
@@ -19,7 +19,8 @@ fi
 # Remove files for a clean solver start
 if [ $STEP -eq 0 ]; then
   rm -f roughness.dat
-{% for shot in range(1, MULTISHOT_COUNT+1) %}
+{% for _ in CASE_MULTISHOT %}
+  {% set shot = loop.index %}
   rm -f soln.fensap.{{ '%06d' % shot }}
   rm -f surface.dat.fensap.{{ '%06d' % shot }}
   rm -f hflux.dat.fensap.{{ '%06d' % shot }}
@@ -53,7 +54,8 @@ if [ $STEP -eq 0 ]; then
   rm -f shell.cas
 fi
 
-{% for shot in range(1, MULTISHOT_COUNT+1) %}
+{% for _ in CASE_MULTISHOT %}
+{% set shot = loop.index %}
 {% set shot1 = '%06d' % shot %}
 {% set shot2 = '%06d' % (shot + 1) %}
 {% set step = (shot - 1) * 4 %}
@@ -117,7 +119,7 @@ if [ $STEP -eq {{ step + 3}} ]; then
     sleep 1
     exit 1
   fi
-{% if shot < MULTISHOT_COUNT %}
+{% if not loop.last %}
   STEP={{ step + 4}}
   echo $STEP > .restart
 {% else %}

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -348,7 +348,7 @@ def test_multishot_run_job_renders_batch(monkeypatch, tmp_path, count):
 
     cfg = GlobalConfig(project_uid="uid", base_dir=tmp_path)
     cfg["FENSAP_EXE"] = "sh"
-    cfg["MULTISHOT_COUNT"] = count
+    cfg["CASE_MULTISHOT"] = [1] * count
 
     paths = PathBuilder(tmp_path).build()
     paths.ensure()
@@ -398,7 +398,7 @@ def test_multishot_initial_type(monkeypatch, tmp_path):
 
     cfg = GlobalConfig(project_uid="uid", base_dir=tmp_path)
     cfg["FENSAP_EXE"] = "sh"
-    cfg["MULTISHOT_COUNT"] = 3
+    cfg["CASE_MULTISHOT"] = [1, 1, 1]
 
     paths = PathBuilder(tmp_path).build()
     paths.ensure()
@@ -450,7 +450,7 @@ def test_multishot_drop_initial_type_and_timebc(monkeypatch, tmp_path):
 
     cfg = GlobalConfig(project_uid="uid", base_dir=tmp_path)
     cfg["FENSAP_EXE"] = "sh"
-    cfg["MULTISHOT_COUNT"] = 3
+    cfg["CASE_MULTISHOT"] = [1, 1, 1]
 
     paths = PathBuilder(tmp_path).build()
     paths.ensure()
@@ -501,7 +501,7 @@ def test_multishot_roughness_and_laplace(monkeypatch, tmp_path):
 
     cfg = GlobalConfig(project_uid="uid", base_dir=tmp_path)
     cfg["FENSAP_EXE"] = "sh"
-    cfg["MULTISHOT_COUNT"] = 3
+    cfg["CASE_MULTISHOT"] = [1, 1, 1]
 
     paths = PathBuilder(tmp_path).build()
     paths.ensure()
@@ -553,7 +553,7 @@ def test_multishot_global_laplace_is_ignored_first_shot(monkeypatch, tmp_path):
 
     cfg = GlobalConfig(project_uid="uid", base_dir=tmp_path)
     cfg["FENSAP_EXE"] = "sh"
-    cfg["MULTISHOT_COUNT"] = 2
+    cfg["CASE_MULTISHOT"] = [1, 1]
     cfg["FSP_MAX_LAPLACE_ITERATIONS"] = 9
 
     paths = PathBuilder(tmp_path).build()

--- a/tests/test_multishot_timings.py
+++ b/tests/test_multishot_timings.py
@@ -42,7 +42,6 @@ def test_multishot_timings(monkeypatch, tmp_path):
 
     cfg = GlobalConfig(project_uid="uid", base_dir=tmp_path)
     cfg["FENSAP_EXE"] = "sh"
-    cfg["MULTISHOT_COUNT"] = 3
     cfg["CASE_MULTISHOT"] = [1, 2, 3]
 
     paths = PathBuilder(tmp_path).build()


### PR DESCRIPTION
## Summary
- derive multi-shot timings from CASE_MULTISHOT entries
- iterate templates based on CASE_MULTISHOT and remove MULTISHOT_COUNT usage
- adjust tests for CASE_MULTISHOT-driven multi-shot timing

## Testing
- `pytest tests/test_engines.py -k multishot_run_job_renders_batch` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_688f41f9e5fc8327b7cb790859715629