### PR TITLE
docs: reference Reynolds code

### DIFF
--- a/docs/xfoil_variable_flow.rst
+++ b/docs/xfoil_variable_flow.rst
@@ -100,15 +100,23 @@ Mach number
    * - File
      - Lines
    * - ``glacium/utils/case_to_global.py``
-     - 20-22, 63-65, 66, 67-69
+     - 20-22, 63-65, 66, 67-70
    * - ``glacium/utils/first_cellheight.py``
-     - 14-17, 36-38, 39, 56-78
+     - 14-17, 36-38, 39, 41, 56-78
 
 Reynolds number
 ^^^^^^^^^^^^^^^
 
 .. math::
    Re = \frac{\rho V c}{\mu}
+
+.. literalinclude:: ../glacium/utils/case_to_global.py
+   :lines: 70
+   :linenos:
+
+.. literalinclude:: ../glacium/utils/first_cellheight.py
+   :lines: 41
+   :linenos:
 
 Trailing-edge gap
 ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary
- reference Reynolds number calculations in docs with code snippets
- update reference table with line numbers for both utility modules

## Testing
- `pytest` *(fails: 41 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c40958a8cc83278c5bddac86e83340