### PR TITLE
Generate multishot curve plots and archive shot folders

### DIFF
--- a/scripts/06_multishot_analysis.py
+++ b/scripts/06_multishot_analysis.py
@@ -14,7 +14,8 @@ base_dir : Path | str, optional
 
 Outputs
 -------
-Files such as ``ice_growth.gif`` copied to ``06_multishot_results``.
+Files such as ``ice_growth.gif`` and per-shot ``plots/curve_s.pdf`` copied to
+``06_multishot_results``.
 
 Usage
 -----
@@ -32,6 +33,8 @@ from __future__ import annotations
 
 from pathlib import Path
 import shutil
+import subprocess
+import sys
 
 from glacium.api import Project
 from glacium.managers.project_manager import ProjectManager
@@ -79,7 +82,13 @@ def load_multishot_project(root: Path) -> Project:
 
 
 def analyze_project(proj: Project, out_dir: Path) -> None:
-    """Collect basic analysis artefacts for a multishot project."""
+    """Collect analysis artefacts for a multishot project.
+
+    Besides copying ``ice_growth.gif``, each shot subdirectory containing a
+    ``merged.dat`` file is processed with ``glacium.post.multishot.plot_s`` to
+    generate ``plots/curve_s.pdf``. The populated shot directories are copied to
+    ``out_dir``.
+    """
 
     out_dir.mkdir(parents=True, exist_ok=True)
     ms_dir = proj.root / "analysis" / "MULTISHOT"
@@ -87,6 +96,30 @@ def analyze_project(proj: Project, out_dir: Path) -> None:
     gif = ms_dir / "ice_growth.gif"
     if gif.exists():
         shutil.copy2(gif, out_dir / gif.name)
+
+    for shot_dir in ms_dir.iterdir():
+        merged = shot_dir / "merged.dat"
+        if not merged.exists():
+            continue
+
+        plots_pdf = shot_dir / "plots" / "curve_s.pdf"
+        plots_pdf.parent.mkdir(parents=True, exist_ok=True)
+
+        try:
+            subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "glacium.post.multishot.plot_s",
+                    str(merged),
+                    str(plots_pdf),
+                ],
+                check=True,
+            )
+        except Exception as err:  # pragma: no cover - logging only
+            log.error(f"plot_s failed for {merged}: {err}")
+
+        shutil.copytree(shot_dir, out_dir / shot_dir.name, dirs_exist_ok=True)
 
 
 def main(base_dir: Path | str = Path("")) -> None:


### PR DESCRIPTION
## Summary
- Extend multishot analysis script to create `plots/curve_s.pdf` for each shot via `glacium.post.multishot.plot_s`
- Copy processed shot directories, including plots, into `06_multishot_results`

## Testing
- `pytest --ignore=glacium/data/veusz_test.py` *(fails: ModuleNotFoundError: scienceplots, reportlab)*

------
https://chatgpt.com/codex/tasks/task_e_68a99481bc1c8327af7cb4907ca8aba8