### PR TITLE
Add compute_h_from_merged utility and tests

### DIFF
--- a/scripts/02_full_power_gci.py
+++ b/scripts/02_full_power_gci.py
@@ -35,6 +35,12 @@ from pathlib import Path
 import math
 import matplotlib.pyplot as plt
 
+from glacium.post.multishot.plot_s import (
+    _read_first_zone_with_conn,
+    order_from_connectivity,
+    arclength,
+)
+
 from glacium.api import Project
 from glacium.managers.project_manager import ProjectManager
 from glacium.utils.logging import log
@@ -52,6 +58,30 @@ from reportlab.lib.styles import getSampleStyleSheet
 from reportlab.lib.units import cm
 from reportlab.lib import colors
 from math import nan
+
+
+def compute_h_from_merged(path: Path) -> float:
+    """Return mean segment length from a merged Tecplot file.
+
+    Parameters
+    ----------
+    path : Path
+        Location of the ``merged.dat`` (or similar) file.
+
+    Returns
+    -------
+    float
+        Average edge length along the ordered polyline, or ``NaN`` on error.
+    """
+    try:
+        nodes, conn, _, _ = _read_first_zone_with_conn(path)
+        order = order_from_connectivity(len(nodes), conn)
+        x = nodes[order, 0]
+        y = nodes[order, 1]
+        s = arclength(x, y)
+        return float(s[-1]) / len(s)
+    except Exception:
+        return float("nan")
 
 
 def load_runs(root: Path) -> list[tuple[float, float, float, Project]]:

--- a/tests/test_full_power_gci.py
+++ b/tests/test_full_power_gci.py
@@ -15,6 +15,7 @@ module_path = Path(__file__).resolve().parents[1] / "scripts" / "02_full_power_g
 full_power_gci = SourceFileLoader("full_power_gci", str(module_path)).load_module()
 load_runs = full_power_gci.load_runs
 gci_analysis2 = full_power_gci.gci_analysis2
+compute_h_from_merged = full_power_gci.compute_h_from_merged
 
 
 def test_load_runs_reads_results(tmp_path):
@@ -63,3 +64,19 @@ def test_best_triplet_selected_from_cl(tmp_path):
 
     assert best[0] == pytest.approx(factors[0])
     assert best_proj.uid == "p0"
+
+
+def test_compute_h_from_merged(tmp_path):
+    merged = tmp_path / "merged.dat"
+    merged.write_text(
+        (
+            'TITLE="t"\n'
+            'VARIABLES="X","Y"\n'
+            'ZONE T="L1", N=2, E=1, ZONETYPE=FELINESEG, DATAPACKING=POINT\n'
+            '0 0\n'
+            '1 0\n'
+            '1 2\n'
+        )
+    )
+    h = compute_h_from_merged(merged)
+    assert h == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- compute mean segment length from a merged Tecplot file via `_read_first_zone_with_conn`, `order_from_connectivity`, and `arclength`
- test helper `compute_h_from_merged` with a minimal Tecplot sample

## Testing
- `pytest tests/test_full_power_gci.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b192f210b88327a0f0041a8bd64a48