### PR TITLE
feat: add multishot project loader

### DIFF
--- a/scripts/06_multishot_analysis.py
+++ b/scripts/06_multishot_analysis.py
@@ -39,6 +39,9 @@ from glacium.api import Project
 from glacium.managers.project_manager import ProjectManager
 from glacium.utils.logging import log
 
+# Re-export utility for selecting multishot projects
+from multishot_loader import load_multishot_project
+
 
 def list_multishot_uids(root: Path) -> list[str]:
     """Return identifiers for all multishot projects under ``root``.

--- a/scripts/07_clean_sweep_creation.py
+++ b/scripts/07_clean_sweep_creation.py
@@ -34,10 +34,8 @@ from glacium.utils import reuse_mesh, run_aoa_sweep
 from glacium.utils.logging import log
 
 from typing import Any
-import importlib
 
-multishot_analysis = importlib.import_module("06_multishot_analysis")
-load_multishot_project = multishot_analysis.load_multishot_project
+from multishot_loader import load_multishot_project
 
 
 def main(

--- a/scripts/09_iced_sweep_creation.py
+++ b/scripts/09_iced_sweep_creation.py
@@ -40,10 +40,7 @@ from glacium.api import Project
 from glacium.utils import reuse_mesh, run_aoa_sweep
 from glacium.utils.logging import log
 
-import importlib
-
-multishot_analysis = importlib.import_module("06_multishot_analysis")
-load_multishot_project = multishot_analysis.load_multishot_project
+from multishot_loader import load_multishot_project
 
 
 def get_last_iced_grid(project: Project) -> Path:

--- a/scripts/multishot_loader.py
+++ b/scripts/multishot_loader.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+"""Utilities for selecting multishot projects.
+
+This module exposes :func:`load_multishot_project` which locates the multishot
+project under a given directory that contains the most shot entries.  It avoids
+looking for solver output files and instead bases the selection purely on the
+``CASE_MULTISHOT`` values stored in each project's configuration.
+"""
+
+from pathlib import Path
+from typing import Iterable
+
+from glacium.api import Project
+from glacium.managers.project_manager import ProjectManager
+
+__all__ = ["load_multishot_project"]
+
+
+def _shots_count(proj: Project) -> int:
+    """Return the number of shot times configured for ``proj``.
+
+    Projects may omit ``CASE_MULTISHOT`` or provide a non-iterable value; in
+    those cases ``0`` is returned.
+    """
+
+    shots = proj.get("CASE_MULTISHOT", [])
+    if isinstance(shots, Iterable):
+        try:
+            return len(list(shots))
+        except TypeError:
+            return 0
+    return 0
+
+
+def load_multishot_project(root: Path) -> Project:
+    """Return the multishot project under ``root`` with most shot times.
+
+    Parameters
+    ----------
+    root:
+        Directory containing multishot projects.
+
+    Returns
+    -------
+    Project
+        The project whose ``CASE_MULTISHOT`` list has the greatest length.
+
+    Raises
+    ------
+    FileNotFoundError
+        If no projects are present beneath ``root`` or none can be loaded.
+    """
+
+    pm = ProjectManager(root)
+    uids = pm.list_uids()
+    if not uids:
+        raise FileNotFoundError(f"No projects found in {root}")
+
+    best_proj: Project | None = None
+    best_count = -1
+    for uid in uids:
+        try:
+            proj = Project.load(root, uid)
+        except FileNotFoundError:
+            continue
+        count = _shots_count(proj)
+        if count > best_count:
+            best_proj = proj
+            best_count = count
+
+    if best_proj is None:
+        raise FileNotFoundError(f"No valid projects found in {root}")
+
+    return best_proj


### PR DESCRIPTION
## Summary
- add reusable `load_multishot_project` utility for selecting multishot project with most shots
- use the loader in clean and iced sweep creation scripts
- re-export loader from multishot analysis for external use

## Testing
- `PYTHONPATH=. python scripts/07_clean_sweep_creation.py >/tmp/clean_output.log 2>&1`
- `pytest` *(fails: 13 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68ac07e0647083279d61c722a0ce6467