### PR TITLE
feat: reuse mesh helper

### DIFF
--- a/glacium/utils/__init__.py
+++ b/glacium/utils/__init__.py
@@ -14,4 +14,5 @@ from .convergence import (
     plot_stats,
 )
 from .solver_time import parse_execution_time
+from .project_utils import reuse_mesh
 from .string_utils import normalise_key

--- a/glacium/utils/project_utils.py
+++ b/glacium/utils/project_utils.py
@@ -1,0 +1,27 @@
+"""Helpers for working with :class:`~glacium.api.Project` instances."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from glacium.api import Project
+
+__all__ = ["reuse_mesh"]
+
+
+def reuse_mesh(project: Project, mesh_path: Path | str, job_name: str) -> None:
+    """Copy ``mesh_path`` into ``project`` and clear dependencies.
+
+    Parameters
+    ----------
+    project
+        The project to update.
+    mesh_path
+        Path to the mesh file that should be copied into ``project``.
+    job_name
+        Name of the job whose dependencies should be cleared.
+    """
+    Project.set_mesh(Path(mesh_path), project)
+    job = project.job_manager._jobs.get(job_name)
+    if job is not None:
+        job.deps = ()

--- a/scripts/clean_sweep_creation.py
+++ b/scripts/clean_sweep_creation.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from glacium.api import Project
+from glacium.utils import reuse_mesh
 from glacium.utils.logging import log
 
 from full_power_gci import load_runs, gci_analysis2
@@ -65,10 +66,7 @@ def main(
         for job in jobs:
             builder.add_job(job)
         proj = builder.create()
-        Project.set_mesh(mesh_path, proj)
-        job = proj.job_manager._jobs.get("FENSAP_RUN")
-        if job is not None:
-            job.deps = ()
+        reuse_mesh(proj, mesh_path, "FENSAP_RUN")
         proj.run()
         log.info(f"Completed angle {aoa}")
 

--- a/scripts/iced_sweep_creation.py
+++ b/scripts/iced_sweep_creation.py
@@ -5,6 +5,7 @@ from typing import Any
 import re
 
 from glacium.api import Project
+from glacium.utils import reuse_mesh
 from glacium.utils.logging import log
 
 from multishot_analysis import load_multishot_project
@@ -66,10 +67,7 @@ def main(
         for job in jobs:
             builder.add_job(job)
         proj = builder.create()
-        Project.set_mesh(grid_path, proj)
-        job = proj.job_manager._jobs.get("FENSAP_RUN")
-        if job is not None:
-            job.deps = ()
+        reuse_mesh(proj, grid_path, "FENSAP_RUN")
         proj.run()
         log.info(f"Completed angle {aoa}")
 

--- a/scripts/multishot_creation.py
+++ b/scripts/multishot_creation.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any
 
 from glacium.api import Project
+from glacium.utils import reuse_mesh
 from glacium.utils.logging import log
 
 from full_power_gci import load_runs, gci_analysis2
@@ -25,11 +26,7 @@ def _run_project(base: Project, mesh: Path, timings: list[float]) -> None:
         builder.add_job(name)
 
     proj = builder.create()
-    Project.set_mesh(mesh, proj)
-
-    job = proj.job_manager._jobs.get("MULTISHOT_RUN")
-    if job is not None:
-        job.deps = ()
+    reuse_mesh(proj, mesh, "MULTISHOT_RUN")
 
     proj.run()
     log.info(f"Completed multishot project {proj.uid} ({len(timings)} shots)")


### PR DESCRIPTION
## Summary
- add `reuse_mesh` helper to set a mesh and clear job dependencies
- refactor sweep creation scripts to use `reuse_mesh`

## Testing
- `pytest` *(fails: 50 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688f853d85788327976f855f7bdf0597