### PR TITLE
Renumber sweep scripts and update references

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,20 +353,20 @@ The scripts populate the ``01_grid_dependency_study`` directory.
 Run an angle-of-attack sweep on the recommended grid and plot the results:
 
 ```bash
-python scripts/07_clean_sweep_creation.py
-python scripts/08_clean_sweep_analysis.py
+python scripts/08_clean_sweep_creation.py
+python scripts/09_clean_sweep_analysis.py
 ```
-The analysis stores plots under ``08_clean_sweep_results``.
+The analysis stores plots under ``09_clean_sweep_results``.
 
 ### Iced sweep
 
 Run an angle-of-attack sweep using the iced grid from the multishot project:
 
 ```bash
-python scripts/09_iced_sweep_creation.py
-python scripts/10_iced_sweep_analysis.py
+python scripts/10_iced_sweep_creation.py
+python scripts/11_iced_sweep_analysis.py
 ```
-The analysis stores plots under ``10_iced_sweep_results``.
+The analysis stores plots under ``11_iced_sweep_results``.
 
 The `scripts/00_fullpower.py` helper runs both studies consecutively.
 

--- a/docs/full_power_study.rst
+++ b/docs/full_power_study.rst
@@ -38,36 +38,36 @@ Subscripts
    These multishot scripts form a :doc:`time dependency study <time_dependency_study>`
    to assess temporal discretisation.
 
-#. ``07_clean_sweep_creation.py`` sweeps angle of attack for the clean geometry
+#. ``08_clean_sweep_creation.py`` sweeps angle of attack for the clean geometry
    using a pre-existing grid.  It relies on the FENSAP recipe and adds analysis
    jobs like ``FENSAP_ANALYSIS`` (which normalises flow plots by the
    characteristic chord length).  Example::
 
-      python scripts/07_clean_sweep_creation.py
+      python scripts/08_clean_sweep_creation.py
 
-#. ``08_clean_sweep_analysis.py`` gathers lift and drag coefficients from the
+#. ``09_clean_sweep_analysis.py`` gathers lift and drag coefficients from the
    clean sweep, stores them in ``polar.csv`` and plots basic polars.
    :func:`glacium.utils.convergence.project_cl_cd_stats` provides fallback
    values when variables are missing.  Example::
 
-      python scripts/08_clean_sweep_analysis.py
+      python scripts/09_clean_sweep_analysis.py
 
-#. ``09_iced_sweep_creation.py`` repeats the angle-of-attack sweep with the
+#. ``10_iced_sweep_creation.py`` repeats the angle-of-attack sweep with the
    last iced mesh from the multishot project.  The helper
    :func:`glacium.utils.reuse_mesh` attaches the frozen grid to each run.
    Example::
 
-      python scripts/09_iced_sweep_creation.py
+      python scripts/10_iced_sweep_creation.py
 
-#. ``10_iced_sweep_analysis.py`` mirrors the clean sweep analysis for the iced
-   geometry and produces ``polar.csv`` in ``10_iced_sweep_results``.  Example::
+#. ``11_iced_sweep_analysis.py`` mirrors the clean sweep analysis for the iced
+   geometry and produces ``polar.csv`` in ``11_iced_sweep_results``.  Example::
 
-      python scripts/10_iced_sweep_analysis.py
+      python scripts/11_iced_sweep_analysis.py
 
-#. ``11_polar_compare.py`` reads the clean and iced ``polar.csv`` files and
+#. ``12_polar_compare.py`` reads the clean and iced ``polar.csv`` files and
    generates combined polar plots for quick visual comparison.  Example::
 
-      python scripts/11_polar_compare.py
+      python scripts/12_polar_compare.py
 
 Command line interface
 ----------------------
@@ -89,9 +89,9 @@ The resulting structure is::
        02_grid_dependency_results/
        05_multishot/
        06_multishot_results/
-       07_clean_sweep/
-       08_clean_sweep_results/
-       09_iced_sweep/
-       10_iced_sweep_results/
-       11_polar_combined_results/
+       08_clean_sweep/
+       09_clean_sweep_results/
+       10_iced_sweep/
+       11_iced_sweep_results/
+       12_polar_combined_results/
 

--- a/scripts/00_fullpower.py
+++ b/scripts/00_fullpower.py
@@ -17,11 +17,12 @@ SCRIPTS = [
     # "02_full_power_gci.py",
     # "05_multishot_creation.py",
     # "06_multishot_analysis.py",
-    "07_clean_sweep_creation.py",
-    "08_clean_sweep_analysis.py",
-    "09_iced_sweep_creation.py",
-    "10_iced_sweep_analysis.py",
-    "11_polar_compare.py",
+    "07_aoa0_projects.py",
+    "08_clean_sweep_creation.py",
+    "09_clean_sweep_analysis.py",
+    "10_iced_sweep_creation.py",
+    "11_iced_sweep_analysis.py",
+    "12_polar_compare.py",
 ]
 
 

--- a/scripts/07_aoa0_projects.py
+++ b/scripts/07_aoa0_projects.py
@@ -38,7 +38,7 @@ _JOBS = ["FENSAP_CONVERGENCE_STATS", "FENSAP_ANALYSIS"]
 
 def _load_get_last_iced_grid():
     """Import and return ``get_last_iced_grid`` from iced sweep script."""
-    script = Path(__file__).resolve().with_name("09_iced_sweep_creation.py")
+    script = Path(__file__).resolve().with_name("10_iced_sweep_creation.py")
     spec = importlib.util.spec_from_file_location("iced_sweep_creation", script)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)  # type: ignore[attr-defined]

--- a/scripts/08_clean_sweep_creation.py
+++ b/scripts/08_clean_sweep_creation.py
@@ -12,11 +12,11 @@ case_vars : dict[str, Any] | None, optional
 
 Outputs
 -------
-Projects created under ``07_clean_sweep``.
+Projects created under ``08_clean_sweep``.
 
 Usage
 -----
-``python scripts/07_clean_sweep_creation.py``
+``python scripts/08_clean_sweep_creation.py``
 
 Requires a prior run of ``05_multishot_creation.py`` to supply the mesh.
 
@@ -47,7 +47,7 @@ def main(
     ----------
     base_dir : Path | str, optional
         Directory containing the ``05_multishot`` folder and where the
-        ``07_clean_sweep`` project will be created.
+        ``08_clean_sweep`` project will be created.
     case_vars : dict[str, Any] | None, optional
         Case variables overriding those read from the selected grid.
     """
@@ -61,7 +61,7 @@ def main(
         return
     mesh_path = ms_project.get_mesh()
 
-    base = Project(base_path / "07_clean_sweep").name("aoa_sweep")
+    base = Project(base_path / "08_clean_sweep").name("aoa_sweep")
     base.set("RECIPE", "fensap")
 
     params = {

--- a/scripts/10_iced_sweep_creation.py
+++ b/scripts/10_iced_sweep_creation.py
@@ -19,11 +19,11 @@ case_vars : dict[str, Any] | None, optional
 
 Outputs
 -------
-Projects created under ``09_iced_sweep``.
+Projects created under ``10_iced_sweep``.
 
 Usage
 -----
-``python scripts/09_iced_sweep_creation.py``
+``python scripts/10_iced_sweep_creation.py``
 
 See Also
 --------
@@ -69,7 +69,7 @@ def main(
     ms_project = load_multishot_project(base / "05_multishot")
     grid_path = get_last_iced_grid(ms_project)
 
-    base = Project(base / "09_iced_sweep").name("aoa_sweep")
+    base = Project(base / "10_iced_sweep").name("aoa_sweep")
     base.set("RECIPE", "fensap")
 
     params = {

--- a/scripts/11_iced_sweep_analysis.py
+++ b/scripts/11_iced_sweep_analysis.py
@@ -1,26 +1,26 @@
-"""Analyse a clean angle-of-attack sweep for the full power study.
+"""Analyse an iced angle-of-attack sweep for the full power study.
 
-The :func:`main` entry point reads all sweep runs, extracts aerodynamic
-coefficients and generates plots plus a ``polar.csv`` file.
+The :func:`main` entry point gathers aerodynamic coefficients from the
+iced sweep projects and generates polar plots and a ``polar.csv`` file.
 
 Key Functions
 -------------
-* :func:`load_runs` – collect AoA, CL and CD from each project.
-* :func:`aoa_sweep_analysis` – generate plots and CSV data.
+* :func:`load_runs` – collect AoA, CL and CD values.
+* :func:`aoa_sweep_analysis` – create plots and CSV data.
 * :func:`main` – command line entry point.
 
 Inputs
 ------
 base_dir : Path | str, optional
-    Base directory containing ``07_clean_sweep``.
+    Base directory containing ``10_iced_sweep``.
 
 Outputs
 -------
-Plots and ``polar.csv`` written to ``08_clean_sweep_results``.
+Plots and ``polar.csv`` written to ``11_iced_sweep_results``.
 
 Usage
 -----
-``python scripts/08_clean_sweep_analysis.py``
+``python scripts/11_iced_sweep_analysis.py``
 
 See Also
 --------
@@ -67,12 +67,9 @@ def load_runs(root: Path) -> list[tuple[float, float, float, Project]]:
 
 
 def first_drop_index(vals: list[float]) -> int:
-    """Return index where values first decrease.
+    """Return the index where ``vals`` first decreases.
 
-    The returned index can be used as an end slice to exclude data beyond
-    the first drop in the sequence.  If no drop is detected the full length
-    of ``vals`` is returned.
-    """
+    If the values never decrease the length of ``vals`` is returned."""
     for i in range(1, len(vals)):
         if vals[i] < vals[i - 1]:
             return i
@@ -92,15 +89,25 @@ def aoa_sweep_analysis(runs: list[tuple[float, float, float, Project]], out_dir:
     cl_vals = [r[1] for r in runs]
     cd_vals = [r[2] for r in runs]
 
-    cut = first_drop_index(cl_vals)
-
+    # Save the complete dataset before trimming for plots
     data = np.column_stack((aoa_vals, cl_vals, cd_vals))
-    np.savetxt(out_dir / "polar.csv", data,
-               delimiter=",", header="AoA,CL,CD", comments="")
+    np.savetxt(
+        out_dir / "polar.csv",
+        data,
+        delimiter=",",
+        header="AoA,CL,CD",
+        comments="",
+    )
+
+    # Determine stall onset and trim arrays for plotting only
+    cut = first_drop_index(cl_vals)
+    aoa_plot = aoa_vals[:cut]
+    cl_plot = cl_vals[:cut]
+    cd_plot = cd_vals[:cut]
 
     # ---- CL vs AoA ----
     fig, ax = plt.subplots(figsize=(8, 5), dpi=150)   # größere Figure + höhere DPI
-    ax.plot(aoa_vals[:cut], cl_vals[:cut], marker="+", linewidth=1.5)
+    ax.plot(aoa_plot, cl_plot, marker="+", linewidth=1.5)
     ax.set_xlabel("AoA (deg)")
     ax.set_ylabel("CL")
     ax.grid(True, linestyle=':')
@@ -111,7 +118,7 @@ def aoa_sweep_analysis(runs: list[tuple[float, float, float, Project]], out_dir:
 
     # ---- CD vs AoA ----
     fig, ax = plt.subplots(figsize=(8, 5), dpi=600)
-    ax.plot(aoa_vals[:cut], cd_vals[:cut], marker="+", linewidth=1.5)
+    ax.plot(aoa_plot, cd_plot, marker="+", linewidth=1.5)
     ax.set_xlabel("AoA (deg)")
     ax.set_ylabel("CD")
     ax.grid(True, linestyle=':')
@@ -123,12 +130,12 @@ def aoa_sweep_analysis(runs: list[tuple[float, float, float, Project]], out_dir:
 
 
 def main(base_dir: Path | str = Path("")) -> None:
-    """Analyze a clean sweep located under ``base_dir``."""
+    """Analyze an iced sweep located under ``base_dir``."""
 
     base = Path(base_dir)
-    root = base / "07_clean_sweep"
+    root = base / "10_iced_sweep"
     runs = load_runs(root)
-    aoa_sweep_analysis(runs, base / "08_clean_sweep_results")
+    aoa_sweep_analysis(runs, base / "11_iced_sweep_results")
 
 
 if __name__ == "__main__":

--- a/scripts/12_polar_compare.py
+++ b/scripts/12_polar_compare.py
@@ -13,16 +13,16 @@ Key Functions
 Inputs
 ------
 base_dir : Path | str, optional
-    Directory containing ``08_clean_sweep_results`` and
-    ``10_iced_sweep_results``.
+    Directory containing ``09_clean_sweep_results`` and
+    ``11_iced_sweep_results``.
 
 Outputs
 -------
-Plots in ``11_polar_combined_results``.
+Plots in ``12_polar_combined_results``.
 
 Usage
 -----
-``python scripts/11_polar_compare.py``
+``python scripts/12_polar_compare.py``
 
 See Also
 --------
@@ -134,14 +134,14 @@ def main(base_dir: Path | str = Path("")) -> None:
     """Compare polar curves located under ``base_dir``."""
 
     base = Path(base_dir)
-    clean_csv = base / "08_clean_sweep_results" / "polar.csv"
-    iced_csv = base / "10_iced_sweep_results" / "polar.csv"
+    clean_csv = base / "09_clean_sweep_results" / "polar.csv"
+    iced_csv = base / "11_iced_sweep_results" / "polar.csv"
     if not clean_csv.exists() or not iced_csv.exists():
         raise FileNotFoundError("polar.csv not found in sweep result directories")
 
     clean = load_csv(clean_csv)
     iced = load_csv(iced_csv)
-    plot_combined(clean, iced, base / "11_polar_combined_results")
+    plot_combined(clean, iced, base / "12_polar_combined_results")
 
 
 if __name__ == "__main__":

--- a/scripts/clean_sweep_gif.py
+++ b/scripts/clean_sweep_gif.py
@@ -66,9 +66,9 @@ def create_gif(images: list[tuple[float, Path]], outfile: Path, *, duration: int
 
 
 def main() -> None:
-    root = Path("07_clean_sweep")
+    root = Path("08_clean_sweep")
     images = collect_images(root)
-    create_gif(images, Path("08_clean_sweep_results") / "pressure_zoom.gif")
+    create_gif(images, Path("09_clean_sweep_results") / "pressure_zoom.gif")
 
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation

--- a/tests/test_clean_sweep_gif.py
+++ b/tests/test_clean_sweep_gif.py
@@ -19,7 +19,7 @@ def _create_project(root: Path, uid: str, aoa: float) -> None:
 
 
 def test_collect_sorted(tmp_path):
-    root = tmp_path / "07_clean_sweep"
+    root = tmp_path / "08_clean_sweep"
     _create_project(root, "p1", 5)
     _create_project(root, "p2", 1)
 
@@ -28,9 +28,9 @@ def test_collect_sorted(tmp_path):
 
 
 def test_gif_written(tmp_path):
-    root = tmp_path / "07_clean_sweep"
+    root = tmp_path / "08_clean_sweep"
     _create_project(root, "p1", 0)
     imgs = collect_images(root)
-    out = tmp_path / "08_clean_sweep_results" / "pressure_zoom.gif"
+    out = tmp_path / "09_clean_sweep_results" / "pressure_zoom.gif"
     create_gif(imgs, out)
     assert out.exists()


### PR DESCRIPTION
## Summary
- rename sweep scripts (08–12) and align docstrings & directories
- insert aoa0 helper into `00_fullpower.py` script list
- update docs, README, test and GIF helper for new numbering

## Testing
- `python -m py_compile scripts/08_clean_sweep_creation.py scripts/09_clean_sweep_analysis.py scripts/10_iced_sweep_creation.py scripts/11_iced_sweep_analysis.py scripts/12_polar_compare.py scripts/00_fullpower.py scripts/07_aoa0_projects.py scripts/clean_sweep_gif.py tests/test_clean_sweep_gif.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'veusz')*

------
https://chatgpt.com/codex/tasks/task_e_68ad775f41908327b8bb92572f7475ea