### PR TITLE
Remove ICE_GUI_TOTAL_TIME from case defaults

### DIFF
--- a/glacium/config/defaults/case.yaml
+++ b/glacium/config/defaults/case.yaml
@@ -12,4 +12,3 @@ PWS_REFINEMENT: 8 # mesh refinement level
 # Icing time for each shot in a multishot run (seconds).
 # The number of shots is determined by the length of the list below.
 # CASE_MULTISHOT: [10, 20, 30]
-ICE_GUI_TOTAL_TIME: 3220  # total icing time for multishot cycles


### PR DESCRIPTION
## Summary
- drop `ICE_GUI_TOTAL_TIME` from case defaults
- retain commented `CASE_MULTISHOT` example for shot timing documentation

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy'; No module named 'glacium'; No module named 'verboselogs')*


------
https://chatgpt.com/codex/tasks/task_e_688f5dbae8ec8327b1af72a10f900d5e