### PR TITLE
Use unified AoA sweep helper

### DIFF
--- a/scripts/07_clean_sweep_creation.py
+++ b/scripts/07_clean_sweep_creation.py
@@ -80,7 +80,15 @@ def main(
 
     jobs = ["FENSAP_CONVERGENCE_STATS", "FENSAP_ANALYSIS"]
     mesh = lambda proj: reuse_mesh(proj, mesh_path, "FENSAP_RUN")
-    run_aoa_sweep(base, range(-4, 18, 2), jobs, postprocess_aoas={0}, mesh_hook=mesh)
+    run_aoa_sweep(
+        base,
+        aoa_start=-4.0,
+        aoa_end=16.0,
+        step_sizes=[2.0, 1.0, 0.5],
+        jobs=jobs,
+        postprocess_aoas={0.0},
+        mesh_hook=mesh,
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/09_iced_sweep_creation.py
+++ b/scripts/09_iced_sweep_creation.py
@@ -90,7 +90,15 @@ def main(
 
     jobs = ["FENSAP_CONVERGENCE_STATS", "FENSAP_ANALYSIS"]
     mesh = lambda proj: reuse_mesh(proj, grid_path, "FENSAP_RUN")
-    run_aoa_sweep(base, range(-4, 18, 2), jobs, postprocess_aoas={0}, mesh_hook=mesh)
+    run_aoa_sweep(
+        base,
+        aoa_start=-4.0,
+        aoa_end=16.0,
+        step_sizes=[2.0, 1.0, 0.5],
+        jobs=jobs,
+        postprocess_aoas={0.0},
+        mesh_hook=mesh,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Delegate legacy sweep helper to `glacium.utils.run_aoa_sweep`
- Call the unified sweep runner from clean and iced sweep creation scripts

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'veusz')*


------
https://chatgpt.com/codex/tasks/task_e_68ac640a35788327828aca11640e0f36