### PR TITLE
docs: include first cell height implementation snippet

### DIFF
--- a/docs/xfoil_variable_flow.rst
+++ b/docs/xfoil_variable_flow.rst
@@ -102,7 +102,7 @@ Mach number
    * - ``glacium/utils/case_to_global.py``
      - 20-22, 63-65, 66, 67-70, 95
    * - ``glacium/utils/first_cellheight.py``
-     - 14-17, 36-38, 39, 41, 56-78
+     - 14-17, 36-38, 39, 41, 43-46, 56-78
 
 Reynolds number
 ^^^^^^^^^^^^^^^
@@ -138,6 +138,12 @@ First cell height
    u_\tau &= \sqrt{\tau_w} \\
    s &= \frac{y^+ \nu}{u_\tau}
    \end{aligned}
+
+Implemented in ``glacium/utils/first_cellheight.py``:
+
+.. literalinclude:: ../glacium/utils/first_cellheight.py
+   :lines: 43-46
+   :linenos:
 
 Global configuration mapping
 ----------------------------


### PR DESCRIPTION
## Summary
- include source snippet for first cell height calculations
- reference implementing file in documentation

## Testing
- `pre-commit run --files docs/xfoil_variable_flow.rst` *(fails: InvalidConfigError: .pre-commit-config.yaml is not a file)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'veusz')*

------
https://chatgpt.com/codex/tasks/task_e_68c40bfdb514832781ac9a6fbe32e9ad