### PR TITLE
Run multishot project without remeshing

### DIFF
--- a/scripts/multishot_creation.py
+++ b/scripts/multishot_creation.py
@@ -26,7 +26,12 @@ def _run_project(base: Project, mesh: Path, timings: list[float]) -> None:
 
     proj = builder.create()
     Project.set_mesh(mesh, proj)
-    # proj.run()
+
+    job = proj.job_manager._jobs.get("MULTISHOT_RUN")
+    if job is not None:
+        job.deps = ()
+
+    proj.run()
     log.info(f"Completed multishot project {proj.uid} ({len(timings)} shots)")
 
 


### PR DESCRIPTION
## Summary
- allow reusing existing mesh for multishot runs by clearing MULTISHOT_RUN dependencies and invoking `proj.run()`

## Testing
- `pytest tests -q` *(fails: TemplateNotFound for FENSAP templates; missing MESH_ANALYSIS registration and mesh path)*

------
https://chatgpt.com/codex/tasks/task_e_688f820ddac48327a0833423b234b080