### PR TITLE
Rename step output directories to numbered snake case

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ Run a single-shot DROP3D/ICE3D case on the best grid:
 python scripts/05_single_shot_creation.py
 python scripts/06_single_shot_analysis.py
 ```
-Results are stored under ``single_shot_results``.
+Results are stored under ``06_single_shot_results``.
 
 ### Clean sweep
 
@@ -366,7 +366,7 @@ python scripts/08_clean_sweep_analysis.py
 python scripts/clean_sweep_cp_gif.py
 ```
 The analysis stores plots, ``polar_momentum.csv`` and ``cp_curves.gif`` under
-``aoa_sweep_results``.
+``08_clean_sweep_results``.
 
 ### Iced sweep
 
@@ -377,7 +377,7 @@ python scripts/09_iced_sweep_creation.py
 python scripts/10_iced_sweep_analysis.py
 ```
 The analysis stores plots and ``polar_momentum.csv`` under
-``aoa_sweep_results_iced``.
+``10_iced_sweep_results``.
 
 The `scripts/full_power.py` helper runs both studies consecutively.
 

--- a/scripts/01_full_power_creation.py
+++ b/scripts/01_full_power_creation.py
@@ -11,12 +11,12 @@ def main(base_dir: Path | str = Path(""), case_vars: dict[str, Any] | None = Non
     Parameters
     ----------
     base_dir : Path | str, optional
-        Directory in which the ``GridDependencyStudy`` folder will be created.
+        Directory in which the ``01_grid_dependency_study`` folder will be created.
     case_vars : dict[str, Any] | None, optional
         Case variables overriding the defaults.
     """
 
-    root = Path(base_dir) / "GridDependencyStudy"
+    root = Path(base_dir) / "01_grid_dependency_study"
     base = Project(root).name("grid")
 
     # defaults: dict[str, Any] = {

--- a/scripts/02_full_power_gci.py
+++ b/scripts/02_full_power_gci.py
@@ -556,9 +556,9 @@ def generate_gci_pdf_report(
 
 def main(base_dir: Path | str = Path("")) -> None:
     base = Path(base_dir)
-    root = base / "GridDependencyStudy"
+    root = base / "01_grid_dependency_study"
     runs = load_runs(root)
-    gci_analysis2(runs, base / "grid_dependency_results")
+    gci_analysis2(runs, base / "02_grid_dependency_results")
 
 
 if __name__ == "__main__":

--- a/scripts/03_multishot_creation.py
+++ b/scripts/03_multishot_creation.py
@@ -43,15 +43,15 @@ def main(
 
     base = Path(base_dir)
 
-    runs = load_runs(base / "GridDependencyStudy")
-    result = gci_analysis2(runs, base / "grid_dependency_results")
+    runs = load_runs(base / "01_grid_dependency_study")
+    result = gci_analysis2(runs, base / "02_grid_dependency_results")
     if result is None:
         return
 
     _, _, best_proj = result
     mesh_path = Project.get_mesh(best_proj)
 
-    base = Project(base / "Multishot").name("multishot")
+    base = Project(base / "03_multishot").name("multishot")
 
     params = {
         "CASE_CHARACTERISTIC_LENGTH": best_proj.get("CASE_CHARACTERISTIC_LENGTH"),

--- a/scripts/04_multishot_analysis.py
+++ b/scripts/04_multishot_analysis.py
@@ -105,7 +105,7 @@ def main(base_dir: Path | str = Path("")) -> None:
     """Entry point used by other scripts and the command line."""
 
     base = Path(base_dir)
-    root = base / "Multishot"
+    root = base / "03_multishot"
 
     try:
         proj = load_multishot_project(root)
@@ -113,7 +113,7 @@ def main(base_dir: Path | str = Path("")) -> None:
         log.error(str(err))
         return
 
-    analyze_project(proj, base / "multishot_results")
+    analyze_project(proj, base / "04_multishot_results")
 
 
 if __name__ == "__main__":

--- a/scripts/05_single_shot_creation.py
+++ b/scripts/05_single_shot_creation.py
@@ -20,13 +20,13 @@ def main(base_dir: Path | str = Path("")) -> None:
 
     base = Path(base_dir)
 
-    runs = load_runs(base / "GridDependencyStudy")
-    result = gci_analysis2(runs, base / "grid_dependency_results")
+    runs = load_runs(base / "01_grid_dependency_study")
+    result = gci_analysis2(runs, base / "02_grid_dependency_results")
     if result is None:
         return
 
     _, _, best_proj = result
-    dest_root = base / "SingleShot"
+    dest_root = base / "05_single_shot"
     dest_root.mkdir(parents=True, exist_ok=True)
     dest = dest_root / best_proj.uid
     if dest.exists():

--- a/scripts/06_single_shot_analysis.py
+++ b/scripts/06_single_shot_analysis.py
@@ -41,13 +41,13 @@ def analyze_project(proj: Project, out_dir: Path) -> None:
 
 def main(base_dir: Path | str = Path("")) -> None:
     base = Path(base_dir)
-    root = base / "SingleShot"
+    root = base / "05_single_shot"
     try:
         proj = load_single_project(root)
     except FileNotFoundError as err:
         log.error(str(err))
         return
-    analyze_project(proj, base / "single_shot_results")
+    analyze_project(proj, base / "06_single_shot_results")
 
 
 if __name__ == "__main__":

--- a/scripts/07_clean_sweep_creation.py
+++ b/scripts/07_clean_sweep_creation.py
@@ -24,23 +24,23 @@ def main(
     Parameters
     ----------
     base_dir : Path | str, optional
-        Directory containing the ``GridDependencyStudy`` folder and where the
-        ``CleanSweep`` project will be created.
+        Directory containing the ``01_grid_dependency_study`` folder and where the
+        ``07_clean_sweep`` project will be created.
     case_vars : dict[str, Any] | None, optional
         Case variables overriding those read from the selected grid.
     """
 
     base_path = Path(base_dir)
 
-    runs = load_runs(base_path / "GridDependencyStudy")
-    result = gci_analysis2(runs, base_path / "grid_dependency_results")
+    runs = load_runs(base_path / "01_grid_dependency_study")
+    result = gci_analysis2(runs, base_path / "02_grid_dependency_results")
     if result is None:
         return
 
     _, _, best_proj = result
     mesh_path = Project.get_mesh(best_proj)
 
-    base = Project(base_path / "CleanSweep").name("aoa_sweep")
+    base = Project(base_path / "07_clean_sweep").name("aoa_sweep")
     base.set("RECIPE", "fensap")
 
     params = {

--- a/scripts/08_clean_sweep_analysis.py
+++ b/scripts/08_clean_sweep_analysis.py
@@ -16,7 +16,7 @@ plt.style.use(["science", "ieee"])
 
 """Analyze a clean angle-of-attack sweep.
 
-Results are written to the ``aoa_sweep_results`` directory, including
+Results are written to the ``08_clean_sweep_results`` directory, including
 ``polar.csv`` and ``polar_momentum.csv``.
 """
 
@@ -113,9 +113,9 @@ def main(base_dir: Path | str = Path("")) -> None:
     """Analyze a clean sweep located under ``base_dir``."""
 
     base = Path(base_dir)
-    root = base / "CleanSweep"
+    root = base / "07_clean_sweep"
     runs = load_runs(root)
-    aoa_sweep_analysis(runs, base / "aoa_sweep_results")
+    aoa_sweep_analysis(runs, base / "08_clean_sweep_results")
 
 
 if __name__ == "__main__":

--- a/scripts/09_iced_sweep_creation.py
+++ b/scripts/09_iced_sweep_creation.py
@@ -37,10 +37,10 @@ def main(
 
     base = Path(base_dir)
 
-    ms_project = load_multishot_project(base / "Multishot")
+    ms_project = load_multishot_project(base / "03_multishot")
     grid_path = get_last_iced_grid(ms_project)
 
-    base = Project(base / "IcedSweep").name("aoa_sweep")
+    base = Project(base / "09_iced_sweep").name("aoa_sweep")
     base.set("RECIPE", "fensap")
 
     params = {

--- a/scripts/10_iced_sweep_analysis.py
+++ b/scripts/10_iced_sweep_analysis.py
@@ -16,7 +16,7 @@ plt.style.use(["science", "ieee"])
 
 """Analyze an iced angle-of-attack sweep.
 
-Results are written to the ``aoa_sweep_results_iced`` directory, including
+Results are written to the ``10_iced_sweep_results`` directory, including
 ``polar.csv`` and ``polar_momentum.csv``.
 """
 
@@ -113,9 +113,9 @@ def main(base_dir: Path | str = Path("")) -> None:
     """Analyze an iced sweep located under ``base_dir``."""
 
     base = Path(base_dir)
-    root = base / "IcedSweep"
+    root = base / "09_iced_sweep"
     runs = load_runs(root)
-    aoa_sweep_analysis(runs, base / "aoa_sweep_results_iced")
+    aoa_sweep_analysis(runs, base / "10_iced_sweep_results")
 
 
 if __name__ == "__main__":

--- a/scripts/11_polar_compare.py
+++ b/scripts/11_polar_compare.py
@@ -75,16 +75,14 @@ def main(base_dir: Path | str = Path("")) -> None:
     """Compare polar curves located under ``base_dir``."""
 
     base = Path(base_dir)
-    result_dirs = sorted(base.glob("aoa_sweep_results*"))
-    if len(result_dirs) < 2:
-        raise FileNotFoundError("not enough result directories found")
-
-    clean_csv = result_dirs[0] / "polar.csv"
-    iced_csv = result_dirs[1] / "polar.csv"
+    clean_csv = base / "08_clean_sweep_results" / "polar.csv"
+    iced_csv = base / "10_iced_sweep_results" / "polar.csv"
+    if not clean_csv.exists() or not iced_csv.exists():
+        raise FileNotFoundError("polar.csv not found in sweep result directories")
 
     clean = load_csv(clean_csv)
     iced = load_csv(iced_csv)
-    plot_combined(clean, iced, base / "polar_combined_results")
+    plot_combined(clean, iced, base / "11_polar_combined_results")
 
 
 if __name__ == "__main__":

--- a/scripts/clean_sweep_cp_gif.py
+++ b/scripts/clean_sweep_cp_gif.py
@@ -73,8 +73,8 @@ def animate_cp_curves(curves: list[tuple[float, pd.DataFrame]], outfile: Path, f
 
 
 def main() -> None:
-    curves = load_cp_curves(Path("CleanSweep"))
-    animate_cp_curves(curves, Path("aoa_sweep_results") / "cp_curves.gif")
+    curves = load_cp_curves(Path("07_clean_sweep"))
+    animate_cp_curves(curves, Path("08_clean_sweep_results") / "cp_curves.gif")
 
 
 if __name__ == "__main__":

--- a/scripts/clean_sweep_gif.py
+++ b/scripts/clean_sweep_gif.py
@@ -66,9 +66,9 @@ def create_gif(images: list[tuple[float, Path]], outfile: Path, *, duration: int
 
 
 def main() -> None:
-    root = Path("CleanSweep")
+    root = Path("07_clean_sweep")
     images = collect_images(root)
-    create_gif(images, Path("aoa_sweep_results") / "pressure_zoom.gif")
+    create_gif(images, Path("08_clean_sweep_results") / "pressure_zoom.gif")
 
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation

--- a/tests/test_clean_sweep_gif.py
+++ b/tests/test_clean_sweep_gif.py
@@ -19,7 +19,7 @@ def _create_project(root: Path, uid: str, aoa: float) -> None:
 
 
 def test_collect_sorted(tmp_path):
-    root = tmp_path / "CleanSweep"
+    root = tmp_path / "07_clean_sweep"
     _create_project(root, "p1", 5)
     _create_project(root, "p2", 1)
 
@@ -28,9 +28,9 @@ def test_collect_sorted(tmp_path):
 
 
 def test_gif_written(tmp_path):
-    root = tmp_path / "CleanSweep"
+    root = tmp_path / "07_clean_sweep"
     _create_project(root, "p1", 0)
     imgs = collect_images(root)
-    out = tmp_path / "aoa_sweep_results" / "pressure_zoom.gif"
+    out = tmp_path / "08_clean_sweep_results" / "pressure_zoom.gif"
     create_gif(imgs, out)
     assert out.exists()


### PR DESCRIPTION
## Summary
- standardize output folders for each workflow step (e.g. `01_grid_dependency_study`, `03_multishot`, `09_iced_sweep`)
- update helper scripts, tests, and README for new directory names
- adjust polar comparison and GIF utilities to look in numbered results directories

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `python -m py_compile scripts/01_full_power_creation.py scripts/02_full_power_gci.py scripts/03_multishot_creation.py scripts/04_multishot_analysis.py scripts/05_single_shot_creation.py scripts/06_single_shot_analysis.py scripts/07_clean_sweep_creation.py scripts/08_clean_sweep_analysis.py scripts/09_iced_sweep_creation.py scripts/10_iced_sweep_analysis.py scripts/11_polar_compare.py scripts/clean_sweep_gif.py scripts/clean_sweep_cp_gif.py tests/test_clean_sweep_gif.py`

------
https://chatgpt.com/codex/tasks/task_e_689c87d1f4848327950d50047e23c8f2