### PR TITLE
Compute total time from multishot timings

### DIFF
--- a/scripts/single_shot_creation.py
+++ b/scripts/single_shot_creation.py
@@ -34,7 +34,8 @@ def main(base_dir: Path | str = Path("")) -> None:
     case_file = proj.root / "case.yaml"
     case_data = yaml.safe_load(case_file.read_text()) if case_file.exists() else {}
     defaults = generate_global_defaults(case_file, global_default_config())
-    total = float(case_data.get("ICE_GUI_TOTAL_TIME", defaults.get("ICE_GUI_TOTAL_TIME")))
+    total = sum(case_data.get("CASE_MULTISHOT", defaults.get("CASE_MULTISHOT", [])))
+    proj.set("ICE_GUI_TOTAL_TIME", total)
 
 
 


### PR DESCRIPTION
## Summary
- derive ICE_GUI_TOTAL_TIME from CASE_MULTISHOT values in single_shot_creation

## Testing
- `pytest` *(fails: FileNotFoundError: Projekt '20250802-102115-458416-F3C5' existiert nicht)*

------
https://chatgpt.com/codex/tasks/task_e_688f680760dc832790ac450f2557e7f0