### PR TITLE
Refactor fensap flow plots for fixed min x/c viewports

### DIFF
--- a/tests/test_fensap_flow_plots.py
+++ b/tests/test_fensap_flow_plots.py
@@ -18,19 +18,6 @@ def test_views_adjust_minimum(monkeypatch):
     monkeypatch.setitem(sys.modules, "pyvista", pv_stub)
     monkeypatch.setitem(sys.modules, "scienceplots", types.ModuleType("scienceplots"))
 
-    # fake minimal glacium.post.multishot.plot_s module
-    plot_s_mod = types.ModuleType("plot_s")
-    plot_s_mod._read_first_zone_with_conn = lambda path: None
-    glacium_pkg = types.ModuleType("glacium")
-    glacium_pkg.__path__ = []
-    post_pkg = types.ModuleType("glacium.post")
-    post_pkg.__path__ = []
-    multishot_pkg = types.ModuleType("glacium.post.multishot")
-    multishot_pkg.__path__ = []
-    monkeypatch.setitem(sys.modules, "glacium", glacium_pkg)
-    monkeypatch.setitem(sys.modules, "glacium.post", post_pkg)
-    monkeypatch.setitem(sys.modules, "glacium.post.multishot", multishot_pkg)
-    monkeypatch.setitem(sys.modules, "glacium.post.multishot.plot_s", plot_s_mod)
 
     import matplotlib
     matplotlib.use("Agg")
@@ -57,84 +44,7 @@ def test_views_adjust_minimum(monkeypatch):
             assert new_xmin == base_xmin
 
 
-def test_wall_min_xc_used_over_slice(monkeypatch, tmp_path):
-    pv_stub = types.SimpleNamespace(
-        Plotter=type("Plotter", (), {}),
-        Camera=type("Camera", (), {}),
-        MultiBlock=type("MultiBlock", (), {}),
-        global_theme=types.SimpleNamespace(show_scalar_bar=False),
-    )
-    # simple grid and slice with min x = 0.0
-    pts = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
-    slc = types.SimpleNamespace(
-        points=pts,
-        bounds=(0, 0, -1, 1, 0, 0),
-        point_data={"v": np.array([0.0, 1.0])},
-    )
-    grid = types.SimpleNamespace(points=pts.copy(), slice=lambda normal: slc)
-
-    class Reader:
-        def __init__(self, path):
-            pass
-
-        def read(self):
-            return grid
-
-    pv_stub.TecplotReader = Reader
-    monkeypatch.setitem(sys.modules, "pyvista", pv_stub)
-    monkeypatch.setitem(sys.modules, "scienceplots", types.ModuleType("scienceplots"))
-
-    # fake minimal glacium.post.multishot.plot_s module
-    nodes = np.array([[-0.3, 0.0, 0.0], [0.2, 0.0, 0.0]])
-
-    def fake_read(path):
-        return nodes, np.empty((0, 2), int), ["X", "Y", "Z"], {"x": 0}
-
-    plot_s_mod = types.ModuleType("plot_s")
-    plot_s_mod._read_first_zone_with_conn = fake_read
-    glacium_pkg = types.ModuleType("glacium")
-    glacium_pkg.__path__ = []
-    post_pkg = types.ModuleType("glacium.post")
-    post_pkg.__path__ = []
-    multishot_pkg = types.ModuleType("glacium.post.multishot")
-    multishot_pkg.__path__ = []
-    monkeypatch.setitem(sys.modules, "glacium", glacium_pkg)
-    monkeypatch.setitem(sys.modules, "glacium.post", post_pkg)
-    monkeypatch.setitem(sys.modules, "glacium.post.multishot", multishot_pkg)
-    monkeypatch.setitem(sys.modules, "glacium.post.multishot.plot_s", plot_s_mod)
-
-    import matplotlib
-    matplotlib.use("Agg")
-    from matplotlib import style as mpl_style
-    monkeypatch.setattr(mpl_style, "use", lambda *args, **kwargs: None)
-
-    module_path = Path(__file__).resolve().parents[1] / "glacium" / "post" / "analysis" / "fensap_flow_plots.py"
-    spec = importlib.util.spec_from_file_location("fensap_flow_plots", module_path)
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-
-    monkeypatch.setattr(module, "ensure_outdir", lambda d: d)
-
-    captured = {}
-
-    class StopCalled(Exception):
-        pass
-
-    def fake_build_views(min_xc):
-        captured["min"] = min_xc
-        raise StopCalled
-
-    monkeypatch.setattr(module, "build_views", fake_build_views)
-
-    dummy = tmp_path / "dummy.dat"
-    dummy.write_text("dummy")
-    with pytest.raises(StopCalled):
-        module.main([str(dummy), str(tmp_path)])
-
-    assert captured["min"] == -0.3
-
-
-def test_main_calls_build_views_for_all_overviews(monkeypatch, tmp_path):
+def test_main_calls_build_views_for_all_values(monkeypatch, tmp_path):
     pv_stub = types.SimpleNamespace(
         Plotter=type("Plotter", (), {}),
         Camera=type("Camera", (), {}),
@@ -161,20 +71,6 @@ def test_main_calls_build_views_for_all_overviews(monkeypatch, tmp_path):
     monkeypatch.setitem(sys.modules, "pyvista", pv_stub)
     monkeypatch.setitem(sys.modules, "scienceplots", types.ModuleType("scienceplots"))
 
-    # fake minimal glacium.post.multishot.plot_s module
-    plot_s_mod = types.ModuleType("plot_s")
-    plot_s_mod._read_first_zone_with_conn = lambda path: None
-    glacium_pkg = types.ModuleType("glacium")
-    glacium_pkg.__path__ = []
-    post_pkg = types.ModuleType("glacium.post")
-    post_pkg.__path__ = []
-    multishot_pkg = types.ModuleType("glacium.post.multishot")
-    multishot_pkg.__path__ = []
-    monkeypatch.setitem(sys.modules, "glacium", glacium_pkg)
-    monkeypatch.setitem(sys.modules, "glacium.post", post_pkg)
-    monkeypatch.setitem(sys.modules, "glacium.post.multishot", multishot_pkg)
-    monkeypatch.setitem(sys.modules, "glacium.post.multishot.plot_s", plot_s_mod)
-
     import matplotlib
     matplotlib.use("Agg")
     from matplotlib import style as mpl_style
@@ -187,8 +83,6 @@ def test_main_calls_build_views_for_all_overviews(monkeypatch, tmp_path):
 
     dummy_png = tmp_path / "dummy.png"
     dummy_png.write_text("dummy")
-
-    monkeypatch.setattr(module, "wall_min_xc", lambda *args: -0.3)
 
     calls = []
 
@@ -209,4 +103,4 @@ def test_main_calls_build_views_for_all_overviews(monkeypatch, tmp_path):
     dummy.write_text("dummy")
     module.main([str(dummy), str(tmp_path)])
 
-    assert calls == [-0.3] + module.MIN_XC_OVERVIEWS
+    assert calls == module.MIN_XC_VALUES


### PR DESCRIPTION
## Summary
- remove dependency on `_read_first_zone_with_conn` and the `wall_min_xc` helper
- drive rendering from new `MIN_XC_VALUES` list and simplify `process`
- update tests to reflect fixed viewport sets and constant name change

## Testing
- `pytest tests/test_fensap_flow_plots.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68aec5e09cf083279100c09c290d934e