### PR TITLE
Define service interface streams

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.16)
+project(glacium_fsfw CXX)
+
+add_library(fsfw
+    src/fsfw/serviceinterface/ServiceInterface.cpp
+)
+
+target_include_directories(fsfw PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/src/fsfw/serviceinterface/ServiceInterface.cpp
+++ b/src/fsfw/serviceinterface/ServiceInterface.cpp
@@ -1,0 +1,8 @@
+#include "fsfw/serviceinterface/ServiceInterface.h"
+
+namespace sif {
+    ServiceInterfaceStream info("INFO");
+    ServiceInterfaceStream warning("WARNING");
+    ServiceInterfaceStream error("ERROR");
+    ServiceInterfaceStream debug("DEBUG");
+}

--- a/src/fsfw/serviceinterface/ServiceInterface.h
+++ b/src/fsfw/serviceinterface/ServiceInterface.h
@@ -1,0 +1,14 @@
+#ifndef FSFW_SERVICEINTERFACE_SERVICEINTERFACE_H_
+#define FSFW_SERVICEINTERFACE_SERVICEINTERFACE_H_
+
+#include <string>
+
+class ServiceInterfaceStream {
+ public:
+  explicit ServiceInterfaceStream(const char* name) : name(name) {}
+
+ private:
+  const char* name;
+};
+
+#endif // FSFW_SERVICEINTERFACE_SERVICEINTERFACE_H_


### PR DESCRIPTION
## Summary
- add ServiceInterface stream definitions for info, warning, error and debug
- expose new ServiceInterface source to build system

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `pytest tests/test_logging.py` *(fails: No module named 'glacium')*

------
https://chatgpt.com/codex/tasks/task_e_68ac39cc68888327842208eb5cd41c66