### PR TITLE
Reuse single-shot mesh for multishot projects

### DIFF
--- a/scripts/03_multishot_creation.py
+++ b/scripts/03_multishot_creation.py
@@ -4,21 +4,17 @@ from pathlib import Path
 from typing import Any
 
 from glacium.api import Project
+from glacium.managers.project_manager import ProjectManager
 from glacium.utils.logging import log
 
 
-def _run_project(base: Project, timings: list[float]) -> None:
+def _run_project(base: Project, timings: list[float], mesh_path: Path) -> None:
     """Instantiate ``base`` with the given ``timings`` and run it."""
 
     builder = base.clone()
     builder.set("CASE_MULTISHOT", timings)
 
     jobs = [
-        "XFOIL_REFINE",
-        "XFOIL_THICKEN_TE",
-        "XFOIL_PW_CONVERT",
-        "POINTWISE_GCI",
-        "FLUENT2FENSAP",
         "MULTISHOT_RUN",
         "CONVERGENCE_STATS",
         "POSTPROCESS_MULTISHOT",
@@ -29,6 +25,12 @@ def _run_project(base: Project, timings: list[float]) -> None:
 
     proj = builder.create()
 
+    # Reuse existing grid and clear dependencies
+    Project.set_mesh(mesh_path, proj)
+    job = proj.job_manager._jobs.get("MULTISHOT_RUN")
+    if job is not None:
+        job.deps = ()
+
     proj.run()
     log.info(f"Completed multishot project {proj.uid} ({len(timings)} shots)")
 
@@ -36,9 +38,21 @@ def _run_project(base: Project, timings: list[float]) -> None:
 def main(
     base_dir: Path | str = Path(""), case_vars: dict[str, Any] | None = None
 ) -> None:
-    """Create and run several multishot projects each generating a new grid."""
+    """Create and run multishot projects reusing the single-shot grid."""
 
     base = Path(base_dir)
+
+    # Load mesh from the single-shot project
+    single_root = base / "05_single_shot"
+    pm = ProjectManager(single_root)
+    uids = pm.list_uids()
+    if not uids:
+        log.error(f"No projects found in {single_root}")
+        return
+    if len(uids) > 1:
+        log.warning("Multiple single-shot projects found, using the first one")
+    single_proj = Project.load(single_root, uids[0])
+    mesh_path = Project.get_mesh(single_proj)
 
     base = Project(base / "03_multishot").name("multishot")
 
@@ -52,10 +66,10 @@ def main(
     ref2 = [10] + [120] * 3
     ref3 = [10] + [60] * 6
 
-    _run_project(base, ref0)
-    _run_project(base, ref1)
-    _run_project(base, ref2)
-    _run_project(base, ref3)
+    _run_project(base, ref0, mesh_path)
+    _run_project(base, ref1, mesh_path)
+    _run_project(base, ref2, mesh_path)
+    _run_project(base, ref3, mesh_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Load the single-shot run and reuse its mesh for all multishot cases
- Trim multishot job sequence to start at solver run
- Clear multishot dependencies after injecting shared mesh

## Testing
- `pytest` *(fails: Projekt '20250802-102115-458416-F3C5' existiert nicht; cannot import _SharedState)*

------
https://chatgpt.com/codex/tasks/task_e_689cadecefbc8327807d18cf17a21dd7