### PR TITLE
docs: clarify POSTPROCESS_SINGLE_FENSAP dependencies

### DIFF
--- a/docs/high_level_api/postprocessing.rst
+++ b/docs/high_level_api/postprocessing.rst
@@ -47,8 +47,11 @@ and thus become available as soon as they are imported from
 Automatic jobs
 --------------
 
-``POSTPROCESS_SINGLE_FENSAP`` and ``POSTPROCESS_MULTISHOT`` convert solver
-results and write a ``manifest.json`` under the project root.
+``POSTPROCESS_SINGLE_FENSAP`` converts single-shot solver results and writes a
+``manifest.json`` under the project root. It runs after the last available
+solver: if ``DROP3D_RUN`` or ``ICE3D_RUN`` jobs exist they must finish first,
+otherwise it executes immediately after ``FENSAP_RUN``. ``POSTPROCESS_MULTISHOT``
+handles ``run_MULTISHOT`` in a similar fashion.
 ``FENSAP_ANALYSIS`` runs :func:`glacium.utils.postprocess_fensap.fensap_analysis`
 to create slice screenshots for ``run_FENSAP/soln.dat``.
 ``MESH_ANALYSIS`` executes :func:`glacium.utils.mesh_analysis.mesh_analysis`
@@ -64,6 +67,9 @@ You can also add the jobs explicitly::
 
    from glacium.api import Project
    proj = Project.load("runs", "uid")
+   proj.add_job("DROP3D_RUN")
+   proj.add_job("ICE3D_RUN")
+   proj.add_job("POSTPROCESS_SINGLE_FENSAP")  # waits for DROP3D_RUN and ICE3D_RUN
    proj.add_job("FENSAP_ANALYSIS")
    proj.add_job("MESH_ANALYSIS")
    proj.run()

--- a/specs_postprocessing.md
+++ b/specs_postprocessing.md
@@ -207,11 +207,25 @@ class FensapMultiImporter:
 
 | Job name                    | Purpose                                                                                     | Implementation hint                                |
 | --------------------------- | ------------------------------------------------------------------------------------------- | -------------------------------------------------- |
-| `POSTPROCESS_SINGLE_FENSAP` | Calls `SingleShotConverter(root).convert()` *once* per single‑shot run directory.           | Attach to `run_FENSAP`, `run_DROP3D`, `run_ICE3D`. |
+| `POSTPROCESS_SINGLE_FENSAP` | Calls `SingleShotConverter(root).convert()` *once* per single‑shot run directory.           | Waits for `DROP3D_RUN` and `ICE3D_RUN` when present; otherwise runs after `FENSAP_RUN`. |
 | `FENSAP_ANALYSIS`           | Create slice screenshots from `run_FENSAP/soln.dat` using `fensap_analysis`. Results are written to `analysis/FENSAP`. | Attach after `POSTPROCESS_SINGLE_FENSAP`. |
 | `POSTPROCESS_MULTISHOT`     | Calls `MultiShotConverter(root / "run_MULTISHOT").convert_all()` after the solver finishes. | Attach at pipeline end.                            |
 | `ANALYZE_MULTISHOT`         | Run analysis helpers on MULTISHOT data and store plots in `analysis/MULTISHOT`. | Attach after `POSTPROCESS_MULTISHOT`. |
 | `MESH_ANALYSIS`             | Create mesh quality screenshots and an HTML report using `mesh_analysis`. Results are written to `analysis/MESH`. | Run after meshing is complete. |
+
+Example dependency order:
+
+```python
+# FENSAP only
+proj.add_job("FENSAP_RUN")
+proj.add_job("POSTPROCESS_SINGLE_FENSAP")  # runs after FENSAP_RUN
+
+# With extra solvers
+proj.add_job("FENSAP_RUN")
+proj.add_job("DROP3D_RUN")
+proj.add_job("ICE3D_RUN")
+proj.add_job("POSTPROCESS_SINGLE_FENSAP")  # waits for DROP3D_RUN and ICE3D_RUN
+```
 
 POSTPROCESS jobs create a manifest (`manifest.json`) so the PostProcessor loads instantly:
 


### PR DESCRIPTION
## Summary
- document that POSTPROCESS_SINGLE_FENSAP waits for DROP3D_RUN and ICE3D_RUN when present
- update post-processing spec with dynamic dependency examples

## Testing
- `pytest -q` *(fails: FileNotFoundError: Projekt '20250802-102115-458416-F3C5' existiert nicht; ImportError: cannot import name '_SharedState')*

------
https://chatgpt.com/codex/tasks/task_e_689dae548db48327a8a4a7566437a679