### PR TITLE
Remove grid params before AOA sweep cloning

### DIFF
--- a/scripts/08_clean_sweep_creation.py
+++ b/scripts/08_clean_sweep_creation.py
@@ -76,6 +76,8 @@ def main(
     mesh_path = baseline_project.get_mesh()
 
     base = baseline_project.clone().name("aoa_sweep")
+    base._params.pop("FSP_FILES_GRID", None)
+    base._params.pop("ICE_GRID_FILE", None)  # safe no-op for clean case
     base._jobs = []  # type: ignore[attr-defined]
 
     if case_vars:


### PR DESCRIPTION
## Summary
- Clear FSP_FILES_GRID and ICE_GRID_FILE after cloning baseline for clean AOA sweep
- Preserve mesh reuse hook to repopulate FSP_FILES_GRID per project

## Testing
- `PYTHONPATH=. python scripts/08_clean_sweep_creation.py`
- `pytest -q` *(fails: ModuleNotFoundError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68aea3b354688327b1108d97b28726c8