### PR TITLE
Add ingest dispatch tests, structured logging, and machine-readable failure reasons

### DIFF
--- a/glacium/ingest/__init__.py
+++ b/glacium/ingest/__init__.py
@@ -1,4 +1,4 @@
-from .registry import IngestResult, IngestionDispatchError, canonicalize_job_url
+from .registry import IngestResult, IngestionDispatchError, canonicalize_job_url, ingest_job_url
 from .workday import (
     WorkdayCanonicalURL,
     WorkdayURLValidationError,
@@ -13,6 +13,7 @@ __all__ = [
     "WorkdayCanonicalURL",
     "WorkdayURLValidationError",
     "canonicalize_job_url",
+    "ingest_job_url",
     "canonicalize_url",
     "can_handle",
     "extract_fields",

--- a/glacium/ingest/registry.py
+++ b/glacium/ingest/registry.py
@@ -1,35 +1,120 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import logging
 from typing import Callable
 
 from . import workday
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
 class IngestResult:
     provider: str
     canonical_key: str
+    normalized_id: str
+    fields: dict[str, str | None] | None = None
 
 
 class IngestionDispatchError(ValueError):
     """Raised when no ingestion module supports a URL."""
 
+    def __init__(self, message: str, *, reason: str) -> None:
+        super().__init__(message)
+        self.reason = reason
 
-_INGESTERS: list[tuple[str, Callable[[str], bool], Callable[[str], str]]] = [
+
+_INGESTERS: list[
+    tuple[
+        str,
+        Callable[[str], bool],
+        Callable[[str], workday.WorkdayCanonicalURL],
+        Callable[[str], dict[str, str | None]],
+    ]
+] = [
     (
         "workday",
         workday.can_handle,
-        lambda url: workday.canonicalize_url(url).canonical_key,
+        workday.canonicalize_url,
+        workday.extract_fields,
     ),
 ]
 
 
 def canonicalize_job_url(url: str) -> IngestResult:
-    for provider, predicate, canonicalizer in _INGESTERS:
+    for provider, predicate, canonicalizer, _parser in _INGESTERS:
         if predicate(url):
-            return IngestResult(provider=provider, canonical_key=canonicalizer(url))
+            canonical = canonicalizer(url)
+            return IngestResult(
+                provider=provider,
+                canonical_key=canonical.canonical_key,
+                normalized_id=canonical.job_id,
+            )
 
     raise IngestionDispatchError(
-        "No ingester registered for URL host. Supported providers: workday (*.myworkdayjobs.com)."
+        "No ingester registered for URL host. Supported providers: workday (*.myworkdayjobs.com).",
+        reason="unsupported_domain",
+    )
+
+
+def ingest_job_url(
+    url: str,
+    *,
+    fetcher: Callable[[str], str],
+) -> IngestResult:
+    logger.info("ingest.url_accepted", extra={"url": url})
+
+    selected_adapter: tuple[
+        str,
+        Callable[[str], bool],
+        Callable[[str], workday.WorkdayCanonicalURL],
+        Callable[[str], dict[str, str | None]],
+    ] | None = None
+    for provider, predicate, canonicalizer, parser in _INGESTERS:
+        if predicate(url):
+            selected_adapter = (provider, predicate, canonicalizer, parser)
+            break
+
+    if selected_adapter is None:
+        logger.warning("ingest.adapter_not_found", extra={"url": url})
+        raise IngestionDispatchError(
+            "No ingester registered for URL host. Supported providers: workday (*.myworkdayjobs.com).",
+            reason="unsupported_domain",
+        )
+
+    provider, _predicate, canonicalizer, parser = selected_adapter
+    logger.info("ingest.adapter_selected", extra={"provider": provider})
+
+    try:
+        canonical = canonicalizer(url)
+    except workday.WorkdayURLValidationError as exc:
+        logger.warning(
+            "ingest.invalid_url",
+            extra={"provider": provider, "error": str(exc)},
+        )
+        raise IngestionDispatchError(str(exc), reason="invalid_workday_url") from exc
+
+    logger.info(
+        "ingest.normalized_id",
+        extra={"provider": provider, "normalized_id": canonical.job_id},
+    )
+
+    logger.info("ingest.fetch_attempted", extra={"provider": provider})
+    payload = fetcher(url)
+
+    fields = parser(payload)
+    if not fields.get("title"):
+        logger.warning("ingest.parse_failed", extra={"provider": provider})
+        raise IngestionDispatchError(
+            "Parser did not extract required fields from payload.",
+            reason="parse_error",
+        )
+
+    logger.info("ingest.parse_succeeded", extra={"provider": provider})
+    return IngestResult(
+        provider=provider,
+        canonical_key=canonical.canonical_key,
+        normalized_id=canonical.job_id,
+        fields=fields,
     )

--- a/tests/test_ingest_dispatch.py
+++ b/tests/test_ingest_dispatch.py
@@ -1,0 +1,86 @@
+import logging
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+from glacium.ingest.registry import IngestionDispatchError, ingest_job_url
+
+
+AIRBUS_WORKDAY_URL = (
+    "https://airbus.wd3.myworkdayjobs.com/en-US/Airbus/job/"
+    "Toulouse-Area/Flight-Physics-Engineer_JR10284481"
+    "?locationCountry=2fcb99c455831013ea52fb338f2932d8"
+)
+
+
+def test_ingest_routes_workday_domain_and_normalizes_id(caplog):
+    payload = """
+    <html>
+      <head>
+        <script type=\"application/ld+json\">
+        {"title": "Flight Physics Engineer", "identifier": {"value": "JR10284481"}}
+        </script>
+      </head>
+    </html>
+    """
+
+    with caplog.at_level(logging.INFO):
+        result = ingest_job_url(AIRBUS_WORKDAY_URL, fetcher=lambda _url: payload)
+
+    assert result.provider == "workday"
+    assert result.normalized_id == "JR10284481"
+    assert result.canonical_key == "workday:airbus.wd3.myworkdayjobs.com/Airbus/JR10284481"
+
+    messages = [record.msg for record in caplog.records]
+    assert "ingest.url_accepted" in messages
+    assert "ingest.adapter_selected" in messages
+    assert "ingest.fetch_attempted" in messages
+    assert "ingest.parse_succeeded" in messages
+    assert "ingest.normalized_id" in messages
+
+
+def test_ingest_unsupported_domain_returns_machine_readable_reason():
+    with pytest.raises(IngestionDispatchError) as exc:
+        ingest_job_url("https://example.com/jobs/123", fetcher=lambda _url: "")
+
+    assert exc.value.reason == "unsupported_domain"
+
+
+def test_ingest_invalid_workday_url_returns_machine_readable_reason():
+    invalid_workday_url = "https://airbus.wd3.myworkdayjobs.com/en-US/Airbus/jobs/Toulouse-Area"
+
+    with pytest.raises(IngestionDispatchError) as exc:
+        ingest_job_url(invalid_workday_url, fetcher=lambda _url: "")
+
+    assert exc.value.reason == "invalid_workday_url"
+
+
+def test_ingest_parse_failure_returns_machine_readable_reason(caplog):
+    payload_without_title = "<html><head></head><body>No structured content</body></html>"
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(IngestionDispatchError) as exc:
+            ingest_job_url(AIRBUS_WORKDAY_URL, fetcher=lambda _url: payload_without_title)
+
+    assert exc.value.reason == "parse_error"
+    assert any(record.msg == "ingest.parse_failed" for record in caplog.records)
+
+
+def test_airbus_workday_regression_url_is_still_ingested():
+    payload = """
+    <html>
+      <head>
+        <script type=\"application/ld+json\">
+        {"title": "Flight Physics Engineer", "identifier": {"value": "JR10284481"}}
+        </script>
+      </head>
+    </html>
+    """
+
+    result = ingest_job_url(AIRBUS_WORKDAY_URL, fetcher=lambda _url: payload)
+
+    assert result.normalized_id == "JR10284481"
+    assert result.canonical_key == "workday:airbus.wd3.myworkdayjobs.com/Airbus/JR10284481"


### PR DESCRIPTION
### Motivation
- Provide a single ingest entrypoint that performs domain routing, normalization and parsing for job URLs.
- Make ingest lifecycle observable via structured log events so callers and operators can trace progress and failures.
- Surface explicit, machine-readable failure reasons to callers so downstream automation can react to specific error classes.
- Add a regression test for the Airbus Workday URL to prevent reintroducing a past failure.

### Description
- Add `ingest_job_url(url, fetcher=...)` in `glacium.ingest.registry` that performs adapter selection, canonicalization, fetching and parsing while emitting structured log events (`ingest.url_accepted`, `ingest.adapter_selected`, `ingest.fetch_attempted`, `ingest.parse_succeeded` / `ingest.parse_failed`, and `ingest.normalized_id`).
- Extend `IngestResult` to include `normalized_id` and parsed `fields`, and update `canonicalize_job_url` to return the normalized ID for supported providers.
- Change `IngestionDispatchError` to carry an explicit `reason` attribute and raise with `reason` values `unsupported_domain`, `invalid_workday_url`, or `parse_error` depending on the failure.
- Register the workday adapter to provide both canonicalization and parsing functions, export the new `ingest_job_url` from the package, and add `tests/test_ingest_dispatch.py` to validate routing, structured logging, machine-readable reasons, and the Airbus Workday regression URL.

### Testing
- Ran `pytest -q tests/test_ingest_dispatch.py tests/test_workday_ingest.py` and the suite completed successfully with all tests passing.
- Result: `11 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a44fa2323c8327b6bde2eacef43c40)