### PR TITLE
Use multishot timing for ICE defaults

### DIFF
--- a/glacium/utils/case_to_global.py
+++ b/glacium/utils/case_to_global.py
@@ -52,7 +52,10 @@ def generate_global_defaults(case_path: Path, template_path: Path) -> Dict[str, 
     yplus = float(case.get("CASE_YPLUS"))
     refinement = float(case.get("PWS_REFINEMENT", cfg.get("PWS_REFINEMENT")))
     multishot = case.get("CASE_MULTISHOT")
-    ice_total = float(case.get("ICE_GUI_TOTAL_TIME", cfg.get("ICE_GUI_TOTAL_TIME")))
+    if multishot:
+        ice_total = float(multishot[0])
+    else:
+        ice_total = float(case.get("ICE_GUI_TOTAL_TIME", cfg.get("ICE_GUI_TOTAL_TIME")))
     # Ambient conditions ------------------------------------------------------
     pressure = _ambient_pressure(altitude)
     density = pressure / (287.05 * temperature)


### PR DESCRIPTION
## Summary
- derive ICE total time from first CASE_MULTISHOT entry
- preserve full multishot timing list in generated config

## Testing
- `pytest` *(fails: ERROR tests/test_engines.py, ERROR tests/test_fensap_analysis_job.py, ERROR tests/test_fensap_importers.py, ERROR tests/test_fluent2fensap_default.py, ERROR tests/test_full_power_gci.py, ERROR tests/test_job_add.py, ERROR tests/test_job_cli_numbers.py, ERROR tests/test_job_import_errors.py, ERROR tests/test_mesh_analysis_job.py, ERROR tests/test_multishot_timings.py, ERROR tests/test_post_analysis_callable.py, ERROR tests/test_postprocess_jobs.py, ERROR tests/test_postprocessor.py, ERROR tests/test_recipes.py, ERROR tests/test_run_all.py, ERROR tests/test_setup_api.py, ERROR tests/test_single_convergence_stats.py, ERROR tests/test_solver_convergence_stats_jobs.py)*

------
https://chatgpt.com/codex/tasks/task_e_688f44a101688327a09f6989bee5c8fc