### PR TITLE
Add reusable AoA sweep helper

### DIFF
--- a/glacium/utils/__init__.py
+++ b/glacium/utils/__init__.py
@@ -16,3 +16,4 @@ from .convergence import (
 from .solver_time import parse_execution_time
 from .project_utils import reuse_mesh
 from .string_utils import normalise_key
+from .aoa_sweep import run_aoa_sweep

--- a/glacium/utils/aoa_sweep.py
+++ b/glacium/utils/aoa_sweep.py
@@ -1,0 +1,108 @@
+"""Utilities to execute angle-of-attack sweeps.
+
+This module provides :func:`run_aoa_sweep` which drives a series of
+FENSAP runs over a list of angles of attack (AoA).  It executes the
+requested jobs for each AoA and optionally reruns the last three angles in
+0.5° steps once a stall is detected.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Iterable, List, Tuple, Set
+
+from glacium.api import Project
+from glacium.utils.convergence import project_cl_cd_stats
+from glacium.utils.logging import log
+
+__all__ = ["run_aoa_sweep"]
+
+
+def _cl_from_project(proj: Project) -> float:
+    """Return the lift coefficient for ``proj``.
+
+    The value is read from the project configuration; if unavailable a
+    fallback is extracted from the convergence statistics.
+    """
+    try:
+        val = proj.get("LIFT_COEFFICIENT")
+        if val is not None:
+            return float(val)
+    except Exception:
+        pass
+
+    try:
+        cl, *_ = project_cl_cd_stats(proj.root / "analysis" / "FENSAP")
+        return float(cl)
+    except FileNotFoundError:
+        return float("nan")
+
+
+def run_aoa_sweep(
+    base: Project,
+    aoas: Iterable[float],
+    jobs: list[str],
+    postprocess_aoas: Set[float],
+    mesh_hook: Callable[[Project], None] | None = None,
+) -> List[Tuple[float, float, Project]]:
+    """Execute an AoA sweep and return ``(aoa, cl, project)`` tuples.
+
+    Parameters
+    ----------
+    base:
+        Base project configured with common parameters.
+    aoas:
+        Angles of attack to execute.
+    jobs:
+        Jobs to run for each AoA. ``POSTPROCESS_SINGLE_FENSAP`` will be
+        appended automatically for angles listed in ``postprocess_aoas``.
+    postprocess_aoas:
+        Angles that should include the post-processing job.
+    mesh_hook:
+        Optional callback applied to each created project after creation
+        but before executing the jobs. This can be used to attach or reuse
+        meshes and adjust job dependencies.
+    """
+
+    results: List[Tuple[float, float, Project]] = []
+    executed: Set[float] = set()
+    prev_cl: float | None = None
+    stalled = False
+    postprocess_aoas = set(postprocess_aoas)
+
+    def _run_single(aoa: float) -> Tuple[float, float, Project]:
+        builder = base.clone().set("CASE_AOA", aoa)
+        for j in jobs:
+            builder.add_job(j)
+        if aoa in postprocess_aoas:
+            builder.add_job("POSTPROCESS_SINGLE_FENSAP")
+        proj = builder.create()
+        if mesh_hook is not None:
+            mesh_hook(proj)
+        proj.run()
+        log.info(f"Completed angle {aoa}")
+        cl = _cl_from_project(proj)
+        executed.add(aoa)
+        return aoa, cl, proj
+
+    for aoa in aoas:
+        aoa, cl, proj = _run_single(float(aoa))
+        results.append((aoa, cl, proj))
+        if prev_cl is not None and cl < prev_cl:
+            stalled = True
+            break
+        prev_cl = cl
+
+    if stalled and len(results) >= 3:
+        window = results[-3:]
+        min_a = min(a for a, _, _ in window)
+        max_a = max(a for a, _, _ in window)
+        start = int(min_a * 2)
+        end = int(max_a * 2)
+        for half in range(start, end + 1):
+            aoa = half / 2
+            if aoa in executed:
+                continue
+            aoa, cl, proj = _run_single(aoa)
+            results.append((aoa, cl, proj))
+
+    return results

--- a/scripts/07_clean_sweep_creation.py
+++ b/scripts/07_clean_sweep_creation.py
@@ -29,11 +29,10 @@ from pathlib import Path
 
 from glacium.api import Project
 from glacium.managers.project_manager import ProjectManager
+from glacium.utils import reuse_mesh, run_aoa_sweep
 from glacium.utils.logging import log
 
 from typing import Any
-
-from sweep_helper import aoa_sweep
 
 
 def main(
@@ -80,15 +79,9 @@ def main(
     for key, val in params.items():
         base.set(key, val)
 
-    #base.set("PWS_REFINEMENT", 0.5)
-
-    def setup(proj: Project) -> None:
-        proj.set_mesh(mesh_path)
-        job = proj.job_manager._jobs.get("FENSAP_RUN")
-        if job is not None:
-            job.deps = ()
-
-    aoa_sweep(base, range(-4, 18, 2), setup, postprocess_aoas={0})
+    jobs = ["FENSAP_CONVERGENCE_STATS", "FENSAP_ANALYSIS"]
+    mesh = lambda proj: reuse_mesh(proj, mesh_path, "FENSAP_RUN")
+    run_aoa_sweep(base, range(-4, 18, 2), jobs, postprocess_aoas={0}, mesh_hook=mesh)
 
 
 if __name__ == "__main__":

--- a/scripts/09_iced_sweep_creation.py
+++ b/scripts/09_iced_sweep_creation.py
@@ -37,12 +37,10 @@ from typing import Any
 import re
 
 from glacium.api import Project
-from glacium.utils import reuse_mesh
+from glacium.utils import reuse_mesh, run_aoa_sweep
 from glacium.utils.logging import log
 
 import importlib
-
-from sweep_helper import aoa_sweep
 
 multishot_analysis = importlib.import_module("06_multishot_analysis")
 load_multishot_project = multishot_analysis.load_multishot_project
@@ -93,10 +91,9 @@ def main(
 
     base.set("PWS_REFINEMENT", 0.5)
 
-    def setup(proj: Project) -> None:
-        reuse_mesh(proj, grid_path, "FENSAP_RUN")
-
-    aoa_sweep(base, range(-4, 18, 2), setup, postprocess_aoas={0})
+    jobs = ["FENSAP_CONVERGENCE_STATS", "FENSAP_ANALYSIS"]
+    mesh = lambda proj: reuse_mesh(proj, grid_path, "FENSAP_RUN")
+    run_aoa_sweep(base, range(-4, 18, 2), jobs, postprocess_aoas={0}, mesh_hook=mesh)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `run_aoa_sweep` utility to orchestrate angle-of-attack sweeps with stall detection and optional mesh reuse
- refactor clean and iced sweep creation scripts to use new helper

## Testing
- `pytest` *(fails: 32 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a8486405408327828c1510981f9cd8