### PR TITLE
Enhance GCI sliding results with raw grid data

### DIFF
--- a/scripts/02_full_power_gci.py
+++ b/scripts/02_full_power_gci.py
@@ -185,7 +185,8 @@ def gci_analysis2(
 
     sliding_results = (
         []
-    )  # tuples: (h, p_cl, p_cd, cl_ext, cd_ext, gci_cl, gci_cd, time, e_cl, e_cd, valid_cl, valid_cd)
+    )  # tuples: (h1, h2, h3, cl1, cl2, cl3, cd1, cd2, cd3, p_cl, p_cd, cl_ext, cd_ext,
+    #            gci_cl, gci_cd, time, e_cl, e_cd, valid_cl, valid_cd)
     Fs = 1.25  # Safety factor
 
     best_idx_cl: int | None = None
@@ -262,6 +263,14 @@ def gci_analysis2(
         sliding_results.append(
             (
                 f1,
+                f2,
+                f3,
+                phi1_cl,
+                phi2_cl,
+                phi3_cl,
+                phi1_cd,
+                phi2_cd,
+                phi3_cd,
                 p_cl,
                 p_cd,
                 cl_ext,
@@ -298,7 +307,15 @@ def gci_analysis2(
     # === Log the sliding analysis ===
     log.info("Sliding-window GCI analysis (per 3-grid triplet):")
     for (
-        f1,
+        h1,
+        h2,
+        h3,
+        cl1,
+        cl2,
+        cl3,
+        cd1,
+        cd2,
+        cd3,
         p_cl,
         p_cd,
         cl_ext,
@@ -312,7 +329,10 @@ def gci_analysis2(
         valid_cd,
     ) in sliding_results:
         log.info(
-            f"h={f1}: p(CL)={p_cl:.3f}, p(CD)={p_cd:.3f}, "
+            f"h1={h1}, h2={h2}, h3={h3}, "
+            f"CL1={cl1:.6f}, CL2={cl2:.6f}, CL3={cl3:.6f}, "
+            f"CD1={cd1:.6f}, CD2={cd2:.6f}, CD3={cd3:.6f}, "
+            f"p(CL)={p_cl:.3f}, p(CD)={p_cd:.3f}, "
             f"CL∞={cl_ext:.6f}, CD∞={cd_ext:.6f}, "
             f"GCI(CL)={gci_cl:.2f}%, GCI(CD)={gci_cd:.2f}%, "
             f"time={t:.1f}s, E(CL)={e_cl:.2f}, E(CD)={e_cd:.2f}, "
@@ -321,10 +341,10 @@ def gci_analysis2(
 
     # === Extract evolution of p and extrapolated solution ===
     h_levels = [res[0] for res in sliding_results]
-    p_cl_vals = [res[1] for res in sliding_results]
-    p_cd_vals = [res[2] for res in sliding_results]
-    cl_ext_vals = [res[3] for res in sliding_results]
-    cd_ext_vals = [res[4] for res in sliding_results]
+    p_cl_vals = [res[9] for res in sliding_results]
+    p_cd_vals = [res[10] for res in sliding_results]
+    cl_ext_vals = [res[11] for res in sliding_results]
+    cd_ext_vals = [res[12] for res in sliding_results]
 
     # Plot p evolution
     plt.figure()
@@ -359,6 +379,14 @@ def gci_analysis2(
     best_triplet = sliding_results[best_idx_cl]
     (
         best_h,
+        _,
+        _,
+        _,
+        _,
+        _,
+        _,
+        _,
+        _,
         best_p_cl,
         best_p_cd,
         best_cl_ext,
@@ -537,7 +565,15 @@ def generate_gci_pdf_report(
         )
         table_data = [
             [
-                "h",
+                "h1",
+                "h2",
+                "h3",
+                "CL1",
+                "CL2",
+                "CL3",
+                "CD1",
+                "CD2",
+                "CD3",
                 "p(CL)",
                 "p(CD)",
                 "CL∞",
@@ -552,7 +588,15 @@ def generate_gci_pdf_report(
             ]
         ]
         for (
-            f1,
+            h1,
+            h2,
+            h3,
+            cl1,
+            cl2,
+            cl3,
+            cd1,
+            cd2,
+            cd3,
             pcl,
             pcd,
             cl_inf,
@@ -567,7 +611,15 @@ def generate_gci_pdf_report(
         ) in sliding_results:
             table_data.append(
                 [
-                    f"{f1:.4f}",
+                    f"{h1:.4f}",
+                    f"{h2:.4f}",
+                    f"{h3:.4f}",
+                    f"{cl1:.6f}",
+                    f"{cl2:.6f}",
+                    f"{cl3:.6f}",
+                    f"{cd1:.6f}",
+                    f"{cd2:.6f}",
+                    f"{cd3:.6f}",
                     f"{pcl:.3f}",
                     f"{pcd:.3f}",
                     f"{cl_inf:.6f}",

--- a/tests/test_full_power_gci.py
+++ b/tests/test_full_power_gci.py
@@ -117,6 +117,13 @@ def test_best_triplet_selected_from_cl(tmp_path, monkeypatch):
     ]
     assert captured["run_table"] == expected
 
+    # ensure raw values are recorded in sliding results
+    first = results[0]
+    assert len(first) == 20
+    expected_raw = [1.0, 2.0, 4.0, 1.0, 0.95, 0.88, 0.3, 0.28, 0.25]
+    for actual, expected in zip(first[0:9], expected_raw):
+        assert actual == pytest.approx(expected)
+
 
 def test_compute_h_from_merged(tmp_path):
     merged = tmp_path / "merged.dat"


### PR DESCRIPTION
## Summary
- Capture raw grid spacings and coefficients `(h1,h2,h3,CL1,CL2,CL3,CD1,CD2,CD3)` in `gci_analysis2` sliding results
- Log detailed triplet data and include these values in the PDF report's "Detailed Grid Convergence Table"
- Extend tests to verify new sliding result structure

## Testing
- `pytest tests/test_full_power_gci.py::test_best_triplet_selected_from_cl -q`
- `pytest -q` *(fails: No module named 'veusz', 'glacium', 'scienceplots', ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d79337f4832784871a014da6c9b6