### PR TITLE
Handle NaN lift coefficients in AoA sweep

### DIFF
--- a/glacium/utils/aoa_sweep.py
+++ b/glacium/utils/aoa_sweep.py
@@ -12,6 +12,7 @@ increasing ``CL`` values.
 
 from __future__ import annotations
 
+import math
 from typing import Callable, Iterable, List, Tuple, Set, TYPE_CHECKING, Dict
 
 if TYPE_CHECKING:  # pragma: no cover - used for type checkers only
@@ -31,7 +32,9 @@ def _cl_from_project(proj: Project) -> float:
     try:
         val = proj.get("LIFT_COEFFICIENT")
         if val is not None:
-            return float(val)
+            cl = float(val)
+            if not math.isnan(cl):
+                return cl
     except Exception:
         pass
 

--- a/tests/test_aoa_sweep.py
+++ b/tests/test_aoa_sweep.py
@@ -1,4 +1,5 @@
 import importlib.util
+import math
 import sys
 import types
 from pathlib import Path
@@ -36,6 +37,7 @@ class FakeRunProject:
         self.aoa = aoa
         self._cl_map = cl_map
         self._executed = executed
+        self.root = Path(".")
 
     def run(self):
         self._executed.append(self.aoa)
@@ -122,3 +124,20 @@ def test_run_aoa_sweep_refinement():
         11.0,
         11.5,
     ]
+
+
+def test_run_aoa_sweep_handles_nan_cl():
+    cl_map = {0.0: float("nan"), 2.0: 2.0, 4.0: 4.0}
+    base = FakeProject(cl_map)
+
+    results = run_aoa_sweep(
+        base,
+        aoa_start=0.0,
+        aoa_end=4.0,
+        step_sizes=[2.0],
+        jobs=[],
+        postprocess_aoas=set(),
+    )
+
+    cls = [c for _a, c, _p in results]
+    assert all(math.isfinite(c) for c in cls)


### PR DESCRIPTION
## Summary
- guard `_cl_from_project` against NaN lift coefficients by falling back to convergence stats
- cover NaN coefficient behaviour in AoA sweep tests

## Testing
- `pytest tests/test_aoa_sweep.py`

------
https://chatgpt.com/codex/tasks/task_e_68aebbf4d340832790a6cc315b197644