### PR TITLE
Handle grid parameters for iced AoA sweep

### DIFF
--- a/scripts/10_iced_sweep_creation.py
+++ b/scripts/10_iced_sweep_creation.py
@@ -84,6 +84,8 @@ def main(
     mesh_path = baseline_project.get_mesh()
 
     base = baseline_project.clone().name("aoa_sweep")
+    base._params.pop("FSP_FILES_GRID", None)
+    base._params.pop("ICE_GRID_FILE", None)
     base._jobs = []  # type: ignore[attr-defined]
 
     if case_vars:


### PR DESCRIPTION
## Summary
- Clear `FSP_FILES_GRID` and `ICE_GRID_FILE` when cloning the iced baseline to avoid stale grid references
- Keep mesh reuse hook so sweep projects attach the iced mesh correctly

## Testing
- `python scripts/10_iced_sweep_creation.py` *(fails: No projects found in 07_iced_aoa0)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'veusz')*


------
https://chatgpt.com/codex/tasks/task_e_68aea584b31c8327959943a9d98d42b0