### PR TITLE
refactor mesh viewports

### DIFF
--- a/glacium/post/analysis/__init__.py
+++ b/glacium/post/analysis/__init__.py
@@ -1,6 +1,7 @@
 from .ice_thickness import read_wall_zone, process_wall_zone, plot_ice_thickness
 from .ice_contours import load_contours, plot_overlay, animate_growth
 from .mesh_screenshots import generate_wireframes
+from .mesh_viewports import fensap_mesh_plots
 
 __all__ = [
     "read_wall_zone",
@@ -10,4 +11,5 @@ __all__ = [
     "plot_overlay",
     "animate_growth",
     "generate_wireframes",
+    "fensap_mesh_plots",
 ]

--- a/glacium/post/analysis/mesh_viewports.py
+++ b/glacium/post/analysis/mesh_viewports.py
@@ -1,15 +1,16 @@
-# fensap_mesh_plots.py — Mesh-Wireframe-Screenshots mit Achsen & festen Viewports
+# mesh_viewports.py — Mesh-Wireframe-Screenshots mit Achsen & festen Viewports
 import argparse
+import os
+import re
+import tempfile
 from pathlib import Path
 from typing import Sequence
-import re
-import numpy as np
-import pyvista as pv
-import matplotlib.pyplot as plt
+
 import matplotlib.image as mpimg
 import matplotlib.patches as mpatches
-import tempfile
-import os
+import matplotlib.pyplot as plt
+import numpy as np
+import pyvista as pv
 import scienceplots
 plt.style.use(["science","no-latex"])
 
@@ -174,7 +175,7 @@ def overlay_axes_on_screenshot(
     plt.close(fig)
 
 # ---------- Main ----------
-def main(argv: Sequence[str] | None = None) -> None:
+def _main(argv: Sequence[str] | None = None) -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("file", type=Path, help="Mesh-Datei (z. B. .dat, .cas, .vtk, .vtu, .grid)")
     ap.add_argument("outdir", nargs="?", type=Path, help="Output directory")
@@ -233,7 +234,7 @@ def main(argv: Sequence[str] | None = None) -> None:
 
 def fensap_mesh_plots(cwd: Path, args: Sequence[str | Path]) -> None:
     """Wie fensap_flow_plots, aber erstellt Wireframe-Mesh-Bilder in festen Viewports."""
-    main([str(a) for a in args])
+    _main([str(a) for a in args])
 
 if __name__ == "__main__":
-    main()
+    _main()


### PR DESCRIPTION
## Summary
- move mesh postprocessing script into analysis package as mesh_viewports
- expose fensap_mesh_plots entrypoint and tidy imports

## Testing
- `pytest` *(fails: 42 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b81dfe0fc48327a0efe24e8fdaf797