### PR TITLE
Sum multishot timings in Fensap context and test

### DIFF
--- a/glacium/engines/fensap.py
+++ b/glacium/engines/fensap.py
@@ -82,7 +82,7 @@ class FensapScriptJob(Job):
         if "ICE_GUI_TOTAL_TIME" not in ctx:
             timings = cfg.get("CASE_MULTISHOT")
             if isinstance(timings, list) and timings:
-                ctx["ICE_GUI_TOTAL_TIME"] = timings[0]
+                ctx["ICE_GUI_TOTAL_TIME"] = sum(timings)
         return ctx
 
     @log_call

--- a/tests/test_fensap_context.py
+++ b/tests/test_fensap_context.py
@@ -1,0 +1,32 @@
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+# Avoid executing glacium/__init__.py by pre-creating a minimal package
+pkg = types.ModuleType("glacium")
+pkg.__path__ = [str(ROOT / "glacium")]
+sys.modules.setdefault("glacium", pkg)
+
+from glacium.engines.fensap import FensapScriptJob
+from glacium.models.config import GlobalConfig
+from glacium.models.project import Project
+from glacium.managers.path_manager import PathBuilder
+from glacium.utils import default_paths
+
+
+def test_fensap_context_multishot_sum(monkeypatch, tmp_path):
+    dummy = tmp_path / "defaults.yaml"  # does not exist
+    monkeypatch.setattr(default_paths, "global_default_config", lambda: dummy)
+
+    cfg = GlobalConfig(project_uid="uid", base_dir=tmp_path)
+    cfg["CASE_MULTISHOT"] = [1, 2, 3]
+
+    paths = PathBuilder(tmp_path).build()
+    project = Project("uid", tmp_path, cfg, paths, [])
+
+    job = FensapScriptJob(project)
+    ctx = job._context()
+    assert ctx["ICE_GUI_TOTAL_TIME"] == sum(cfg["CASE_MULTISHOT"])


### PR DESCRIPTION
## Summary
- compute `ICE_GUI_TOTAL_TIME` as the sum of multishot timings
- add unit test for `_context` handling of multishot timing lists

## Testing
- `pytest tests/test_fensap_context.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f63dffe408327841eff2a65ed959c