### PR TITLE
docs: include ambient pressure source

### DIFF
--- a/docs/xfoil_variable_flow.rst
+++ b/docs/xfoil_variable_flow.rst
@@ -44,6 +44,16 @@ Ambient pressure
 .. math::
    p = 101325 \left(1 - 2.25577\times10^{-5} h\right)^{5.2559}
 
+.. literalinclude:: ../glacium/utils/case_to_global.py
+   :lines: 20-22
+   :linenos:
+
+.. literalinclude:: ../glacium/utils/first_cellheight.py
+   :lines: 14-17
+   :linenos:
+
+* Implemented in ``glacium/utils/case_to_global.py`` and ``glacium/utils/first_cellheight.py``.
+
 Density
 ^^^^^^^
 


### PR DESCRIPTION
## Summary
- include ambient pressure implementation snippets from utility modules in the XFOIL variable flow docs
- note files providing the ambient pressure formula

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'veusz', pandas, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68c40297f0bc832795d17f1b4203c347