### PR TITLE
Allow configuring convertgrid path via env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,12 @@ The analysis stores plots under ``11_iced_sweep_results``.
 
 The `scripts/00_fullpower.py` helper runs both studies consecutively.
 
+### Mesh node overview
+
+Some analysis steps invoke an external `convertgrid` utility to extract
+grid statistics. Provide the path via the `CONVERTGRID_EXE` environment
+variable or pass `--convertgrid-exe`/`--exe` to the respective scripts.
+
 ## Development
 
 All tests can be run with:

--- a/glacium/post/multishot/mesh_nodes.py
+++ b/glacium/post/multishot/mesh_nodes.py
@@ -10,13 +10,14 @@ Nutzung (Beispiele):
 
 Hinweise:
 - Es wird rekursiv nach Dateien "grid.ice.<ID>" gesucht, wobei <ID> aus genau 6 Ziffern besteht.
-- Die Knotenzahl wird via `convertgrid.exe -d <file>` ausgelesen (Parameter mit --exe anpassbar).
+- Die Knotenzahl wird via `convertgrid.exe -d <file>` ausgelesen (Pfad anpassbar mit --exe oder der Umgebungsvariable CONVERTGRID_EXE).
 """
 
 from __future__ import annotations
 
 import argparse
 import csv
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -29,7 +30,9 @@ GRID_RX = re.compile(r"^grid\.ice\.(\d{6})$")
 NODE_RX = re.compile(r"Number of nodes\s*[:=]\s*(\d+)", re.IGNORECASE)
 
 
-def get_node_count(grid_file: Path, exe: str = "convertgrid.exe") -> int | None:
+def get_node_count(
+    grid_file: Path, exe: str = os.environ.get("CONVERTGRID_EXE", "convertgrid.exe")
+) -> int | None:
     """Rufe `convertgrid.exe -d <grid_file>` auf und parse die Knotenzahl."""
     try:
         result = subprocess.run([exe, "-d", str(grid_file)], capture_output=True, text=True, check=False)
@@ -104,7 +107,14 @@ def main() -> None:
     ap.add_argument("--src", type=Path, default=Path.cwd(), help="Wurzelverzeichnis (rekursiv) für die Suche (Default: CWD)")
     ap.add_argument("--out", type=Path, default=Path("mesh_nodes_per_shot.png"), help="Pfad zur Ausgabegrafik (PNG)")
     ap.add_argument("--csv", type=Path, default=None, help="Optionaler Pfad für CSV-Ausgabe")
-    ap.add_argument("--exe", type=str, default="convertgrid.exe", help="Pfad/Name des convertgrid-Tools (Default: convertgrid.exe)")
+    ap.add_argument(
+        "--exe",
+        type=str,
+        default=os.environ.get("CONVERTGRID_EXE", "convertgrid.exe"),
+        help=(
+            "Pfad/Name des convertgrid-Tools (Default: $CONVERTGRID_EXE oder 'convertgrid.exe')"
+        ),
+    )
     args = ap.parse_args()
 
     shots, nodes = collect_nodes(args.src, args.exe)

--- a/tests/test_analyze_multishot_job.py
+++ b/tests/test_analyze_multishot_job.py
@@ -35,9 +35,17 @@ def test_analyze_multishot_job(tmp_path, monkeypatch):
             return ret
         return wrapper
 
-    def fake_run_multishot(input_dir, output_dir, start_shot=None, end_shot=None):
+    def fake_run_multishot(
+        input_dir, output_dir, start_shot=None, end_shot=None, convertgrid_path=None
+    ):
         cwd["cwd"] = Path.cwd()
-        calls["run_multishot"] = (input_dir, output_dir, start_shot, end_shot)
+        calls["run_multishot"] = (
+            input_dir,
+            output_dir,
+            start_shot,
+            end_shot,
+            convertgrid_path,
+        )
 
     monkeypatch.setattr("glacium.jobs.analysis_jobs.run_multishot", fake_run_multishot)
     monkeypatch.setattr(post_analysis, "read_wall_zone", rec("read_wall_zone", "WZ"))


### PR DESCRIPTION
## Summary
- allow `mesh_nodes` to default to `CONVERTGRID_EXE` and mention it in CLI help
- add `--convertgrid-exe` option to `run_multishot` and forward to `mesh_nodes`
- document how to override convertgrid path via `CONVERTGRID_EXE`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'veusz')*

------
https://chatgpt.com/codex/tasks/task_e_68adb825a0e88327881ca0f437f442d8