### PR TITLE
docs: clarify FENSAP analysis outputs

### DIFF
--- a/docs/high_level_api/postprocessing.rst
+++ b/docs/high_level_api/postprocessing.rst
@@ -52,9 +52,11 @@ Automatic jobs
 solver: if ``DROP3D_RUN`` or ``ICE3D_RUN`` jobs exist they must finish first,
 otherwise it executes immediately after ``FENSAP_RUN``. ``POSTPROCESS_MULTISHOT``
 handles ``run_MULTISHOT`` in a similar fashion.
-``FENSAP_ANALYSIS`` runs
-:func:`glacium.post.analysis.fensap_flow_plots.fensap_flow_plots`
-to create slice screenshots for ``run_FENSAP/soln.dat``.
+``FENSAP_ANALYSIS`` invokes the
+:mod:`glacium.post.analysis.fensap_flow_plots` module to create slice
+screenshots for ``run_FENSAP/soln.dat``. The script emits each slice as
+PNG, PDF and SVG files in two preset sizes (full and double column) so
+that both high-resolution figures and compact thumbnails are available.
 ``MESH_ANALYSIS`` executes :func:`glacium.utils.mesh_analysis.mesh_analysis`
 and produces a mesh quality report under ``analysis/MESH``.
 ``ANALYZE_MULTISHOT`` runs the analysis helpers afterwards and stores figures


### PR DESCRIPTION
## Summary
- reference `glacium.post.analysis.fensap_flow_plots` in FENSAP_ANALYSIS docs
- note multi-format multi-size figures produced

## Testing
- `cd docs && make html`

------
https://chatgpt.com/codex/tasks/task_e_68a83afc67608327a1eea51e03a68cb5