### PR TITLE
fix circular import in aoa_sweep

### DIFF
--- a/glacium/utils/aoa_sweep.py
+++ b/glacium/utils/aoa_sweep.py
@@ -8,9 +8,10 @@ requested jobs for each AoA and optionally reruns the last three angles in
 
 from __future__ import annotations
 
-from typing import Callable, Iterable, List, Tuple, Set
+from typing import Callable, Iterable, List, Tuple, Set, TYPE_CHECKING
 
-from glacium.api import Project
+if TYPE_CHECKING:  # pragma: no cover - used for type checkers only
+    from glacium.api import Project
 from glacium.utils.convergence import project_cl_cd_stats
 from glacium.utils.logging import log
 


### PR DESCRIPTION
## Summary
- avoid circular import between utils and api by importing Project only for type checking in `aoa_sweep`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'veusz', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a84deee28c8327944a241ae06ec81b