### PR TITLE
Remove stale results file when initializing sweeps

### DIFF
--- a/scripts/08_clean_sweep_creation.py
+++ b/scripts/08_clean_sweep_creation.py
@@ -66,6 +66,9 @@ def main(
     sweep_root = base_path / "08_clean_sweep"
     dest_root = sweep_root / baseline_project.uid
     shutil.copytree(baseline_project.root, dest_root, dirs_exist_ok=True)
+    res_file = dest_root / "results.yaml"
+    if res_file.exists():
+        res_file.unlink()
 
     cfg_file = dest_root / "_cfg" / "global_config.yaml"
     cfg = yaml.safe_load(cfg_file.read_text()) or {}

--- a/scripts/10_iced_sweep_creation.py
+++ b/scripts/10_iced_sweep_creation.py
@@ -74,6 +74,9 @@ def main(
     sweep_root = base_path / "10_iced_sweep"
     dest_root = sweep_root / baseline_project.uid
     shutil.copytree(baseline_project.root, dest_root, dirs_exist_ok=True)
+    res_file = dest_root / "results.yaml"
+    if res_file.exists():
+        res_file.unlink()
 
     cfg_file = dest_root / "_cfg" / "global_config.yaml"
     cfg = yaml.safe_load(cfg_file.read_text()) or {}


### PR DESCRIPTION
## Summary
- Delete copied results.yaml in clean sweep creation
- Delete copied results.yaml in iced sweep creation

## Testing
- `pytest` *(fails: ModuleNotFoundError: pandas and others during collection)*
- Verified clean sweep project regenerates results: `clean dest results: False` / `clean new results: True`
- Verified iced sweep project regenerates results: `iced dest results: False` / `iced new results: True`


------
https://chatgpt.com/codex/tasks/task_e_68aedc02c174832798414d1f8db0100d