### PR TITLE
Refactor AoA sweep with adaptive refinement

### DIFF
--- a/scripts/07_clean_sweep_creation.py
+++ b/scripts/07_clean_sweep_creation.py
@@ -31,8 +31,9 @@ from glacium.api import Project
 from glacium.managers.project_manager import ProjectManager
 from glacium.utils.logging import log
 
-
 from typing import Any
+
+from sweep_helper import aoa_sweep
 
 
 def main(
@@ -81,23 +82,13 @@ def main(
 
     #base.set("PWS_REFINEMENT", 0.5)
 
-    jobs = [
-        "FENSAP_CONVERGENCE_STATS",
-        "POSTPROCESS_SINGLE_FENSAP",
-        "FENSAP_ANALYSIS",
-    ]
-
-    for aoa in range(-4, 18, 2):
-        builder = base.clone().set("CASE_AOA", aoa)
-        for job in jobs:
-            builder.add_job(job)
-        proj = builder.create()
+    def setup(proj: Project) -> None:
         proj.set_mesh(mesh_path)
         job = proj.job_manager._jobs.get("FENSAP_RUN")
         if job is not None:
             job.deps = ()
-        proj.run()
-        log.info(f"Completed angle {aoa}")
+
+    aoa_sweep(base, range(-4, 18, 2), setup)
 
 
 if __name__ == "__main__":

--- a/scripts/09_iced_sweep_creation.py
+++ b/scripts/09_iced_sweep_creation.py
@@ -42,6 +42,8 @@ from glacium.utils.logging import log
 
 import importlib
 
+from sweep_helper import aoa_sweep
+
 multishot_analysis = importlib.import_module("06_multishot_analysis")
 load_multishot_project = multishot_analysis.load_multishot_project
 
@@ -91,20 +93,10 @@ def main(
 
     base.set("PWS_REFINEMENT", 0.5)
 
-    jobs = [
-        "FENSAP_CONVERGENCE_STATS",
-        "POSTPROCESS_SINGLE_FENSAP",
-        "FENSAP_ANALYSIS",
-    ]
-
-    for aoa in range(-4, 18, 2):
-        builder = base.clone().set("CASE_AOA", aoa)
-        for job in jobs:
-            builder.add_job(job)
-        proj = builder.create()
+    def setup(proj: Project) -> None:
         reuse_mesh(proj, grid_path, "FENSAP_RUN")
-        proj.run()
-        log.info(f"Completed angle {aoa}")
+
+    aoa_sweep(base, range(-4, 18, 2), setup)
 
 
 if __name__ == "__main__":

--- a/scripts/sweep_helper.py
+++ b/scripts/sweep_helper.py
@@ -1,0 +1,105 @@
+"""Utilities for running angle-of-attack sweeps.
+
+This module contains helper logic shared by the clean and iced sweep
+creation scripts.  The :func:`aoa_sweep` function executes a sweep over a
+set of angles of attack, recording lift coefficients after each run and
+optionally refining the sweep once the lift begins to decrease.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Iterable, List, Tuple
+
+from glacium.api import Project
+from glacium.utils.convergence import project_cl_cd_stats
+from glacium.utils.logging import log
+
+
+def _jobs_for_aoa(aoa: float) -> list[str]:
+    """Return the job list for a given angle of attack."""
+
+    jobs = ["FENSAP_CONVERGENCE_STATS", "FENSAP_ANALYSIS"]
+    if aoa == 0:
+        jobs.append("POSTPROCESS_SINGLE_FENSAP")
+    return jobs
+
+
+def aoa_sweep(
+    base: Project,
+    aoas: Iterable[float],
+    setup: Callable[[Project], None],
+) -> List[Tuple[float, float, Project]]:
+    """Execute an AOA sweep.
+
+    Parameters
+    ----------
+    base:
+        Base project configured with common parameters.
+    aoas:
+        Angles of attack to execute.
+    setup:
+        Callback invoked with each created project before running.  This is
+        used to apply case-specific setup such as mesh reuse.
+
+    Returns
+    -------
+    list[tuple[float, float, Project]]
+        ``(aoa, cl, project)`` tuples for each executed case.
+    """
+
+    results: List[Tuple[float, float, Project]] = []
+    prev_cl: float | None = None
+    stalled = False
+
+    for aoa in aoas:
+        builder = base.clone().set("CASE_AOA", aoa)
+        for job in _jobs_for_aoa(aoa):
+            builder.add_job(job)
+        proj = builder.create()
+        setup(proj)
+        proj.run()
+        log.info(f"Completed angle {aoa}")
+
+        cl = proj.get("LIFT_COEFFICIENT")
+        if cl is None:
+            try:
+                cl, *_ = project_cl_cd_stats(proj.root / "analysis" / "FENSAP")
+            except FileNotFoundError:
+                cl = float("nan")
+
+        results.append((aoa, cl, proj))
+        if prev_cl is not None and cl < prev_cl:
+            stalled = True
+            break
+        prev_cl = cl
+
+    if stalled and len(results) >= 3:
+        last = results[-3:]
+        min_aoa = min(a for a, _, _ in last)
+        max_aoa = max(a for a, _, _ in last)
+        executed = {a for a, _, _ in results}
+        for half in range(int(min_aoa * 2), int(max_aoa * 2) + 1):
+            aoa = half / 2
+            if aoa in executed:
+                continue
+            builder = base.clone().set("CASE_AOA", aoa)
+            for job in _jobs_for_aoa(aoa):
+                builder.add_job(job)
+            proj = builder.create()
+            setup(proj)
+            proj.run()
+            log.info(f"Completed angle {aoa}")
+
+            cl = proj.get("LIFT_COEFFICIENT")
+            if cl is None:
+                try:
+                    cl, *_ = project_cl_cd_stats(proj.root / "analysis" / "FENSAP")
+                except FileNotFoundError:
+                    cl = float("nan")
+            results.append((aoa, cl, proj))
+
+    return results
+
+
+__all__ = ["aoa_sweep"]
+


### PR DESCRIPTION
## Summary
- Refactor AoA sweep scripts to share logic via `sweep_helper.aoa_sweep`
- Record lift coefficients and halt sweep once lift drops
- Add adaptive 0.5° refinement over last three angles and only postprocess at 0°

## Testing
- `pytest` *(fails: 29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a845495b208327888c1c2ad59b385a