### PR TITLE
Add mesh analysis job to recipes and AoA=0 script

### DIFF
--- a/glacium/recipes/grid_dependency.py
+++ b/glacium/recipes/grid_dependency.py
@@ -20,4 +20,5 @@ class GridDependencyRecipe(BaseRecipe):
             JobFactory.create("FLUENT2FENSAP", project),
             JobFactory.create("FENSAP_RUN", project),
             JobFactory.create("FENSAP_CONVERGENCE_STATS", project),
+            JobFactory.create("MESH_ANALYSIS", project),
         ]

--- a/glacium/recipes/multishot.py
+++ b/glacium/recipes/multishot.py
@@ -19,5 +19,6 @@ class DefaultAero(BaseRecipe):
             JobFactory.create("FLUENT2FENSAP", project),
             JobFactory.create("MULTISHOT_RUN", project),
             JobFactory.create("CONVERGENCE_STATS", project),
+            JobFactory.create("MESH_ANALYSIS", project),
         ]
 

--- a/scripts/07_aoa0_projects.py
+++ b/scripts/07_aoa0_projects.py
@@ -38,6 +38,7 @@ from multishot_loader import load_multishot_project
 # generated figures and reports.
 _JOBS = [
     "FENSAP_CONVERGENCE_STATS",
+    "MESH_ANALYSIS",
     "FENSAP_ANALYSIS",
     "POSTPROCESS_SINGLE_FENSAP",
 ]


### PR DESCRIPTION
## Summary
- run mesh analysis after FENSAP convergence jobs in `grid_dependency` and `multishot` recipes
- include mesh analysis in AoA=0 project job list

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'veusz', 'glacium', 'pandas', 'PyPDF2')*

------
https://chatgpt.com/codex/tasks/task_e_68b81b3f113883278158153d9b7d8ad6