### PR TITLE
docs: cite trailing-edge gap implementation

### DIFF
--- a/docs/xfoil_variable_flow.rst
+++ b/docs/xfoil_variable_flow.rst
@@ -100,7 +100,7 @@ Mach number
    * - File
      - Lines
    * - ``glacium/utils/case_to_global.py``
-     - 20-22, 63-65, 66, 67-70
+     - 20-22, 63-65, 66, 67-70, 95
    * - ``glacium/utils/first_cellheight.py``
      - 14-17, 36-38, 39, 41, 56-78
 
@@ -123,6 +123,10 @@ Trailing-edge gap
 
 .. math::
    \text{gap} = \frac{0.001}{c}
+
+.. literalinclude:: ../glacium/utils/case_to_global.py
+   :lines: 95
+   :linenos:
 
 First cell height
 ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary
- document trailing-edge gap equation with code from `case_to_global.py`
- record `case_to_global.py` line 95 in source reference table

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'veusz')*

------
https://chatgpt.com/codex/tasks/task_e_68c40a80b518832780722a7bf296ac53