### PR TITLE
Run post-processing before multishot analysis

### DIFF
--- a/scripts/05_multishot_creation.py
+++ b/scripts/05_multishot_creation.py
@@ -47,6 +47,7 @@ def _run_project(base: Project, timings: list[float], mesh_path: Path) -> None:
     jobs = [
         "MULTISHOT_RUN",
         "CONVERGENCE_STATS",
+        "POSTPROCESS_MULTISHOT",
         "ANALYZE_MULTISHOT",
     ]
     for name in jobs:


### PR DESCRIPTION
## Summary
- ensure multishot projects perform POSTPROCESS_MULTISHOT before ANALYZE_MULTISHOT

## Testing
- `pytest tests/test_analyze_multishot_job.py::test_analyze_multishot_job tests/test_postprocess_jobs.py::test_postprocess_multishot tests/test_multishot_timings.py::test_multishot_timings -q`
- `PYTHONPATH=.. python scripts/05_multishot_creation.py` *(fails: xfoil.exe and FENSAP solver not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a86db31d608327b154ce212dc14fc8