### PR TITLE
Fix inlet regex in auto_cp_normals

### DIFF
--- a/glacium/post/multishot/auto_cp_normals.py
+++ b/glacium/post/multishot/auto_cp_normals.py
@@ -149,7 +149,9 @@ def _infer_inlet(
 ) -> Dict[str, float]:
     import re as _re
 
-    pat = _re.compile(r't\s*=\s*"[^"]*(?:' + _re.escape(inlet_name) + r"|farfield)[^"]*"", _re.I)
+    pat = _re.compile(
+        r't\s*=\s*"[^"]*(?:' + _re.escape(inlet_name) + r'|farfield)[^"]*"', _re.I
+    )
     z_ranges = _iter_zones(lines)
     pick = None
     for s, e in z_ranges:

--- a/tests/test_auto_cp_normals.py
+++ b/tests/test_auto_cp_normals.py
@@ -1,0 +1,19 @@
+import importlib.util
+from pathlib import Path
+
+module_path = Path(__file__).resolve().parents[1] / "glacium/post/multishot/auto_cp_normals.py"
+spec = importlib.util.spec_from_file_location("auto_cp_normals", module_path)
+auto_cp_normals = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(auto_cp_normals)
+_infer_inlet = auto_cp_normals._infer_inlet
+
+
+def test_infer_inlet_minimal():
+    lines = [
+        'VARIABLES = "x" "pressure"',
+        'ZONE T="INLET", N=1',
+        '0 101325',
+    ]
+    var_names = ["x", "pressure"]
+    result = _infer_inlet(lines, var_names)
+    assert "p_inf" in result


### PR DESCRIPTION
## Summary
- fix malformed regex for detecting INLET or farfield zone names
- add regression test for `_infer_inlet`

## Testing
- `pytest tests/test_auto_cp_normals.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68adb51a23ec83279bcd85b101a50c9e