### PR TITLE
feat: add precomputed AOA sweep support

### DIFF
--- a/scripts/10_iced_sweep_creation.py
+++ b/scripts/10_iced_sweep_creation.py
@@ -78,13 +78,14 @@ def main(
     base = Project(base_path / "10_iced_sweep").name("aoa_sweep")
     base.set("RECIPE", "fensap")
 
+    get = getattr(ms_project, "get", lambda _k: None)
     params = {
-        "CASE_CHARACTERISTIC_LENGTH": ms_project.get("CASE_CHARACTERISTIC_LENGTH"),
-        "CASE_VELOCITY": ms_project.get("CASE_VELOCITY"),
-        "CASE_ALTITUDE": ms_project.get("CASE_ALTITUDE"),
-        "CASE_TEMPERATURE": ms_project.get("CASE_TEMPERATURE"),
-        "CASE_YPLUS": ms_project.get("CASE_YPLUS"),
-        "PWS_REFINEMENT": ms_project.get("PWS_REFINEMENT"),
+        "CASE_CHARACTERISTIC_LENGTH": get("CASE_CHARACTERISTIC_LENGTH"),
+        "CASE_VELOCITY": get("CASE_VELOCITY"),
+        "CASE_ALTITUDE": get("CASE_ALTITUDE"),
+        "CASE_TEMPERATURE": get("CASE_TEMPERATURE"),
+        "CASE_YPLUS": get("CASE_YPLUS"),
+        "PWS_REFINEMENT": get("PWS_REFINEMENT"),
     }
     if case_vars:
         params.update(case_vars)


### PR DESCRIPTION
## Summary
- allow reusing precomputed AoA projects and skipping angles
- return last processed project from `run_aoa_sweep`
- fix iced sweep script to tolerate multishot project without `get`

## Testing
- `pytest tests/test_aoa_sweep.py tests/test_clean_sweep_precomputed.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2a7584e2c8327b8755d644276b0f6