### PR TITLE
fix: handle missing CASE_MULTISHOT when counting shots

### DIFF
--- a/scripts/multishot_loader.py
+++ b/scripts/multishot_loader.py
@@ -24,7 +24,10 @@ def _shots_count(proj: Project) -> int:
     those cases ``0`` is returned.
     """
 
-    shots = proj.get("CASE_MULTISHOT", [])
+    try:
+        shots = proj.get("CASE_MULTISHOT")
+    except KeyError:
+        shots = []
     if isinstance(shots, Iterable):
         try:
             return len(list(shots))


### PR DESCRIPTION
## Summary
- handle KeyError when counting CASE_MULTISHOT entries

## Testing
- `pre-commit run --files scripts/multishot_loader.py` *(fails: InvalidConfigError: .pre-commit-config.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68ac12fa6af48327ac58b3dbdb64bd0b