### PR TITLE
Include first drop point in polar compare plots

### DIFF
--- a/scripts/12_polar_compare.py
+++ b/scripts/12_polar_compare.py
@@ -52,16 +52,16 @@ def load_csv(csv_file: Path) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
 
 
 def first_drop_index(vals: Sequence[float]) -> int:
-    """Return index where values first decrease.
+    """Return slice end index at the first decrease.
 
-    The returned index can be used as an end slice to exclude data beyond
-    the first drop in the sequence.  If no drop is detected the full length
-    of ``vals`` is returned.
+    The returned value is intended for use as ``vals[:index]`` and therefore
+    **includes** the first point after the peak where the sequence begins to
+    decrease. If no drop is detected the full length of ``vals`` is returned.
     """
 
     for i in range(1, len(vals)):
         if vals[i] < vals[i - 1]:
-            return i
+            return i + 1
     return len(vals)
 
 

--- a/tests/test_polar_compare.py
+++ b/tests/test_polar_compare.py
@@ -1,0 +1,31 @@
+"""Tests for the ``scripts/12_polar_compare.py`` helpers."""
+
+from __future__ import annotations
+
+import runpy
+from pathlib import Path
+
+
+def load_module() -> dict[str, object]:
+    """Return the module globals for ``12_polar_compare.py``."""
+    script = Path(__file__).resolve().parents[1] / "scripts" / "12_polar_compare.py"
+    return runpy.run_path(script)
+
+
+def test_first_drop_index_includes_drop_point() -> None:
+    module = load_module()
+    first_drop_index = module["first_drop_index"]
+
+    vals = [0.1, 0.5, 0.8, 0.6, 0.55]
+    cut = first_drop_index(vals)
+    assert cut == 4
+    assert vals[:cut][-1] == 0.6
+
+
+def test_first_drop_index_no_drop() -> None:
+    module = load_module()
+    first_drop_index = module["first_drop_index"]
+
+    vals = [0.1, 0.2, 0.3]
+    cut = first_drop_index(vals)
+    assert cut == len(vals)


### PR DESCRIPTION
## Summary
- ensure `first_drop_index` includes the first decreasing point in the slice
- add tests verifying the post-peak point is kept and behavior without drops

## Testing
- `python - <<'PY'
import runpy, matplotlib.pyplot as plt
plt.rcParams['text.usetex']=False
mod=runpy.run_path('scripts/12_polar_compare.py', run_name='not_main')
mod['main']()
PY`
- `pytest tests/test_polar_compare.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad99c937248327833d926bb4519a19