### PR TITLE
Recompute runnable jobs after each execution

### DIFF
--- a/glacium/managers/job_manager.py
+++ b/glacium/managers/job_manager.py
@@ -116,16 +116,21 @@ class JobManager:
                     return False
             return True
 
-        while True:
+        def compute_runnable() -> List[Job]:
             runnable_statuses = {JobStatus.PENDING, JobStatus.STALE}
             if include_failed:
                 runnable_statuses.add(JobStatus.FAILED)
-            runnable = [j for j in self._jobs.values()
-                        if j.name in target and j.status in runnable_statuses and ready(j)]
+            return [
+                j
+                for j in self._jobs.values()
+                if j.name in target and j.status in runnable_statuses and ready(j)
+            ]
+
+        while True:
+            runnable = compute_runnable()
             if not runnable:
                 break
-            for job in runnable:
-                self._execute(job)
+            self._execute(runnable[0])
         self._save_status()
 
     # ------------------------------------------------------------------

--- a/tests/test_jobmanager_runnable_order.py
+++ b/tests/test_jobmanager_runnable_order.py
@@ -1,0 +1,64 @@
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# Avoid executing glacium.__init__ (pulls heavy optional deps)
+pkg_root = Path(__file__).resolve().parents[1] / "glacium"
+glacium_stub = types.ModuleType("glacium")
+glacium_stub.__path__ = [str(pkg_root)]
+sys.modules.setdefault("glacium", glacium_stub)
+
+from glacium.models.config import GlobalConfig
+from glacium.managers.path_manager import PathBuilder
+from glacium.models.project import Project
+from glacium.managers.job_manager import JobManager
+from glacium.models.job import Job
+
+
+def _project(root: Path) -> Project:
+    cfg = GlobalConfig(project_uid="uid", base_dir=root)
+    paths = PathBuilder(root).build()
+    paths.ensure()
+    return Project("uid", root, cfg, paths, [])
+
+
+def test_scheduler_picks_newly_ready_jobs_before_unrelated(tmp_path):
+    executed: list[str] = []
+    project = _project(tmp_path)
+
+    class A(Job):
+        name = "A"
+        deps = ()
+
+        def execute(self):
+            executed.append(self.name)
+
+    class B(Job):
+        name = "B"
+        deps = ("A",)
+
+        def execute(self):
+            executed.append(self.name)
+
+    class D(Job):
+        name = "D"
+        deps = ("B",)
+
+        def execute(self):
+            executed.append(self.name)
+
+    class C(Job):
+        name = "C"
+        deps = ("A",)
+
+        def execute(self):
+            executed.append(self.name)
+
+    project.jobs = [A(project), B(project), D(project), C(project)]
+
+    jm = JobManager(project)
+    jm.run()
+
+    assert executed == ["A", "B", "D", "C"]


### PR DESCRIPTION
## Summary
- Recompute runnable job list after every job execution to pick up newly ready jobs immediately
- Add unit test verifying that jobs released by dependencies run before unrelated tasks

## Testing
- `pytest tests/test_jobmanager_runnable_order.py tests/test_jobmanager_include_failed.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689db224d61c8327b59d8abb08bfe1c7