### PR TITLE
Reuse baseline AoA 0 project in clean sweep

### DIFF
--- a/scripts/08_clean_sweep_creation.py
+++ b/scripts/08_clean_sweep_creation.py
@@ -63,6 +63,7 @@ def main(
         log.error(f"No projects found in {src_root}")
         return
     baseline_project = Project.load(src_root, uids[0])
+    precomputed = {0.0: baseline_project}
 
     try:
         ms_project = load_multishot_project(base_path / "05_multishot")
@@ -96,6 +97,7 @@ def main(
         postprocess_aoas=set(),
         mesh_hook=mesh,
         skip_aoas={0.0},
+        precomputed=precomputed,
     )
 
 


### PR DESCRIPTION
## Summary
- Cache precomputed AoA 0 project for clean sweep generation
- Pass precomputed map to run_aoa_sweep so AoA 0 case is skipped and reused

## Testing
- `pytest` *(fails: 42 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68af2095b46c832796c2927c5ef7a14f