### PR TITLE
Use CASE_MULTISHOT for total time

### DIFF
--- a/scripts/full/example_run.py
+++ b/scripts/full/example_run.py
@@ -39,10 +39,10 @@ def main():
     prj.add_job("FENSAP_CONVERGENCE_STATS")
     prj.add_job("POSTPROCESS_SINGLE_FENSAP")
 
-    # Explicitly define the timing of each shot (20 shots, 30 s each)
+    # Explicitly define the timing of each shot (20 shots, 30 s each). The
+    # total time is derived from the sum of CASE_MULTISHOT.
     shot_times = [30] * 20
     prj.set("CASE_MULTISHOT", shot_times)
-    prj.set("ICE_GUI_TOTAL_TIME", 30)
     prj.add_job("MULTISHOT_RUN")
     prj.add_job("POSTPROCESS_MULTISHOT")
     prj.add_job("ANALYZE_MULTISHOT")

--- a/scripts/full_power.py
+++ b/scripts/full_power.py
@@ -27,7 +27,8 @@ def main(study_name: str | None = None) -> None:
         "CASE_AOA": 0,
         "CASE_YPLUS": 0.3,
         "CASE_LWC": 0.000595,
-        "ICE_GUI_TOTAL_TIME": 1
+        # Total time comes from the sum of CASE_MULTISHOT
+        "CASE_MULTISHOT": [1],
     }
 
     base_dir = Path("") / study_name
@@ -55,7 +56,7 @@ def main(study_name: str | None = None) -> None:
     #     "CASE_AOA": 0,
     #     "CASE_YPLUS": 0.3,
     #     "CASE_LWC": 0.00052,
-    #     "ICE_GUI_TOTAL_TIME": 3220
+    #     "CASE_MULTISHOT": [3220],  # total time from sum of CASE_MULTISHOT
     # }
     #
     # base_dir = Path("") / study_name


### PR DESCRIPTION
## Summary
- rely on `CASE_MULTISHOT` shot durations instead of explicitly setting `ICE_GUI_TOTAL_TIME`
- note that total run time now comes from the sum of `CASE_MULTISHOT`

## Testing
- `pytest` *(fails: FileNotFoundError: Projekt '20250802-102115-458416-F3C5' existiert nicht)*

------
https://chatgpt.com/codex/tasks/task_e_688f6d7856c08327a34e590e289866d4