### PR TITLE
feat(cli): support shot time sequences

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,12 @@ command provides `--help` for additional options.
 
 ```bash
 # create a new project from the default recipe
-glacium new MyWing
+glacium new MyWing --shot-time 10 --shot-time 20
 ```
 
-The multishot recipe runs ten solver cycles by default. Control the shot count
-via the ``CASE_MULTISHOT`` setting in ``case.yaml``.
+The multishot recipe runs ten solver cycles by default. Control the shot timings
+with ``--shot-time`` or by editing the ``CASE_MULTISHOT`` setting in
+``case.yaml``.
 
 The command prints the generated project UID. All projects live below
 `./runs/<UID>` in the current working directory. ``glacium new`` and ``glacium init`` parse ``case.yaml`` and write ``global_config.yaml`` automatically.
@@ -56,7 +57,8 @@ of icing times for each shot.
 ### Case sweep
 
 ```bash
-glacium case-sweep --param CASE_AOA=0,4 --param CASE_VELOCITY=50,100
+glacium case-sweep --shot-time 10 --shot-time 20 \
+    --param CASE_AOA=0,4 --param CASE_VELOCITY=50,100
 ```
 
 One project is created for each parameter combination and

--- a/docs/grid_dependency_study.rst
+++ b/docs/grid_dependency_study.rst
@@ -39,7 +39,7 @@ lift or drag after the runs have finished.
 After completion you can inspect the coefficients with
 :func:`glacium.utils.convergence.project_cl_cd_stats`.  The
 ``grid-convergence`` layout automatically runs a follow-up
-``prep+solver`` project and any provided ``--multishot`` sequences.  When
+``prep+solver`` project and any provided ``--shot-time`` sequences.  When
 sequences are present the ``multishot`` recipe is used and the results
 are stored in solver specific ``analysis/<solver>`` folders alongside the
 generated reports.

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -24,10 +24,10 @@ project from the default recipe and prints its unique identifier (UID):
 
 .. code-block:: bash
 
-   glacium new MyWing
+   glacium new MyWing --shot-time 10 --shot-time 20
 
-The multishot recipe uses ten solver cycles by default. Control the number by
-editing ``CASE_MULTISHOT`` in ``case.yaml``.
+The multishot recipe uses ten solver cycles by default. Control the timings with
+``--shot-time`` or by editing ``CASE_MULTISHOT`` in ``case.yaml``.
 
 To chain multiple recipes use ``+`` between their names, e.g.:
 
@@ -51,7 +51,8 @@ Create multiple projects for all combinations of parameters:
 
 .. code-block:: bash
 
-   glacium case-sweep --param CASE_AOA=0,4 --param CASE_VELOCITY=50,100 \
+   glacium case-sweep --shot-time 10 --shot-time 20 \
+       --param CASE_AOA=0,4 --param CASE_VELOCITY=50,100 \
        --param PWS_REFINEMENT=1,2
 
 The command prints the generated UIDs and writes ``global_config.yaml``

--- a/glacium/cli/case_sweep.py
+++ b/glacium/cli/case_sweep.py
@@ -31,6 +31,13 @@ DEFAULT_AIRFOIL = Path(__file__).resolve().parents[1] / "data" / "AH63K127.dat"
     help="Recipe name or names joined with '+'",
 )
 @click.option(
+    "--shot-time",
+    "shot_times",
+    type=int,
+    multiple=True,
+    help="Add icing duration for a multishot run. Can be provided multiple times",
+)
+@click.option(
     "-o",
     "--output",
     default="runs",
@@ -39,7 +46,9 @@ DEFAULT_AIRFOIL = Path(__file__).resolve().parents[1] / "data" / "AH63K127.dat"
     help="Root directory for projects",
 )
 @log_call
-def cli_case_sweep(params: tuple[str], recipe: str, output: Path) -> None:
+def cli_case_sweep(
+    params: tuple[str], recipe: str, shot_times: tuple[int, ...], output: Path
+) -> None:
     """Create projects for all parameter combinations."""
 
     def _parse_value(v: str):
@@ -65,6 +74,8 @@ def cli_case_sweep(params: tuple[str], recipe: str, output: Path) -> None:
         case = yaml.safe_load(case_file.read_text()) or {}
         for k, v in zip(keys, combo):
             case[k] = v
+        if shot_times:
+            case["CASE_MULTISHOT"] = list(shot_times)
         case_file.write_text(yaml.safe_dump(case, sort_keys=False))
         cli_update.callback(proj.uid, None)
         click.echo(proj.uid)

--- a/glacium/cli/new.py
+++ b/glacium/cli/new.py
@@ -46,6 +46,13 @@ DEFAULT_AIRFOIL = PKG_PKG / "data" / "AH63K127.dat"
     show_default=True,
     help="Recipe name or multiple names joined with '+'",
 )
+@click.option(
+    "--shot-time",
+    "shot_times",
+    type=int,
+    multiple=True,
+    help="Add icing duration for a multishot run. Can be provided multiple times",
+)
 @click.option("-o", "--output", default=str(RUNS_ROOT), show_default=True,
               type=click.Path(file_okay=False, dir_okay=True, writable=True, path_type=Path),
               help="Root-Ordner für Projekte")
@@ -56,6 +63,7 @@ def cli_new(
     name: str,
     airfoil: Path,
     recipe: str,
+    shot_times: tuple[int, ...],
     output: Path,
     yes: bool,
 ) -> None:
@@ -64,6 +72,8 @@ def cli_new(
     builder = Project(output)
     builder.name(name).select_airfoil(airfoil)
     builder.set("recipe", recipe)
+    if shot_times:
+        builder.set("CASE_MULTISHOT", list(shot_times))
     project = builder.create()
     log.success(f"Projekt angelegt: {project.root}")
     click.echo(project.uid)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -70,3 +70,23 @@ def test_cli_info(tmp_path):
         assert result.exit_code == 0
         assert "CASE_AOA" in result.output
         assert "PWS_REFINEMENT" in result.output
+
+
+def test_cli_new_shot_time(tmp_path):
+    runner = CliRunner()
+    env = {"HOME": str(tmp_path)}
+
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        result = runner.invoke(
+            cli,
+            ["new", "MyWing", "--shot-time", "10", "--shot-time", "20"],
+            env=env,
+        )
+        assert result.exit_code == 0
+        uid = result.output.strip()
+        case_file = Path("runs") / uid / "case.yaml"
+        cfg_file = Path("runs") / uid / "_cfg" / "global_config.yaml"
+        case = yaml.safe_load(case_file.read_text())
+        cfg = yaml.safe_load(cfg_file.read_text())
+        assert case["CASE_MULTISHOT"] == [10, 20]
+        assert cfg["CASE_MULTISHOT"] == [10, 20]

--- a/tests/test_cli_case_sweep.py
+++ b/tests/test_cli_case_sweep.py
@@ -27,6 +27,10 @@ def test_cli_case_sweep(tmp_path, monkeypatch):
             cli,
             [
                 "case-sweep",
+                "--shot-time",
+                "1",
+                "--shot-time",
+                "2",
                 "--param",
                 "CASE_AOA=0,4",
                 "--param",
@@ -57,6 +61,8 @@ def test_cli_case_sweep(tmp_path, monkeypatch):
             assert cfg["CASE_AOA"] == case["CASE_AOA"]
             assert cfg["CASE_VELOCITY"] == case["CASE_VELOCITY"]
             assert cfg["PWS_REFINEMENT"] == case["PWS_REFINEMENT"]
+            assert case["CASE_MULTISHOT"] == [1, 2]
+            assert cfg["CASE_MULTISHOT"] == [1, 2]
 
         assert combos == {
             (0, 50, 1),


### PR DESCRIPTION
## Summary
- allow specifying `--shot-time` multiple times in `glacium new` and `glacium case-sweep`
- propagate shot times into `CASE_MULTISHOT`
- document and test shot time CLI usage

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'trimesh')*


------
https://chatgpt.com/codex/tasks/task_e_688f4c7c8c7c83279cf6b9e0391eb791