### PR TITLE
docs: document Mach number source

### DIFF
--- a/docs/xfoil_variable_flow.rst
+++ b/docs/xfoil_variable_flow.rst
@@ -84,21 +84,25 @@ Dynamic viscosity
    :lines: 56-78
    :linenos:
 
+Mach number
+^^^^^^^^^^^
+
+.. math::
+   M = \frac{V}{\sqrt{\gamma R T}}
+
+.. literalinclude:: ../glacium/utils/case_to_global.py
+   :lines: 67-69
+   :linenos:
+
 .. list-table:: Source code references
    :header-rows: 1
 
    * - File
      - Lines
    * - ``glacium/utils/case_to_global.py``
-     - 20-22, 63-65, 66
+     - 20-22, 63-65, 66, 67-69
    * - ``glacium/utils/first_cellheight.py``
      - 14-17, 36-38, 39, 56-78
-
-Mach number
-^^^^^^^^^^^
-
-.. math::
-   M = \frac{V}{\sqrt{\gamma R T}}
 
 Reynolds number
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary
- document Mach number equation with code sample
- reference Mach calculation in source table

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas PyPDF2 veusz` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68c4078dd3b083279fa65318a18e2369