### PR TITLE
Normalize FENSAP flow plots by chord length

### DIFF
--- a/docs/full_power_study.rst
+++ b/docs/full_power_study.rst
@@ -40,7 +40,8 @@ Subscripts
 
 #. ``07_clean_sweep_creation.py`` sweeps angle of attack for the clean geometry
    using a pre-existing grid.  It relies on the FENSAP recipe and adds analysis
-   jobs like ``FENSAP_ANALYSIS``.  Example::
+   jobs like ``FENSAP_ANALYSIS`` (which normalises flow plots by the
+   characteristic chord length).  Example::
 
       python scripts/07_clean_sweep_creation.py
 

--- a/docs/high_level_api/postprocessing.rst
+++ b/docs/high_level_api/postprocessing.rst
@@ -57,6 +57,8 @@ handles ``run_MULTISHOT`` in a similar fashion.
 screenshots for ``run_FENSAP/soln.dat``. The script emits each slice as
 PNG, PDF and SVG files in two preset sizes (full and double column) so
 that both high-resolution figures and compact thumbnails are available.
+Coordinates are normalised by the case characteristic length
+(``CASE_CHARACTERISTIC_LENGTH``) so the resulting axes show ``x/c`` and ``y/c``.
 ``MESH_ANALYSIS`` executes :func:`glacium.utils.mesh_analysis.mesh_analysis`
 and produces a mesh quality report under ``analysis/MESH``.
 ``ANALYZE_MULTISHOT`` runs the analysis helpers afterwards and stores figures

--- a/glacium/jobs/analysis_jobs.py
+++ b/glacium/jobs/analysis_jobs.py
@@ -158,9 +158,11 @@ class FensapAnalysisJob(Job):
         out_dir = project_root / "analysis" / "FENSAP"
 
         out_dir.mkdir(parents=True, exist_ok=True)
+        cfg = self.project.config
+        chord = float(cfg.get("CASE_CHARACTERISTIC_LENGTH", 1.0))
 
         engine = PyEngine(fensap_flow_plots)
-        engine.run([dat_file, out_dir], cwd=project_root)
+        engine.run([dat_file, out_dir, "--scale", str(chord)], cwd=project_root)
 
 
 class MeshAnalysisJob(Job):

--- a/specs_postprocessing.md
+++ b/specs_postprocessing.md
@@ -208,7 +208,7 @@ class FensapMultiImporter:
 | Job name                    | Purpose                                                                                     | Implementation hint                                |
 | --------------------------- | ------------------------------------------------------------------------------------------- | -------------------------------------------------- |
 | `POSTPROCESS_SINGLE_FENSAP` | Calls `SingleShotConverter(root).convert()` *once* per single‑shot run directory.           | Waits for `DROP3D_RUN` and `ICE3D_RUN` when present; otherwise runs after `FENSAP_RUN`. |
-| `FENSAP_ANALYSIS`           | Create slice screenshots from `run_FENSAP/soln.dat` using `fensap_flow_plots`. Results are written to `analysis/FENSAP`. | Attach after `POSTPROCESS_SINGLE_FENSAP`. |
+| `FENSAP_ANALYSIS`           | Create chord-normalised slice screenshots from `run_FENSAP/soln.dat` using `fensap_flow_plots`. Results are written to `analysis/FENSAP`. | Attach after `POSTPROCESS_SINGLE_FENSAP`. |
 | `POSTPROCESS_MULTISHOT`     | Calls `MultiShotConverter(root / "run_MULTISHOT").convert_all()` after the solver finishes. | Attach at pipeline end.                            |
 | `ANALYZE_MULTISHOT`         | Run analysis helpers on MULTISHOT data and store plots in `analysis/MULTISHOT`. | Attach after `POSTPROCESS_MULTISHOT`. |
 | `MESH_ANALYSIS`             | Create mesh quality screenshots and an HTML report using `mesh_analysis`. Results are written to `analysis/MESH`. | Run after meshing is complete. |

--- a/tests/test_fensap_analysis_job.py
+++ b/tests/test_fensap_analysis_job.py
@@ -1,22 +1,52 @@
 from pathlib import Path
 import sys
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import types
+import importlib
 
-from glacium.jobs.analysis_jobs import FensapAnalysisJob
-import glacium.jobs.analysis_jobs as analysis_jobs
-from glacium.models.config import GlobalConfig
-from glacium.managers.path_manager import PathBuilder
-from glacium.models.project import Project
-from glacium.managers.job_manager import JobManager
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 
 def test_fensap_analysis_job(tmp_path, monkeypatch):
+    pkg_path = Path(__file__).resolve().parents[1] / "glacium"
+    fake_pkg = types.ModuleType("glacium")
+    fake_pkg.__path__ = [str(pkg_path)]
+    sys.modules.setdefault("glacium", fake_pkg)
+
+    fake_post = types.ModuleType("glacium.post")
+    fake_post.__path__ = []
+    sys.modules.setdefault("glacium.post", fake_post)
+
+    fake_analysis = types.ModuleType("glacium.post.analysis")
+    sys.modules.setdefault("glacium.post.analysis", fake_analysis)
+    fake_post.analysis = fake_analysis
+
+    fake_ffp = types.ModuleType("glacium.post.analysis.fensap_flow_plots")
+    fake_ffp.fensap_flow_plots = lambda *_: None
+    sys.modules.setdefault("glacium.post.analysis.fensap_flow_plots", fake_ffp)
+
+    fake_multishot = types.ModuleType("glacium.post.multishot")
+    fake_multishot.run_multishot = lambda *_: None
+    sys.modules.setdefault("glacium.post.multishot", fake_multishot)
+
+    spec = importlib.util.spec_from_file_location(
+        "glacium.jobs.analysis_jobs", pkg_path / "jobs" / "analysis_jobs.py"
+    )
+    analysis_jobs = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = analysis_jobs
+    spec.loader.exec_module(analysis_jobs)
+    FensapAnalysisJob = analysis_jobs.FensapAnalysisJob
+    from glacium.models.config import GlobalConfig
+    from glacium.managers.path_manager import PathBuilder
+    from glacium.models.project import Project
+    from glacium.managers.job_manager import JobManager
+
     run_dir = tmp_path / "run_FENSAP"
     run_dir.mkdir()
     dat = run_dir / "soln.dat"
     dat.write_text("")
 
-    cfg = GlobalConfig(project_uid="uid", base_dir=tmp_path)
+    chord = 0.5
+    cfg = GlobalConfig(project_uid="uid", base_dir=tmp_path, CASE_CHARACTERISTIC_LENGTH=chord)
     paths = PathBuilder(tmp_path).build()
     paths.ensure()
 
@@ -36,7 +66,6 @@ def test_fensap_analysis_job(tmp_path, monkeypatch):
             called["args"] = list(args)
 
     monkeypatch.setattr(analysis_jobs, "PyEngine", FakePyEngine)
-    monkeypatch.setattr(analysis_jobs, "fensap_flow_plots", lambda *_: None)
 
     jm = JobManager(project)
     jm.run()
@@ -44,4 +73,5 @@ def test_fensap_analysis_job(tmp_path, monkeypatch):
     out_dir = tmp_path / "analysis" / "FENSAP"
     assert called["fn"] is analysis_jobs.fensap_flow_plots
     assert called["cwd"] == tmp_path
-    assert called["args"] == [dat, out_dir]
+    assert called["args"] == [dat, out_dir, "--scale", str(chord)]
+


### PR DESCRIPTION
## Summary
- Scale FENSAP flow plot coordinates by `CASE_CHARACTERISTIC_LENGTH`
- Document chord-normalised flow plots in user and spec docs
- Test `FensapAnalysisJob` to ensure scaling parameter is passed to PyEngine

## Testing
- `pytest tests/test_fensap_analysis_job.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9962396c48327bce00941d6381c4b