### PR TITLE
docs: clarify icing duration computation

### DIFF
--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -48,9 +48,9 @@ and ``glacium init`` the ``case.yaml`` file is parsed and the resulting
 ``global_config.yaml`` is written automatically.  If you change
 ``case.yaml`` later you can run ``glacium update`` to rebuild the
 configuration. When multishot jobs run, template files for each shot index are
-created automatically before launching the solver. ``ICE_GUI_TOTAL_TIME``
-defines the icing duration for cycles after the fixed ``10``‑second first shot.
-Individual timings are no longer needed unless overriding that initial shot.
+created automatically before launching the solver. The overall icing duration
+is calculated by summing all values in ``CASE_MULTISHOT``—using the example
+above results in a 30‑second icing run.
 
 Case sweep
 ~~~~~~~~~~


### PR DESCRIPTION
## Summary
- remove discussion of ICE_GUI_TOTAL_TIME in quick start guide
- note that icing duration comes from summing CASE_MULTISHOT

## Testing
- `pytest` *(fails: Interrupted: 50 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688f6f7de1f083278f49f162dc93a74f