### PR TITLE
docs: clarify CASE_MULTISHOT shot times

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ The multishot recipe runs ten solver cycles by default. Control the shot timings
 with ``--shot-time`` or by editing the ``CASE_MULTISHOT`` setting in
 ``case.yaml``.
 
+Example ``case.yaml``:
+
+```yaml
+CASE_MULTISHOT:
+  - 10
+  - 20
+```
+
 The command prints the generated project UID. All projects live below
 `./runs/<UID>` in the current working directory. ``glacium new`` and ``glacium init`` parse ``case.yaml`` and write ``global_config.yaml`` automatically.
 When running multishot jobs the template files for each shot are generated

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -29,6 +29,14 @@ project from the default recipe and prints its unique identifier (UID):
 The multishot recipe uses ten solver cycles by default. Control the timings with
 ``--shot-time`` or by editing ``CASE_MULTISHOT`` in ``case.yaml``.
 
+Example ``case.yaml``:
+
+.. code-block:: yaml
+
+   CASE_MULTISHOT:
+     - 10
+     - 20
+
 To chain multiple recipes use ``+`` between their names, e.g.:
 
 .. code-block:: bash

--- a/scripts/multishot_analysis.py
+++ b/scripts/multishot_analysis.py
@@ -6,6 +6,14 @@ The module exposes :func:`load_multishot_project` to locate the multishot
 project with the highest number of shots based on ``CASE_MULTISHOT`` and a
 small :func:`main` entry point mirroring the behaviour of
 :mod:`scripts.single_shot_analysis`.
+
+Populate ``CASE_MULTISHOT`` in ``case.yaml`` with the desired shot times,
+for example::
+
+    CASE_MULTISHOT: [10, 20, 30]
+
+These timings are used to identify which project to analyse and to order
+post-processing results.
 """
 
 from pathlib import Path
@@ -27,12 +35,10 @@ plt.style.use(["science", "ieee"])
 def load_multishot_project(root: Path) -> Project:
     """Return the multishot project with the longest shot sequence.
 
-    The previous implementation relied on ``MULTISHOT_COUNT`` to determine
-    which project to analyse.  That value is redundant now that the timing of
-    each shot is stored explicitly in ``CASE_MULTISHOT``.  This helper therefore
-    inspects the length of that list for every project under ``root`` and
-    returns the one with the most entries.  Projects missing a valid
-    ``CASE_MULTISHOT`` list are ignored.
+    Each multishot case records every shot time in ``CASE_MULTISHOT``.
+    This helper inspects the length of that list for all projects under
+    ``root`` and returns the one with the most entries. Projects missing a
+    valid ``CASE_MULTISHOT`` list are ignored.
 
     Parameters
     ----------


### PR DESCRIPTION
## Summary
- document specifying shot times via `CASE_MULTISHOT` with sample YAML
- explain that multishot projects are identified by the length of `CASE_MULTISHOT`

## Testing
- `sphinx-build -b html docs docs/_build/html` (warnings: failed to import modules, title underline short, explicit markup ends without blank line)
- `pytest` (fail: 31 errors during collection)

------
https://chatgpt.com/codex/tasks/task_e_688f55590d708327bf09b07c916bce24