### PR TITLE
Clear baseline aerodynamic result params

### DIFF
--- a/scripts/08_clean_sweep_creation.py
+++ b/scripts/08_clean_sweep_creation.py
@@ -78,6 +78,8 @@ def main(
     base = baseline_project.clone().name("aoa_sweep")
     base._params.pop("FSP_FILES_GRID", None)
     base._params.pop("ICE_GRID_FILE", None)  # safe no-op for clean case
+    base._params.pop("LIFT_COEFFICIENT", None)
+    base._params.pop("DRAG_COEFFICIENT", None)
     base._jobs = []  # type: ignore[attr-defined]
 
     if case_vars:

--- a/scripts/10_iced_sweep_creation.py
+++ b/scripts/10_iced_sweep_creation.py
@@ -86,6 +86,8 @@ def main(
     base = baseline_project.clone().name("aoa_sweep")
     base._params.pop("FSP_FILES_GRID", None)
     base._params.pop("ICE_GRID_FILE", None)
+    base._params.pop("LIFT_COEFFICIENT", None)
+    base._params.pop("DRAG_COEFFICIENT", None)
     base._jobs = []  # type: ignore[attr-defined]
 
     if case_vars:


### PR DESCRIPTION
## Summary
- clear baseline sweep params for lift and drag

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'veusz', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68aeba15fb688327a7ac2d3d66eac4f3