### PR TITLE
docs: update script references

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,9 +342,11 @@ run_MULTISHOT/
 Create mesh refinement projects and analyse convergence using:
 
 ```bash
-python scripts/01_full_power_creation.py
-python scripts/02_full_power_gci.py
+python scripts/01_grid_dependency_creation.py
+python scripts/02_grid_dependency_gci.py
 ```
+
+The scripts populate the ``01_grid_dependency_study`` directory.
 
 ### Single shot
 
@@ -379,7 +381,7 @@ python scripts/10_iced_sweep_analysis.py
 The analysis stores plots and ``polar_momentum.csv`` under
 ``10_iced_sweep_results``.
 
-The `scripts/full_power.py` helper runs both studies consecutively.
+The `scripts/00_fullpower.py` helper runs both studies consecutively.
 
 ## Development
 

--- a/docs/grid_dependency_study.rst
+++ b/docs/grid_dependency_study.rst
@@ -47,11 +47,11 @@ generated reports.
 Automated GCI analysis
 ---------------------
 
-The ``scripts/02_full_power_gci.py`` script helps to analyse completed grid
+The ``scripts/02_grid_dependency_gci.py`` script helps to analyse completed grid
 refinement runs.  It assumes that the
 ``FENSAP_CONVERGENCE_STATS`` job was executed for each project so that
 ``results.yaml`` contains ``LIFT_COEFFICIENT`` and ``DRAG_COEFFICIENT``
-entries.  If these values are missing, ``02_full_power_gci.py`` falls back to
+entries.  If these values are missing, ``02_grid_dependency_gci.py`` falls back to
 parsing the convergence history under ``analysis/FENSAP`` and computes the
 statistics via :func:`glacium.utils.convergence.project_cl_cd_stats`.
 


### PR DESCRIPTION
## Summary
- replace outdated full power script names in README
- align grid dependency study docs with numbered scripts

## Testing
- `pytest` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_689c8ec5a3ec8327bef5c2857b500514