### PR TITLE
Refactor sweep helper to control postprocessing AoAs

### DIFF
--- a/scripts/01_full_power_creation.py
+++ b/scripts/01_full_power_creation.py
@@ -71,7 +71,6 @@ def main(base_dir: Path | str = Path(""), case_vars: dict[str, Any] | None = Non
         "FLUENT2FENSAP",
         "FENSAP_RUN",
         "FENSAP_CONVERGENCE_STATS",
-        "POSTPROCESS_SINGLE_FENSAP",
         "FENSAP_ANALYSIS",
     ]
 

--- a/scripts/07_clean_sweep_creation.py
+++ b/scripts/07_clean_sweep_creation.py
@@ -88,7 +88,7 @@ def main(
         if job is not None:
             job.deps = ()
 
-    aoa_sweep(base, range(-4, 18, 2), setup)
+    aoa_sweep(base, range(-4, 18, 2), setup, postprocess_aoas={0})
 
 
 if __name__ == "__main__":

--- a/scripts/09_iced_sweep_creation.py
+++ b/scripts/09_iced_sweep_creation.py
@@ -96,7 +96,7 @@ def main(
     def setup(proj: Project) -> None:
         reuse_mesh(proj, grid_path, "FENSAP_RUN")
 
-    aoa_sweep(base, range(-4, 18, 2), setup)
+    aoa_sweep(base, range(-4, 18, 2), setup, postprocess_aoas={0})
 
 
 if __name__ == "__main__":

--- a/scripts/create_mesh.py
+++ b/scripts/create_mesh.py
@@ -30,7 +30,6 @@ mesh_jobs = [
     "FENSAP_RUN",
     "DROP3D_RUN",
     "ICE3D_RUN",
-    "POSTPROCESS_SINGLE_FENSAP",
     "FENSAP_ANALYSIS",
     "MULTISHOT_RUN"
 ]


### PR DESCRIPTION
## Summary
- Allow specifying which angles receive `POSTPROCESS_SINGLE_FENSAP` via new `postprocess_aoas` argument in `aoa_sweep`
- Reuse iced grid meshes in sweep creation and pass `postprocess_aoas={0}`
- Remove `POSTPROCESS_SINGLE_FENSAP` from default job lists in helper and example scripts

## Testing
- `pytest` *(fails: Interrupted: 29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a8472a7804832791d9fda57f93b3c2