### PR TITLE
Track previous CL in AoA sweep refinement

### DIFF
--- a/glacium/utils/aoa_sweep.py
+++ b/glacium/utils/aoa_sweep.py
@@ -94,6 +94,7 @@ def run_aoa_sweep(
         prev_cl = cl
 
     if stalled and len(results) >= 3:
+        prev_cl = results[-1][1]
         window = results[-3:]
         min_a = min(a for a, _, _ in window)
         max_a = max(a for a, _, _ in window)
@@ -105,5 +106,8 @@ def run_aoa_sweep(
                 continue
             aoa, cl, proj = _run_single(aoa)
             results.append((aoa, cl, proj))
+            if cl < prev_cl:
+                break
+            prev_cl = cl
 
     return results


### PR DESCRIPTION
## Summary
- Track CL between refinement runs in AoA sweep
- Stop refinement when a new angle produces lower CL than the previous one

## Testing
- `pytest` *(fails: 28 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68ab03b46b4883279774fa1b7921def4