### PR TITLE
Allow custom name for full power study

### DIFF
--- a/docs/full_power_study.rst
+++ b/docs/full_power_study.rst
@@ -88,6 +88,10 @@ The entire sequence can be executed with::
 
    python scripts/00_fullpower.py <study_name>
 
+For example, to use a custom directory name::
+
+   python scripts/00_fullpower.py my_study
+
 Running the driver creates ``<study_name>/`` (default
 ``C02_V50_T2_L052``) and executes each subscript within that directory.
 The resulting structure is::

--- a/scripts/00_fullpower.py
+++ b/scripts/00_fullpower.py
@@ -1,8 +1,16 @@
 from __future__ import annotations
 
+"""Drive the full power study scripts.
+
+Results are written into a study directory. If no name is provided,
+the default ``C02_V50_T2_L052`` is used.
+"""
+
 from pathlib import Path
 import argparse
 import subprocess
+
+DEFAULT_STUDY_NAME = "C02_V50_T2_L052"
 
 SCRIPTS = [
     "01_full_power_creation.py",
@@ -20,7 +28,8 @@ SCRIPTS = [
 
 
 def main(study_name: str | None = None) -> None:
-    study_name = "C02_V50_T2_L052"
+    if study_name is None:
+        study_name = DEFAULT_STUDY_NAME
 
     base_dir = Path(study_name)
     base_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- Allow passing a custom study directory name to `00_fullpower.py` with a documented default fallback
- Document how to provide a custom name when running the full power study driver

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'veusz'; ModuleNotFoundError: No module named 'reportlab')*

------
https://chatgpt.com/codex/tasks/task_e_68a4691717508327b476276a11b3d25a