### PR TITLE
Handle missing soln.dat in full power GCI load

### DIFF
--- a/scripts/02_full_power_gci.py
+++ b/scripts/02_full_power_gci.py
@@ -98,19 +98,27 @@ def load_runs(root: Path) -> list[tuple[float, float, float, Project]]:
 
         soln = proj.root / "run_FENSAP" / "soln.dat"
         merged = proj.root / "analysis" / "FENSAP" / "merged.dat"
+        if not soln.exists():
+            log.warning(f"Missing soln.dat for {uid}, skipping run")
+            continue
+
         if not merged.exists():
             merged.parent.mkdir(parents=True, exist_ok=True)
-            subprocess.run(
-                [
-                    sys.executable,
-                    "-m",
-                    "glacium.post.multishot.merge",
-                    str(soln),
-                    "--out",
-                    str(merged),
-                ],
-                check=True,
-            )
+            try:
+                subprocess.run(
+                    [
+                        sys.executable,
+                        "-m",
+                        "glacium.post.multishot.merge",
+                        str(soln),
+                        "--out",
+                        str(merged),
+                    ],
+                    check=True,
+                )
+            except subprocess.CalledProcessError:
+                log.warning(f"Failed to merge {soln} for {uid}")
+                continue
 
         h = compute_h_from_merged(merged)
 

--- a/tests/test_full_power_gci.py
+++ b/tests/test_full_power_gci.py
@@ -45,6 +45,9 @@ def test_load_runs_reads_results(tmp_path):
             '1 2\n'
         )
     )
+    soln = project.root / "run_FENSAP" / "soln.dat"
+    soln.parent.mkdir(parents=True, exist_ok=True)
+    soln.write_text("dummy")
     expected_h = compute_h_from_merged(merged)
 
     runs = load_runs(tmp_path)
@@ -59,6 +62,16 @@ def test_load_runs_reads_results(tmp_path):
     assert cl == pytest.approx(results["LIFT_COEFFICIENT"])
     assert cd == pytest.approx(results["DRAG_COEFFICIENT"])
     assert proj.uid == project.uid
+
+
+def test_load_runs_skips_missing_soln(tmp_path):
+    TemplateManager(Path(__file__).resolve().parents[1] / "glacium" / "templates")
+    pm = ProjectManager(tmp_path)
+    airfoil = Path(__file__).resolve().parents[1] / "glacium" / "data" / "AH63K127.dat"
+    pm.create("proj", "hello", airfoil)
+
+    runs = load_runs(tmp_path)
+    assert runs == []
 
 
 def test_best_triplet_selected_from_cl(tmp_path):


### PR DESCRIPTION
## Summary
- guard against missing `soln.dat` and merge failures in GCI run loading
- skip runs without a solution file
- add regression test for missing solution file

## Testing
- `pytest tests/test_full_power_gci.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1babc45648327bbc54de42567971f