### PR TITLE
Remove flow postprocess jobs from single and multishot creation

### DIFF
--- a/scripts/03_single_shot_creation.py
+++ b/scripts/03_single_shot_creation.py
@@ -58,7 +58,6 @@ def main(
         "DROP3D_CONVERGENCE_STATS",
         "ICE3D_RUN",
         "ICE3D_CONVERGENCE_STATS",
-        "POSTPROCESS_SINGLE_FENSAP",
         "FENSAP_ANALYSIS",
     ]
     for j in jobs:

--- a/scripts/05_multishot_creation.py
+++ b/scripts/05_multishot_creation.py
@@ -47,7 +47,6 @@ def _run_project(base: Project, timings: list[float], mesh_path: Path) -> None:
     jobs = [
         "MULTISHOT_RUN",
         "CONVERGENCE_STATS",
-        "POSTPROCESS_MULTISHOT",
         "ANALYZE_MULTISHOT",
     ]
     for name in jobs:


### PR DESCRIPTION
## Summary
- Drop `POSTPROCESS_SINGLE_FENSAP` from single-shot creation jobs
- Remove `POSTPROCESS_MULTISHOT` from multishot creation helper
- Verified only grid study or AoA sweep scripts still schedule flow-picture postprocessing

## Testing
- `pytest` *(fails: Interrupted: 29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a83fe4df5883279cc69a39b9ffa919