### PR TITLE
Use base path for multishot normals outputs

### DIFF
--- a/glacium/post/multishot/run_multishot.py
+++ b/glacium/post/multishot/run_multishot.py
@@ -12,7 +12,7 @@ Für jeden gefundenen Shot wird folgendes ausgeführt (alles direkt unter
 ``<output>/<ID>/``):
 
 1. :mod:`glacium.post.multishot.merge`             → ``merged.dat``
-2. :mod:`glacium.post.multishot.auto_cp_normals`  → ``merged_normals.png``
+2. :mod:`glacium.post.multishot.auto_cp_normals`  → ``merged_normals_<size>.<fmt>``
 3. :mod:`glacium.post.multishot.plot_s`           → ``plots/``
 4. :mod:`glacium.post.multishot.correlate`        → ``correlation_analysis/``
 """
@@ -90,8 +90,8 @@ def process_shot(shot_id: str, files: List[Path], out_root: Path) -> None:
     ]
     run_cmd(merge_cmd, cwd=shot_dir)
 
-    # 2) Cp-Normalen -> <shot_dir>/merged_normals.png
-    normals_png = shot_dir / "merged_normals.png"
+    # 2) Cp-Normalen -> <shot_dir>/merged_normals_<size>.<fmt>
+    normals_base = shot_dir / "merged_normals"
     run_cmd(
         [
             sys.executable,
@@ -102,7 +102,7 @@ def process_shot(shot_id: str, files: List[Path], out_root: Path) -> None:
             "--merged-in",
             str(merged),
             "--png-out",
-            str(normals_png),
+            str(normals_base),
         ],
         cwd=shot_dir,
     )

--- a/scripts/06_multishot_analysis.py
+++ b/scripts/06_multishot_analysis.py
@@ -107,8 +107,9 @@ def analyze_project(proj: Project, out_dir: Path) -> None:
         soln_files = sorted(shot_dir.glob("soln.fensap.*.dat*"))
         if soln_files:
             soln = soln_files[0]
-            normals_png = shot_dir / "merged_normals.png"
-            cp_png = shot_dir / "cp_curve.png"
+            normals_base = shot_dir / "merged_normals"
+            cp_base = shot_dir / "cp_curve"
+            # ``auto_cp_normals`` emits multiple <size>.<fmt> files for these bases
             try:
                 subprocess.run(
                     [
@@ -120,9 +121,9 @@ def analyze_project(proj: Project, out_dir: Path) -> None:
                         "--merged-in",
                         str(merged),
                         "--png-out",
-                        str(normals_png),
+                        str(normals_base),
                         "--cp-png-out",
-                        str(cp_png),
+                        str(cp_base),
                     ],
                     check=True,
                 )


### PR DESCRIPTION
## Summary
- use a base filename for merged normals so auto_cp_normals writes multiple size/format files
- adjust multishot analysis helper to pass base paths for Cp normals and curve plots

## Testing
- `PYTHONPATH=. pytest tests/test_run_multishot_cp_plot.py`

------
https://chatgpt.com/codex/tasks/task_e_68ad665f353c8327923c8b59def82eed