### PR TITLE
refactor: use instance mesh helpers on Project

### DIFF
--- a/docs/high_level_api/project.rst
+++ b/docs/high_level_api/project.rst
@@ -25,10 +25,10 @@ The object forwards unknown attributes to the underlying dataclass so
     Append ``name`` and any missing dependencies.  The jobs configuration
     and recipe are updated on disk.  Returns a list of added job names.
 
-``get_grid()``
+``get_mesh()``
     Return ``Path`` to ``mesh.grid`` inside the project.
 
-``mesh_grid(path)``
+``set_mesh(path)``
     Copy a mesh file into the project and update configuration keys.
 
 Example::

--- a/docs/run_builder.rst
+++ b/docs/run_builder.rst
@@ -29,10 +29,10 @@ Fluent methods
 ``tag(label)``
     Attach a tag to the project directory.
 
-``get_mesh(project)``
-    Return ``Path`` to ``mesh.grid`` inside ``project``.
+``get_mesh()``
+    Return ``Path`` to ``mesh.grid`` inside the project.
 
-``set_mesh(path, project)``
+``set_mesh(path)``
     Copy a mesh file into the project and update configuration keys.
 
 ``clone()``

--- a/glacium/api/project.py
+++ b/glacium/api/project.py
@@ -386,40 +386,17 @@ class Project:
         return self.__class__.load(self.runs_root, uid)
 
     # ------------------------------------------------------------------
-    @staticmethod
-    def get_mesh(project: "Project") -> Path:
-        """Return the path of ``mesh.grid`` inside ``project``."""
-
-        return project.paths.mesh_dir() / "mesh.grid"
-
-    @staticmethod
-    def set_mesh(mesh: Path, project: "Project") -> None:
-        """Copy ``mesh`` into the project and update config paths."""
-
-        dest = Project.get_mesh(project)
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(mesh, dest)
-
-        rel = Path("..") / dest.relative_to(project.root)
-        cfg_mgr = ConfigManager(project.paths)
-        cfg = cfg_mgr.load_global()
-        cfg["FSP_FILES_GRID"] = str(rel)
-        if "ICE_GRID_FILE" in cfg:
-            cfg["ICE_GRID_FILE"] = str(rel)
-        cfg_mgr.dump_global()
-
-    # ------------------------------------------------------------------
-    def get_grid(self) -> Path:
-        """Return the path to ``mesh.grid`` inside the project."""
+    def get_mesh(self) -> Path:
+        """Return the path of ``mesh.grid`` inside the project."""
 
         return self.paths.mesh_dir() / "mesh.grid"
 
-    def mesh_grid(self, grid: Path) -> None:
-        """Copy ``grid`` into the project and update configuration keys."""
+    def set_mesh(self, mesh: Path) -> None:
+        """Copy ``mesh`` into the project and update config paths."""
 
-        dest = self.get_grid()
+        dest = self.get_mesh()
         dest.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(grid, dest)
+        shutil.copy2(mesh, dest)
 
         rel = Path("..") / dest.relative_to(self.root)
         cfg_mgr = ConfigManager(self.paths)

--- a/glacium/utils/project_utils.py
+++ b/glacium/utils/project_utils.py
@@ -24,9 +24,7 @@ def reuse_mesh(project: "Project", mesh_path: Path | str, job_name: str) -> None
     job_name
         Name of the job whose dependencies should be cleared.
     """
-    from glacium.api import Project as _Project
-
-    _Project.set_mesh(Path(mesh_path), project)
+    project.set_mesh(Path(mesh_path))
     job = project.job_manager._jobs.get(job_name)
     if job is not None:
         job.deps = ()

--- a/scripts/03_multishot_creation.py
+++ b/scripts/03_multishot_creation.py
@@ -26,7 +26,7 @@ def _run_project(base: Project, timings: list[float], mesh_path: Path) -> None:
     proj = builder.create()
 
     # Reuse existing grid and clear dependencies
-    Project.set_mesh(mesh_path, proj)
+    proj.set_mesh(mesh_path)
     job = proj.job_manager._jobs.get("MULTISHOT_RUN")
     if job is not None:
         job.deps = ()
@@ -52,7 +52,7 @@ def main(
     if len(uids) > 1:
         log.warning("Multiple single-shot projects found, using the first one")
     single_proj = Project.load(single_root, uids[0])
-    mesh_path = Project.get_mesh(single_proj)
+    mesh_path = single_proj.get_mesh()
 
     base = Project(base / "03_multishot").name("multishot")
 

--- a/scripts/07_clean_sweep_creation.py
+++ b/scripts/07_clean_sweep_creation.py
@@ -35,7 +35,7 @@ def main(
     if len(uids) > 1:
         log.warning("Multiple single-shot projects found, using the first one")
     single_proj = Project.load(single_root, uids[0])
-    mesh_path = Project.get_mesh(single_proj)
+    mesh_path = single_proj.get_mesh()
 
     base = Project(base_path / "07_clean_sweep").name("aoa_sweep")
     base.set("RECIPE", "fensap")
@@ -67,7 +67,7 @@ def main(
         for job in jobs:
             builder.add_job(job)
         proj = builder.create()
-        proj.set_mesh(mesh_path, proj)
+        proj.set_mesh(mesh_path)
         job = proj.job_manager._jobs.get("FENSAP_RUN")
         if job is not None:
             job.deps = ()

--- a/scripts/load_test.py
+++ b/scripts/load_test.py
@@ -8,7 +8,7 @@ from glacium.utils.logging import log
 base_dir = ""
 root = Path(base_dir) / "StudyTest"
 base = Project.load("StudyTest", "20250802-102115-458416-F3C5")
-base.get_grid()
+base.get_mesh()
 
 proj = base.clone()
 proj.add_job("FENSAP_RUN")

--- a/tests/test_project_api.py
+++ b/tests/test_project_api.py
@@ -86,7 +86,7 @@ def test_load_add_job_and_run(tmp_path, monkeypatch):
     assert called["jobs"] == ["POINTWISE_MESH2"]
 
 
-def test_project_mesh_grid(tmp_path):
+def test_project_set_mesh(tmp_path):
     TemplateManager(Path(__file__).resolve().parents[1] / "glacium" / "templates")
     run = Project(tmp_path)
     project = run.create()
@@ -94,9 +94,9 @@ def test_project_mesh_grid(tmp_path):
     grid_src = tmp_path / "input.grid"
     grid_src.write_text("griddata")
 
-    project.mesh_grid(grid_src)
+    project.set_mesh(grid_src)
 
-    dest = project.get_grid()
+    dest = project.get_mesh()
     assert dest.read_text() == "griddata"
 
     cfg_file = tmp_path / project.uid / "_cfg" / "global_config.yaml"

--- a/tests/test_run_builder.py
+++ b/tests/test_run_builder.py
@@ -76,9 +76,9 @@ def test_run_builder_mesh_helpers(tmp_path):
 
     mesh_src = tmp_path / "input.grid"
     mesh_src.write_text("meshdata")
-    run.set_mesh(mesh_src, project)
+    project.set_mesh(mesh_src)
 
-    dest = run.get_mesh(project)
+    dest = project.get_mesh()
     assert dest.read_text() == "meshdata"
 
     cfg = yaml.safe_load((tmp_path / project.uid / "_cfg" / "global_config.yaml").read_text())


### PR DESCRIPTION
## Summary
- convert `Project.get_mesh`/`set_mesh` into instance methods
- remove `get_grid`/`mesh_grid` and update utilities, scripts, tests, and docs

## Testing
- `pytest` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_689cb4ee760c8327bdec4d0507d8a5f3