### PR TITLE
Switch multishot tests to CASE_MULTISHOT lists

### DIFF
--- a/tests/test_case_sweep.py
+++ b/tests/test_case_sweep.py
@@ -28,6 +28,7 @@ def test_case_sweep_creates_projects(tmp_path, monkeypatch):
                 "PWS_REFINEMENT=1,2",
             ),
             recipe="multishot",
+            shot_times=(1, 2),
             output=Path("runs"),
         )
 
@@ -46,6 +47,10 @@ def test_case_sweep_creates_projects(tmp_path, monkeypatch):
             assert cfg["CASE_AOA"] == case["CASE_AOA"]
             assert cfg["CASE_VELOCITY"] == case["CASE_VELOCITY"]
             assert cfg["PWS_REFINEMENT"] == case["PWS_REFINEMENT"]
+            assert case["CASE_MULTISHOT"] == [1, 2]
+            assert cfg["CASE_MULTISHOT"] == [1, 2]
+            assert len(case["CASE_MULTISHOT"]) == 2
+            assert len(cfg["CASE_MULTISHOT"]) == 2
 
         assert combos == {
             (0, 50, 1),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -79,7 +79,16 @@ def test_cli_new_shot_time(tmp_path):
     with runner.isolated_filesystem(temp_dir=tmp_path):
         result = runner.invoke(
             cli,
-            ["new", "MyWing", "--shot-time", "10", "--shot-time", "20"],
+            [
+                "new",
+                "MyWing",
+                "--shot-time",
+                "10",
+                "--shot-time",
+                "20",
+                "-o",
+                "runs",
+            ],
             env=env,
         )
         assert result.exit_code == 0
@@ -90,3 +99,5 @@ def test_cli_new_shot_time(tmp_path):
         cfg = yaml.safe_load(cfg_file.read_text())
         assert case["CASE_MULTISHOT"] == [10, 20]
         assert cfg["CASE_MULTISHOT"] == [10, 20]
+        assert len(case["CASE_MULTISHOT"]) == 2
+        assert len(cfg["CASE_MULTISHOT"]) == 2

--- a/tests/test_cli_case_sweep.py
+++ b/tests/test_cli_case_sweep.py
@@ -63,6 +63,8 @@ def test_cli_case_sweep(tmp_path, monkeypatch):
             assert cfg["PWS_REFINEMENT"] == case["PWS_REFINEMENT"]
             assert case["CASE_MULTISHOT"] == [1, 2]
             assert cfg["CASE_MULTISHOT"] == [1, 2]
+            assert len(case["CASE_MULTISHOT"]) == 2
+            assert len(cfg["CASE_MULTISHOT"]) == 2
 
         assert combos == {
             (0, 50, 1),

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -254,6 +254,7 @@ def test_multishot_run_job(monkeypatch, tmp_path):
 
     cfg = GlobalConfig(project_uid="uid", base_dir=tmp_path)
     cfg["FENSAP_EXE"] = "sh"
+    cfg["CASE_MULTISHOT"] = [1, 2]
 
     paths = PathBuilder(tmp_path).build()
     paths.ensure()
@@ -263,6 +264,7 @@ def test_multishot_run_job(monkeypatch, tmp_path):
     job = MultiShotRunJob(project)
     job.execute()
     assert (paths.solver_dir("run_MULTISHOT") / ".solvercmd").exists()
+    assert len(cfg["CASE_MULTISHOT"]) == 2
 
 
 def test_multishot_run_job_calls_base_engine(monkeypatch, tmp_path):
@@ -294,6 +296,7 @@ def test_multishot_run_job_calls_base_engine(monkeypatch, tmp_path):
 
     cfg = GlobalConfig(project_uid="uid", base_dir=tmp_path)
     cfg["FENSAP_EXE"] = str(exe)
+    cfg["CASE_MULTISHOT"] = [1]
 
     paths = PathBuilder(tmp_path).build()
     paths.ensure()
@@ -319,6 +322,7 @@ def test_multishot_run_job_calls_base_engine(monkeypatch, tmp_path):
     assert solvercmd.exists()
     assert called["cmd"] == [str(exe), str(solvercmd)]
     assert called["cwd"] == work
+    assert len(cfg["CASE_MULTISHOT"]) == 1
 
 
 @pytest.mark.parametrize("count", [3, 5])
@@ -358,6 +362,7 @@ def test_multishot_run_job_renders_batch(monkeypatch, tmp_path, count):
     job = MultiShotRunJob(project)
     job.execute()
     work = paths.solver_dir("run_MULTISHOT")
+    assert len(cfg["CASE_MULTISHOT"]) == count
     assert len(list(work.glob("config.fensap.*"))) == count
     assert len(list(work.glob("config.drop.*"))) == count
     for i in range(1, count + 1):

--- a/tests/test_multishot_timings.py
+++ b/tests/test_multishot_timings.py
@@ -63,4 +63,5 @@ def test_multishot_timings(monkeypatch, tmp_path):
         text = (work / f"config.ice.{idx}").read_text().strip()
         nums = [float(x) for x in text.split()]
         assert nums == [float(pair[0]), float(pair[1])]
+    assert len(cfg["CASE_MULTISHOT"]) == 3
 


### PR DESCRIPTION
## Summary
- pass explicit CASE_MULTISHOT lists to multishot-related tests
- verify list lengths and timing values instead of count parameters
- exercise CLI with new --shot-time option

## Testing
- `pytest tests/test_case_sweep.py tests/test_cli_case_sweep.py tests/test_cli.py::test_cli_new_shot_time tests/test_multishot_timings.py tests/test_engines.py::test_multishot_run_job tests/test_engines.py::test_multishot_run_job_calls_base_engine tests/test_engines.py::test_multishot_run_job_renders_batch -q`


------
https://chatgpt.com/codex/tasks/task_e_688f581894648327a6789d72f26a3408