### PR TITLE
Increase colorbar padding for double plots

### DIFF
--- a/glacium/post/analysis/fensap_flow_plots.py
+++ b/glacium/post/analysis/fensap_flow_plots.py
@@ -16,7 +16,7 @@ plt.style.use(["science","no-latex"])
 __all__ = ["fensap_flow_plots"]
 
 # ---------- Einstellungen ----------
-SIZES = [("full", (6.3, 3.9), 0.15), ("dbl", (3.15, 2.0), 0.25)]  # (Label, figsize, cbar_pad)
+SIZES = [("full", (6.3, 3.9), 0.15), ("dbl", (3.15, 2.0), 0.4)]  # (Label, figsize, cbar_pad)
 pv.global_theme.show_scalar_bar = False               # PyVista-Colorbar global aus
 
 # Viewport definitions. Ranges starting at -0.1 will later be adjusted to a


### PR DESCRIPTION
## Summary
- bump double-size colorbar padding so it doesn't overlap with axes title

## Testing
- `python - <<'PY'
import importlib.util, matplotlib.pyplot as plt, numpy as np
from pathlib import Path
spec = importlib.util.spec_from_file_location('fensap_flow_plots', Path('glacium/post/analysis/fensap_flow_plots.py'))
module = importlib.util.module_from_spec(spec)
spec.loader.exec_module(module)
img = np.ones((10,10,3))
Path('dummy_img.png').unlink(missing_ok=True)
plt.imsave('dummy_img.png', img)
for label, figsize, cbar_pad in module.SIZES:
    if label == 'dbl':
        size, pad = figsize, cbar_pad
        break
import matplotlib.image as mpimg
img = mpimg.imread('dummy_img.png')
fig, ax = plt.subplots(figsize=size)
ax.imshow(img, extent=[0,1,0,1], origin='upper', interpolation='nearest', aspect='auto')
ax.set_xlabel('x/c'); ax.set_ylabel('y/c')
import matplotlib as mpl
sm = mpl.cm.ScalarMappable(norm=mpl.colors.Normalize(vmin=0, vmax=1), cmap=plt.get_cmap('plasma'))
sm.set_array([])
cbar = fig.colorbar(sm, ax=ax, orientation='horizontal', fraction=0.06, pad=pad)
fig.savefig('out.png', dpi=300)
ax_pos = ax.get_position(); cbar_pos = cbar.ax.get_position()
print('pad', pad)
print('ax bottom', ax_pos.y0)
print('cbar top', cbar_pos.y1)
print('non-overlap', cbar_pos.y1 <= ax_pos.y0)
plt.close(fig)
PY`
- `pytest tests/test_fensap_flow_plots.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68aec86d40a88327a1a4c81c70c1aa37