### PR TITLE
Derive minimum x/c from wall nodes in FENSAP flow plots

### DIFF
--- a/tests/test_fensap_flow_plots.py
+++ b/tests/test_fensap_flow_plots.py
@@ -4,6 +4,7 @@ import importlib
 import importlib.util
 from pathlib import Path
 import numpy as np
+import pytest
 
 
 def test_views_adjust_minimum(monkeypatch):
@@ -16,6 +17,20 @@ def test_views_adjust_minimum(monkeypatch):
     )
     monkeypatch.setitem(sys.modules, "pyvista", pv_stub)
     monkeypatch.setitem(sys.modules, "scienceplots", types.ModuleType("scienceplots"))
+
+    # fake minimal glacium.post.multishot.plot_s module
+    plot_s_mod = types.ModuleType("plot_s")
+    plot_s_mod._read_first_zone_with_conn = lambda path: None
+    glacium_pkg = types.ModuleType("glacium")
+    glacium_pkg.__path__ = []
+    post_pkg = types.ModuleType("glacium.post")
+    post_pkg.__path__ = []
+    multishot_pkg = types.ModuleType("glacium.post.multishot")
+    multishot_pkg.__path__ = []
+    monkeypatch.setitem(sys.modules, "glacium", glacium_pkg)
+    monkeypatch.setitem(sys.modules, "glacium.post", post_pkg)
+    monkeypatch.setitem(sys.modules, "glacium.post.multishot", multishot_pkg)
+    monkeypatch.setitem(sys.modules, "glacium.post.multishot.plot_s", plot_s_mod)
 
     import matplotlib
     matplotlib.use("Agg")
@@ -40,3 +55,76 @@ def test_views_adjust_minimum(monkeypatch):
             assert new_xmin == min_xc
         else:
             assert new_xmin == base_xmin
+
+
+def test_wall_min_xc_used_over_slice(monkeypatch, tmp_path):
+    pv_stub = types.SimpleNamespace(
+        Plotter=type("Plotter", (), {}),
+        Camera=type("Camera", (), {}),
+        MultiBlock=type("MultiBlock", (), {}),
+        global_theme=types.SimpleNamespace(show_scalar_bar=False),
+    )
+    # simple grid and slice with min x = 0.0
+    pts = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
+    slc = types.SimpleNamespace(points=pts, bounds=(0, 0, -1, 1, 0, 0))
+    grid = types.SimpleNamespace(points=pts.copy(), slice=lambda normal: slc)
+
+    class Reader:
+        def __init__(self, path):
+            pass
+
+        def read(self):
+            return grid
+
+    pv_stub.TecplotReader = Reader
+    monkeypatch.setitem(sys.modules, "pyvista", pv_stub)
+    monkeypatch.setitem(sys.modules, "scienceplots", types.ModuleType("scienceplots"))
+
+    # fake minimal glacium.post.multishot.plot_s module
+    nodes = np.array([[-0.3, 0.0, 0.0], [0.2, 0.0, 0.0]])
+
+    def fake_read(path):
+        return nodes, np.empty((0, 2), int), ["X", "Y", "Z"], {"x": 0}
+
+    plot_s_mod = types.ModuleType("plot_s")
+    plot_s_mod._read_first_zone_with_conn = fake_read
+    glacium_pkg = types.ModuleType("glacium")
+    glacium_pkg.__path__ = []
+    post_pkg = types.ModuleType("glacium.post")
+    post_pkg.__path__ = []
+    multishot_pkg = types.ModuleType("glacium.post.multishot")
+    multishot_pkg.__path__ = []
+    monkeypatch.setitem(sys.modules, "glacium", glacium_pkg)
+    monkeypatch.setitem(sys.modules, "glacium.post", post_pkg)
+    monkeypatch.setitem(sys.modules, "glacium.post.multishot", multishot_pkg)
+    monkeypatch.setitem(sys.modules, "glacium.post.multishot.plot_s", plot_s_mod)
+
+    import matplotlib
+    matplotlib.use("Agg")
+    from matplotlib import style as mpl_style
+    monkeypatch.setattr(mpl_style, "use", lambda *args, **kwargs: None)
+
+    module_path = Path(__file__).resolve().parents[1] / "glacium" / "post" / "analysis" / "fensap_flow_plots.py"
+    spec = importlib.util.spec_from_file_location("fensap_flow_plots", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    monkeypatch.setattr(module, "ensure_outdir", lambda d: d)
+
+    captured = {}
+
+    class StopCalled(Exception):
+        pass
+
+    def fake_build_views(min_xc):
+        captured["min"] = min_xc
+        raise StopCalled
+
+    monkeypatch.setattr(module, "build_views", fake_build_views)
+
+    dummy = tmp_path / "dummy.dat"
+    dummy.write_text("dummy")
+    with pytest.raises(StopCalled):
+        module.main([str(dummy), str(tmp_path)])
+
+    assert captured["min"] == -0.3


### PR DESCRIPTION
## Summary
- compute minimum x/c from Tecplot wall nodes with `wall_min_xc`
- use `wall_min_xc` in flow plot generation
- test that wall-derived minimum overrides slice minimum

## Testing
- `pytest tests/test_fensap_flow_plots.py -vv`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68ad7103180083278213deb5c734b207