### PR TITLE
Reuse baseline project in iced AoA sweep

### DIFF
--- a/scripts/10_iced_sweep_creation.py
+++ b/scripts/10_iced_sweep_creation.py
@@ -70,6 +70,7 @@ def main(
         log.error(f"No projects found in {src_root}")
         return
     baseline_project = Project.load(src_root, uids[0])
+    precomputed = {0.0: baseline_project}
 
     try:
         ms_project = load_multishot_project(base_path / "05_multishot")
@@ -103,6 +104,7 @@ def main(
         postprocess_aoas=set(),
         mesh_hook=mesh,
         skip_aoas={0.0},
+        precomputed=precomputed,
     )
 
 


### PR DESCRIPTION
## Summary
- track the baseline iced project in a `precomputed` map
- supply the precomputed baseline to `run_aoa_sweep`

## Testing
- `pytest` *(fails: No module named 'veusz', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68af215568f483279626e089124b695b